### PR TITLE
Add metadata-preserving XDRemux product modes

### DIFF
--- a/apps/macos/XDRemuxApp/Sources/AppStrings.swift
+++ b/apps/macos/XDRemuxApp/Sources/AppStrings.swift
@@ -67,23 +67,61 @@ enum AppStrings {
     static let inputProcessingHelp = "控制 base image 和 gain map 在转换过程中由系统重建、混合写回，还是尽量保留原始增益图。"
     static let inputProcessingSystem = "系统重建"
     static let inputProcessingSystemHelp = "让 ImageIO 接管 base image 和 gain map 的重打包过程；系统可能会重新编码图像数据。"
+    static let inputProcessingSystemDecoded = "系统解码重建"
+    static let inputProcessingSystemDecodedHelp = "先解码主图再由 ImageIO 重编码；仅用于 10-bit 主图兼容性诊断。"
     static let inputProcessingHybrid = "混合模式"
     static let inputProcessingHybridHelp = "先让系统重建，再只取系统重新编码为 HEVC Rext 的 gain map，写回原始容器结构。"
     static let inputProcessingPassthrough = "保留原始增益图"
     static let inputProcessingPassthroughHelp = "不让系统重编码 gain map；直接重建符合 ISO 标准的 ISOBMFF box 来保留原始增益图数据。"
 
+    static let tmapFormatLabel = "ISO tmap 格式"
+    static let tmapFormatStrict = "严格 ISO 145B"
+    static let tmapFormatImageIO = "ImageIO 142B"
+    static let tmapFormatStrictHelp = "实验性写入 ISO 21496-1 三通道 145-byte GainMapMetadata。Find X9 Ultra 实测会导致相册 Exif 解析和编辑组件异常，不建议正式输出。"
+    static let tmapFormatImageIOHelp = "默认保留 Apple ImageIO 生成的 142-byte 兼容形式；Find X9 Ultra 相册 Exif、编辑和 HDR 兼容性更好。"
+
     static let oppoCompatLabel = "[实验性] OPPO 相册 HDR 兼容层"
-    static let oppoCompatHelp = "控制 OPPO 相册识别信号。关闭时保持默认 Apple/ImageIO 输出；自动使用无私有尾部的 ISO 诊断路径；开启也不追加任何私有 tail。LHDR 在兼容模式下固定使用 RGB-copy gain map。"
+    static let oppoCompatHelp = "控制 Gain Map 的 OPPO 编码兼容性和可选私有激活位；相机私有尾由下方选项独立控制。默认自动输出 Main Still 4:2:0，并保持源 UserComment 不变。"
     static let oppoCompatAuto = "自动"
+    static let oppoCompatISO = "标准 HDR 位"
+    static let oppoCompatISONoLocal = "标准 HDR（清除 LHDR）"
+    static let oppoCompatISOGraph = "仅 ISO 图"
     static let oppoCompatOn = "开启"
     static let oppoCompatTail = "兼容开启"
     static let oppoCompatOff = "关闭"
-    static let oppoCompatAutoHelp = "写入 142B ImageIO-native tmap 和 PQ tmap 颜色，并清理会触发私有 OUHDR 路径的 tagflags；不追加任何私有 tail。"
-    static let oppoCompatOnHelp = "保留 source primary，写入标准 HEIC tmap/gain map 结构并设置 OPPO UHDR tagflags；LHDR 固定输出 RGB-copy gain map；不追加任何私有 tail。"
-    static let oppoCompatTailHelp = "兼容旧命令名；行为等同于开启，不追加任何私有 tail。"
-    static let oppoCompatOffHelp = "不写 OPPO 兼容 tmap 扩展，保持默认元数据行为。"
+    static let oppoCompatAutoHelp = "按所选 tmap 格式写入 PQ tmap 颜色，并保持源 OPPO tagflags 不变；私有尾部由下方选项独立控制。"
+    static let oppoCompatISOHelp = "清除 OPLUS_UHDR 私有路由位并设置标准 ULTRA_HDR 位；用于验证 Gallery 的标准 ISO HDR 路径。"
+    static let oppoCompatISONoLocalHelp = "清除 OPLUS_UHDR 与 LOCAL_HDR，并设置标准 ULTRA_HDR；仅用于 Main10/LHDR 路由诊断。"
+    static let oppoCompatISOGraphHelp = "清除 OPLUS_UHDR 和 ULTRA_HDR 两种 HDR 位，仅依赖 ISO tmap/Gain Map 图触发；用于诊断，不建议正式输出。"
+    static let oppoCompatOnHelp = "输出 Main Still 4:2:0，并在 Exif UserComment 设置 OPPO 私有 UHDR activation bit；仅用于明确的路由测试。"
+    static let oppoCompatTailHelp = "兼容旧命令名；行为等同于开启。相机尾部仍由下方选项控制。"
+    static let oppoCompatOffHelp = "从原始高规格源生成 profile 4/4:4:4 Gain Map；已经降采样为 4:2:0 的输入不能反向升级。"
+    static let oppoGalleryCompatibility = "输出 OPPO 相册兼容格式"
+    static let oppoGalleryCompatibilityHelp = "开启时输出 Main Still Picture 4:2:0 Gain Map；关闭时保留原始单通道，或从未降采样的三通道源输出 4:4:4/RExt。元数据保留策略不受影响。"
+    static let preservePortraitEditingData = "保留人像后期数据"
+    static let preservePortraitEditingDataHelp = "关闭时删除 depth、src.image、mask、mesh 和 crop 等大体积后期资源；水印、大师模式、HDR 数据和其他厂商元数据继续保留。"
+    static let oppoCameraTailLabel = "[实验性] OPPO 相机尾部"
+    static let oppoCameraTailHelp = "控制是否复制 OPPO Camera FileExtendedContainer 中的水印、大师模式、人像/景深条目；这和 HDR gain map 兼容层相互独立。"
+    static let oppoCameraTailOff = "关闭"
+    static let oppoCameraTailWatermark = "水印"
+    static let oppoCameraTailCompact = "紧凑景深"
+    static let oppoCameraTailPreserve = "完整保留"
+    static let oppoCameraTailPreserveWithoutPortrait = "不保留人像后期数据"
+    static let oppoCameraTailPreserveWithoutPrivateUHDR = "移除私有 UHDR 数据"
+    static let oppoCameraTailPreserveWithoutPrivateHDR = "移除全部私有 HDR 数据"
+    static let oppoCameraTailPreserveNoUHDR = "停用私有 UHDR"
+    static let oppoCameraTailPreserveNoHDR = "停用 HDR 尾"
+    static let oppoCameraTailOffHelp = "不追加 OPPO 相机私有尾部，保持默认 ISO 输出行为。"
+    static let oppoCameraTailWatermarkHelp = "只追加水印相关 FileExtendedContainer 条目，保留 watermark.*、大师模式 preset 和拍摄参数，不复制大型景深/source/gainmap 私有块。"
+    static let oppoCameraTailCompactHelp = "在水印基础上追加已验证的人像/景深紧凑尾部，并按真实 JSON-to-EOF span 写入 jxrs footer。"
+    static let oppoCameraTailPreserveHelp = "强制使用保留源主图与非 HDR item 的混合写入路径；重建 ISO 21496-1 HDR 图后，逐字节复制源文件 mdat 之后的完整 OPPO/QTI/FileExtendedContainer 尾部，保留景深、水印、原图、编辑、实况和未知数据。"
+    static let oppoCameraTailPreserveWithoutPortraitHelp = "保留水印、大师模式、HDR、UserComment 和其他厂商数据，仅移除景深、蒙版、网格和恢复原图等大体积人像后期资源。"
+    static let oppoCameraTailPreserveWithoutPrivateUHDRHelp = "物理移除 local.uhdr.gainmap.data/info，保留人像、水印和其他非目标条目；仅用于设备验证。"
+    static let oppoCameraTailPreserveWithoutPrivateHDRHelp = "物理移除 local.uhdr.*、local.hdr.*、src.local.hdr.* 和 hdr.*，保留非 HDR 厂商数据；仅用于设备验证。"
+    static let oppoCameraTailPreserveNoUHDRHelp = "完整保留尾长、payload、offset、大师模式和未知数据，仅把 local.uhdr.gainmap.data/info 在 manifest 中等长改名，停用私有 UHDR reader。"
+    static let oppoCameraTailPreserveNoHDRHelp = "在完整保留其他业务数据的前提下，等长停用 local.uhdr.*、hdr.*、local.hdr.* 和 src.local.hdr.* manifest key。"
     static let skipExisting = "跳过已有有效输出"
-    static let skipExistingHelp = "目标文件已经包含可识别的 ISO gain map 时不重复转换。"
+    static let skipExistingHelp = "目标文件已经满足当前 ISO gain map 与 OPPO 相机尾部设置时不重复转换。"
     static let concurrentJobs = "并发任务"
     static let outputFileSuffix = "输出文件后缀"
     static let outputFileSuffixHelp = "未设置输出目录时，在原目录用这个后缀生成新文件。"
@@ -95,11 +133,13 @@ enum AppStrings {
     static let chooseDirectory = "选择目录"
     static let clear = "清除"
 }
-
 extension OppoCompatibility {
     var appTitle: String {
         switch self {
         case .auto: return AppStrings.oppoCompatAuto
+        case .iso: return AppStrings.oppoCompatISO
+        case .isoNoLocal: return AppStrings.oppoCompatISONoLocal
+        case .isoGraph: return AppStrings.oppoCompatISOGraph
         case .on: return AppStrings.oppoCompatOn
         case .tail: return AppStrings.oppoCompatTail
         case .off: return AppStrings.oppoCompatOff
@@ -109,9 +149,58 @@ extension OppoCompatibility {
     var appHelp: String {
         switch self {
         case .auto: return AppStrings.oppoCompatAutoHelp
+        case .iso: return AppStrings.oppoCompatISOHelp
+        case .isoNoLocal: return AppStrings.oppoCompatISONoLocalHelp
+        case .isoGraph: return AppStrings.oppoCompatISOGraphHelp
         case .on: return AppStrings.oppoCompatOnHelp
         case .tail: return AppStrings.oppoCompatTailHelp
         case .off: return AppStrings.oppoCompatOffHelp
+        }
+    }
+}
+
+extension TmapFormat {
+    var appTitle: String {
+        switch self {
+        case .strict: return AppStrings.tmapFormatStrict
+        case .imageIO: return AppStrings.tmapFormatImageIO
+        }
+    }
+
+    var appHelp: String {
+        switch self {
+        case .strict: return AppStrings.tmapFormatStrictHelp
+        case .imageIO: return AppStrings.tmapFormatImageIOHelp
+        }
+    }
+}
+
+extension OppoCameraTail {
+    var appTitle: String {
+        switch self {
+        case .off: return AppStrings.oppoCameraTailOff
+        case .watermark: return AppStrings.oppoCameraTailWatermark
+        case .compact: return AppStrings.oppoCameraTailCompact
+        case .preserve: return AppStrings.oppoCameraTailPreserve
+        case .preserveWithoutPortrait: return AppStrings.oppoCameraTailPreserveWithoutPortrait
+        case .preserveWithoutPrivateUHDR: return AppStrings.oppoCameraTailPreserveWithoutPrivateUHDR
+        case .preserveWithoutPrivateHDR: return AppStrings.oppoCameraTailPreserveWithoutPrivateHDR
+        case .preserveNoUHDR: return AppStrings.oppoCameraTailPreserveNoUHDR
+        case .preserveNoHDR: return AppStrings.oppoCameraTailPreserveNoHDR
+        }
+    }
+
+    var appHelp: String {
+        switch self {
+        case .off: return AppStrings.oppoCameraTailOffHelp
+        case .watermark: return AppStrings.oppoCameraTailWatermarkHelp
+        case .compact: return AppStrings.oppoCameraTailCompactHelp
+        case .preserve: return AppStrings.oppoCameraTailPreserveHelp
+        case .preserveWithoutPortrait: return AppStrings.oppoCameraTailPreserveWithoutPortraitHelp
+        case .preserveWithoutPrivateUHDR: return AppStrings.oppoCameraTailPreserveWithoutPrivateUHDRHelp
+        case .preserveWithoutPrivateHDR: return AppStrings.oppoCameraTailPreserveWithoutPrivateHDRHelp
+        case .preserveNoUHDR: return AppStrings.oppoCameraTailPreserveNoUHDRHelp
+        case .preserveNoHDR: return AppStrings.oppoCameraTailPreserveNoHDRHelp
         }
     }
 }
@@ -130,6 +219,7 @@ extension InputProcessingBranch {
     var appTitle: String {
         switch self {
         case .system: return AppStrings.inputProcessingSystem
+        case .systemDecoded: return AppStrings.inputProcessingSystemDecoded
         case .hybrid: return AppStrings.inputProcessingHybrid
         case .passthrough: return AppStrings.inputProcessingPassthrough
         }
@@ -138,6 +228,7 @@ extension InputProcessingBranch {
     var appHelp: String {
         switch self {
         case .system: return AppStrings.inputProcessingSystemHelp
+        case .systemDecoded: return AppStrings.inputProcessingSystemDecodedHelp
         case .hybrid: return AppStrings.inputProcessingHybridHelp
         case .passthrough: return AppStrings.inputProcessingPassthroughHelp
         }

--- a/apps/macos/XDRemuxApp/Sources/ContentView.swift
+++ b/apps/macos/XDRemuxApp/Sources/ContentView.swift
@@ -196,7 +196,8 @@ struct ContentView: View {
     private var configSummary: String {
         let output = viewModel.config.outputDirectory?.lastPathComponent ?? viewModel.config.fileNameSuffix
         let oppo = "\(AppStrings.oppoCompatLabel): \(viewModel.config.oppoCompatibility.appTitle)"
-        return "\(viewModel.config.family.appTitle) / \(viewModel.config.inputProcessingBranch.appTitle) / \(oppo) / \(output)"
+        let cameraTail = "\(AppStrings.oppoCameraTailLabel): \(viewModel.config.oppoCameraTail.appTitle)"
+        return "\(viewModel.config.family.appTitle) / \(viewModel.config.inputProcessingBranch.appTitle) / \(oppo) / \(cameraTail) / \(output)"
     }
 
     private var stateTitle: String {
@@ -801,29 +802,17 @@ private struct SettingsView: View {
             }
 
             Form {
-                Picker(AppStrings.inputHDRType, selection: $viewModel.config.family) {
-                    ForEach(Family.allCases) { family in
-                        Text(family.appTitle).tag(family)
-                    }
-                }
-                .pickerStyle(.segmented)
-                SettingExplanation(AppStrings.inputHDRTypeHelp)
+                Toggle(
+                    AppStrings.oppoGalleryCompatibility,
+                    isOn: $viewModel.config.oppoGalleryCompatibilityEnabled
+                )
+                SettingExplanation(AppStrings.oppoGalleryCompatibilityHelp)
 
-                Picker(AppStrings.inputProcessing, selection: $viewModel.config.inputProcessingBranch) {
-                    ForEach(InputProcessingBranch.allCases) { branch in
-                        Text(branch.appTitle).tag(branch)
-                    }
-                }
-                .pickerStyle(.segmented)
-                SettingExplanation(viewModel.config.inputProcessingBranch.appHelp)
-
-                Picker(AppStrings.oppoCompatLabel, selection: $viewModel.config.oppoCompatibility) {
-                    ForEach(OppoCompatibility.allCases) { mode in
-                        Text(mode.appTitle).tag(mode)
-                    }
-                }
-                .pickerStyle(.segmented)
-                SettingExplanation(viewModel.config.oppoCompatibility.appHelp)
+                Toggle(
+                    AppStrings.preservePortraitEditingData,
+                    isOn: $viewModel.config.preservesPortraitEditingData
+                )
+                SettingExplanation(AppStrings.preservePortraitEditingDataHelp)
 
                 Toggle(AppStrings.skipExisting, isOn: $viewModel.config.skipExisting)
                     .onChange(of: viewModel.config.skipExisting) {

--- a/apps/macos/XDRemuxApp/Sources/XDRemuxCore.swift
+++ b/apps/macos/XDRemuxApp/Sources/XDRemuxCore.swift
@@ -109,32 +109,68 @@ enum Family: String, CaseIterable, Codable, Sendable, Identifiable, Hashable {
 
 enum InputProcessingBranch: String, CaseIterable, Codable, Sendable, Identifiable, Hashable {
     case system
+    case systemDecoded = "system-decoded"
     case hybrid
     case passthrough
 
     var id: String { rawValue }
 }
 
+enum TmapFormat: String, CaseIterable, Codable, Sendable, Identifiable, Hashable {
+    case strict = "strict"
+    case imageIO = "imageio"
+
+    var id: String { rawValue }
+}
+
 enum OppoCompatibility: String, CaseIterable, Codable, Sendable, Identifiable, Hashable {
     case auto
+    case iso
+    case isoNoLocal = "iso-no-local"
+    case isoGraph = "iso-graph"
     case on
     case tail
     case off
 
     var id: String { rawValue }
     var wantsOppoCompat: Bool { self != .off }
-    var wantsOppoActivationTagflags: Bool { self == .on || self == .tail }
+}
+
+enum OppoCameraTail: String, CaseIterable, Codable, Sendable, Identifiable, Hashable {
+    case off
+    case watermark
+    case compact
+    case preserve
+    case preserveWithoutPortrait = "preserve-without-portrait"
+    case preserveWithoutPrivateUHDR = "preserve-without-private-uhdr"
+    case preserveWithoutPrivateHDR = "preserve-without-private-hdr"
+    case preserveNoUHDR = "preserve-no-uhdr"
+    case preserveNoHDR = "preserve-no-hdr"
+
+    var id: String { rawValue }
 }
 
 struct ConversionConfig: Sendable {
     var family: Family = .auto
     var outputDirectory: URL?
-    var oppoCompatibility: OppoCompatibility = .off
+    var oppoCompatibility: OppoCompatibility = .auto
     var inputProcessingBranch: InputProcessingBranch = .hybrid
+    var oppoCameraTail: OppoCameraTail = .preserve
+    var tmapFormat: TmapFormat = .imageIO
     var debugDirectory: URL?
     var fileNameSuffix: String = "_iso"
     var skipExisting: Bool = true
     var maxConcurrentJobs: Int = min(ProcessInfo.processInfo.activeProcessorCount, 4)
+
+    var oppoGalleryCompatibilityEnabled: Bool {
+        get { oppoCompatibility.wantsOppoCompat }
+        set { oppoCompatibility = newValue ? .auto : .off }
+    }
+
+    var preservesPortraitEditingData: Bool {
+        get { oppoCameraTail != .preserveWithoutPortrait }
+        set { oppoCameraTail = newValue ? .preserve : .preserveWithoutPortrait }
+    }
 }
 
 private func fourCCString(_ value: UInt32?) -> String {
@@ -154,6 +190,7 @@ private struct ManifestEntry {
     let offset: Int
     let length: Int
     let version: Any?
+    let jsonOrder: Int
     let start: Int
     let end: Int
 }
@@ -711,7 +748,7 @@ private enum LHDRExtractor {
     }
 
     private static func locateManifest(in data: Data) throws -> ManifestInfo {
-        let extensionStart = try findExtensionStart(in: data)
+        let detectedExtensionStart = try? findExtensionStart(in: data)
         guard let manifestArray = parseManifest(in: data) else {
             throw XDRemuxError.manifestNotFound
         }
@@ -721,9 +758,21 @@ private enum LHDRExtractor {
             throw XDRemuxError.manifestNotFound
         }
         let jsonEnd = jsonEndBase + 1
+        let markerStart = lastIndex(of: Data([0] + "jxrs".utf8), in: data)
+        let hasValidJXRSFooter: Bool = markerStart.map { marker in
+            guard marker + 9 == data.count else { return false }
+            let footerLength = Int(data[marker + 5])
+                | (Int(data[marker + 6]) << 8)
+                | (Int(data[marker + 7]) << 16)
+                | (Int(data[marker + 8]) << 24)
+            return footerLength == data.count - jsonStart
+        } ?? false
+        guard detectedExtensionStart != nil || hasValidJXRSFooter else {
+            throw XDRemuxError.qtiMarkerNotFound
+        }
 
         var entries: [ManifestEntry] = []
-        for raw in manifestArray {
+        for (jsonOrder, raw) in manifestArray.enumerated() {
             guard let dict = raw as? [String: Any],
                   let offset = dict["offset"] as? NSNumber,
                   let length = dict["length"] as? NSNumber else {
@@ -738,12 +787,16 @@ private enum LHDRExtractor {
                     offset: offsetValue,
                     length: lengthValue,
                     version: dict["version"],
+                    jsonOrder: jsonOrder,
                     start: offsetValue - lengthValue,
                     end: offsetValue
                 )
             )
         }
         entries.sort { $0.start < $1.start }
+        let extensionStart = detectedExtensionStart
+            ?? entries.map { jsonStart - $0.offset }.filter { $0 >= 0 }.min()
+            ?? jsonStart
 
         return ManifestInfo(
             extensionStart: extensionStart,
@@ -1579,7 +1632,8 @@ private enum ISOHDRWriter {
                 outputURL: outputURL,
                 gainMapChannelCount: gainMap.channelCount,
                 inputProcessingBranch: inputProcessingBranch,
-                oppoCompatibility: oppoCompatibility
+                oppoCompatibility: oppoCompatibility,
+                decodePrimaryImage: inputProcessingBranch == .systemDecoded
             )
             try verifyOutput(outputURL, requiredGainMapPixelFormat: requiredPixelFormat(for: inputProcessingBranch, channelCount: gainMap.channelCount))
         }
@@ -1717,7 +1771,8 @@ private enum ISOHDRWriter {
         outputURL: URL,
         gainMapChannelCount: Int,
         inputProcessingBranch: InputProcessingBranch,
-        oppoCompatibility: OppoCompatibility
+        oppoCompatibility: OppoCompatibility,
+        decodePrimaryImage: Bool = false
     ) throws {
         guard let destination = CGImageDestinationCreateWithURL(
             outputURL as CFURL,
@@ -1743,7 +1798,7 @@ private enum ISOHDRWriter {
             kCGImageDestinationMergeMetadata: primaryMetadata
         ]
         
-        if let originalProperties {
+        if let originalProperties, !decodePrimaryImage {
             for (key, value) in originalProperties {
                 imageOptions[key] = value
             }
@@ -1762,7 +1817,31 @@ private enum ISOHDRWriter {
             imageOptions[kCGImagePropertyExifDictionary] = exifDictionary as CFDictionary
         }
 
-        CGImageDestinationAddImageFromSource(destination, source, 0, imageOptions as CFDictionary)
+        if decodePrimaryImage {
+            guard let decodedImage = CGImageSourceCreateImageAtIndex(
+                source,
+                0,
+                [kCGImageSourceShouldCache: false] as CFDictionary
+            ),
+            let context = CGContext(
+                data: nil,
+                width: decodedImage.width,
+                height: decodedImage.height,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ) else {
+                throw XDRemuxError.unableToLoadBaseImage(outputURL)
+            }
+            context.draw(decodedImage, in: CGRect(x: 0, y: 0, width: decodedImage.width, height: decodedImage.height))
+            guard let image8Bit = context.makeImage() else {
+                throw XDRemuxError.unableToLoadBaseImage(outputURL)
+            }
+            CGImageDestinationAddImage(destination, image8Bit, imageOptions as CFDictionary)
+        } else {
+            CGImageDestinationAddImageFromSource(destination, source, 0, imageOptions as CFDictionary)
+        }
         CGImageDestinationAddAuxiliaryDataInfo(destination, kCGImageAuxiliaryDataTypeISOGainMap, auxiliaryDataInfo)
 
         guard CGImageDestinationFinalize(destination) else {
@@ -1874,7 +1953,7 @@ private enum ISOHDRWriter {
 
     private static func requiredPixelFormat(for branch: InputProcessingBranch, channelCount: Int) throws -> UInt32? {
         switch branch {
-        case .system, .hybrid, .passthrough:
+        case .system, .systemDecoded, .hybrid, .passthrough:
             return nil
         }
     }
@@ -1885,7 +1964,7 @@ private enum ISOHDRWriter {
         branch: InputProcessingBranch
     ) throws {
         switch branch {
-        case .system, .hybrid, .passthrough:
+        case .system, .systemDecoded, .hybrid, .passthrough:
             return
         }
     }
@@ -2051,6 +2130,347 @@ private func verifyImageIOISOGainMap(_ outputURL: URL) throws {
     }
 }
 
+private func isoGainMapPixelFormat(at url: URL) -> UInt32? {
+    guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+          let info = CGImageSourceCopyAuxiliaryDataInfoAtIndex(
+              source,
+              0,
+              kCGImageAuxiliaryDataTypeISOGainMap
+          ) as? [CFString: Any],
+          let description = info[kCGImageAuxiliaryDataInfoDataDescription] as? [CFString: Any] else {
+        return nil
+    }
+    if let number = description[kCGImagePropertyPixelFormat] as? NSNumber {
+        return number.uint32Value
+    }
+    if let string = description[kCGImagePropertyPixelFormat] as? String, string.utf8.count == 4 {
+        return pixelFormatFourCC(string)
+    }
+    return nil
+}
+
+private func isSubsampledGainMapPixelFormat(_ pixelFormat: UInt32) -> Bool {
+    pixelFormat == pixelFormatFourCC("420f")
+        || pixelFormat == pixelFormatFourCC("420v")
+        || pixelFormat == pixelFormatFourCC("x420")
+}
+
+private func gainMapEncodingMatchesTarget(at url: URL, compatibility: OppoCompatibility) -> Bool {
+    guard let pixelFormat = isoGainMapPixelFormat(at: url) else { return false }
+    if compatibility.wantsOppoCompat {
+        return isSubsampledGainMapPixelFormat(pixelFormat)
+    }
+    return pixelFormat == pixelFormatFourCC("444f")
+        || pixelFormat == pixelFormatFourCC("L008")
+}
+
+private func pixelFormatFourCC(_ value: String) -> UInt32 {
+    value.utf8.reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+}
+
+private func rejectLossyGainMapPromotion(inputURL: URL, compatibility: OppoCompatibility) throws {
+    guard !compatibility.wantsOppoCompat,
+          let pixelFormat = isoGainMapPixelFormat(at: inputURL),
+          isSubsampledGainMapPixelFormat(pixelFormat) else { return }
+    throw XDRemuxError.invalidContainer(
+        "cannot promote an existing 4:2:0 Gain Map to high-spec 4:4:4 because chroma information has already been discarded"
+    )
+}
+
+private let oppoCameraWatermarkAuxiliaryEntryNames: Set<String> = [
+    "color.space",
+    "gr.effect.info",
+    "master.mode.preset.info",
+    "private.emptyspace"
+]
+
+private let oppoCameraPortraitEditingEntryNames: Set<String> = [
+    "crop.region",
+    "front.depth",
+    "front.depth.config",
+    "front.hair.mask",
+    "front.matter.info",
+    "front.negevimg",
+    "front.segment",
+    "mesh.coord",
+    "mesh.coord.config",
+    "rear.depth",
+    "rear.depth.config",
+    "rear.spotlight",
+    "src.image",
+    "src.image.block"
+]
+
+private let oppoCameraCompactPortraitTailEntryNames: Set<String> =
+    oppoCameraPortraitEditingEntryNames.union(["hdr.transform.data", "src.local.hdr.linear.mask"])
+
+private func shouldPreserveOppoCameraTailEntry(_ name: String, mode: OppoCameraTail) -> Bool {
+    switch mode {
+    case .off:
+        return false
+    case .watermark:
+        return name.hasPrefix("watermark.") || oppoCameraWatermarkAuxiliaryEntryNames.contains(name)
+    case .compact:
+        return shouldPreserveOppoCameraTailEntry(name, mode: .watermark)
+            || oppoCameraCompactPortraitTailEntryNames.contains(name)
+    case .preserveWithoutPortrait:
+        return !oppoCameraPortraitEditingEntryNames.contains(name)
+    case .preserveWithoutPrivateUHDR:
+        return !oppoPrivateUHDRTailEntryNames.contains(name)
+    case .preserveWithoutPrivateHDR:
+        return !isOppoPrivateHDRTailEntry(name)
+    case .preserve, .preserveNoUHDR, .preserveNoHDR:
+        return true
+    }
+}
+
+private let oppoPrivateUHDRTailEntryNames: Set<String> = [
+    "local.uhdr.gainmap.data",
+    "local.uhdr.gainmap.info"
+]
+
+private func isOppoPrivateHDRTailEntry(_ name: String) -> Bool {
+    oppoPrivateUHDRTailEntryNames.contains(name)
+        || name.hasPrefix("hdr.")
+        || name.hasPrefix("local.hdr.")
+        || name.hasPrefix("src.local.hdr.")
+}
+
+private func shouldNeutralizeOppoCameraTailEntry(_ name: String, mode: OppoCameraTail) -> Bool {
+    switch mode {
+    case .preserveNoUHDR:
+        return oppoPrivateUHDRTailEntryNames.contains(name)
+    case .preserveNoHDR:
+        return isOppoPrivateHDRTailEntry(name)
+    case .off, .watermark, .compact, .preserve, .preserveWithoutPortrait, .preserveWithoutPrivateUHDR, .preserveWithoutPrivateHDR:
+        return false
+    }
+}
+
+private func appendCompleteSourceTail(
+    outputURL: URL,
+    sourceData: Data,
+    manifestInfo: ManifestInfo,
+    mode: OppoCameraTail
+) throws {
+    guard let sourceMdat = isobmffBoxes(in: sourceData, start: 0, end: sourceData.count)
+        .first(where: { $0.type == "mdat" }) else {
+        throw XDRemuxError.invalidContainer("source mdat missing while preserving OPPO metadata tail")
+    }
+    let tailStart = sourceMdat.boxStart + sourceMdat.size
+    guard tailStart < sourceData.count else { return }
+    var tail = sourceData.subdata(in: tailStart..<sourceData.count)
+
+    if mode == .preserveNoUHDR || mode == .preserveNoHDR {
+        let jsonStart = manifestInfo.jsonStart - tailStart
+        let jsonEnd = manifestInfo.jsonEnd - tailStart
+        guard jsonStart >= 0, jsonEnd <= tail.count, jsonStart < jsonEnd else {
+            throw XDRemuxError.invalidContainer("OPPO manifest is outside preserved tail")
+        }
+        for entry in manifestInfo.entries where shouldNeutralizeOppoCameraTailEntry(entry.name, mode: mode) {
+            let nameBytes = Data(entry.name.utf8)
+            guard let range = tail.range(of: nameBytes, options: [], in: jsonStart..<jsonEnd),
+                  !range.isEmpty else {
+                throw XDRemuxError.invalidContainer("unable to neutralize OPPO tail entry \(entry.name)")
+            }
+            // Keep the JSON and tail byte lengths stable. Exact vendor lookups
+            // no longer match, while payload bytes and every offset stay intact.
+            tail[range.lowerBound] = UInt8(ascii: "x")
+        }
+    }
+
+    if let outputData = try? Data(contentsOf: outputURL, options: [.mappedIfSafe]),
+       outputData.count >= tail.count,
+       outputData.suffix(tail.count) == tail {
+        return
+    }
+
+    let handle = try FileHandle(forWritingTo: outputURL)
+    defer { try? handle.close() }
+    try handle.seekToEnd()
+    try handle.write(contentsOf: tail)
+}
+
+private struct PackedOppoCameraTailEntry {
+    let entry: ManifestEntry
+    let payloadStart: Int
+}
+
+private struct OppoCameraTailManifestRecord: Encodable {
+    let length: Int
+    let name: String
+    let offset: Int
+    let version: Int
+}
+
+private func oppoCameraTailTag(in sourceData: Data) -> Data {
+    guard sourceData.count >= 9,
+          sourceData[sourceData.count - 9] == 0 else {
+        return Data("jxrs".utf8)
+    }
+    let tag = sourceData.subdata(in: sourceData.count - 8..<sourceData.count - 4)
+    guard tag.allSatisfy({ (32...126).contains($0) }) else {
+        return Data("jxrs".utf8)
+    }
+    return tag
+}
+
+private func appendOppoCameraTailIfNeeded(
+    outputURL: URL,
+    sourceData: Data,
+    extracted: ExtractedLHDR,
+    mode: OppoCameraTail
+) throws {
+    guard mode != .off else { return }
+
+    if mode == .preserve || mode == .preserveNoUHDR || mode == .preserveNoHDR {
+        try appendCompleteSourceTail(
+            outputURL: outputURL,
+            sourceData: sourceData,
+            manifestInfo: extracted.manifestInfo,
+            mode: mode
+        )
+        return
+    }
+
+    let selected = extracted.manifestInfo.entries.filter {
+        shouldPreserveOppoCameraTailEntry($0.name, mode: mode)
+    }
+    guard !selected.isEmpty else { return }
+
+    var payload = Data()
+    var packedEntries: [PackedOppoCameraTailEntry] = []
+    let selectedWithSourceStart = selected.map { entry -> (entry: ManifestEntry, sourceStart: Int) in
+        let manifestRelativeStart = extracted.manifestInfo.jsonStart - entry.offset
+        if manifestRelativeStart >= 0,
+           manifestRelativeStart + entry.length <= sourceData.count {
+            return (entry, manifestRelativeStart)
+        }
+        return (entry, extracted.dataBase + entry.start)
+    }
+
+    for (entry, sourceStart) in selectedWithSourceStart.sorted(by: { $0.sourceStart < $1.sourceStart }) {
+        let sourceEnd = sourceStart + entry.length
+        guard sourceStart >= 0, sourceEnd <= sourceData.count else {
+            throw XDRemuxError.invalidContainer("OPPO camera tail entry \(entry.name) is out of bounds")
+        }
+        let payloadStart = payload.count
+        payload.append(sourceData.subdata(in: sourceStart..<sourceEnd))
+        packedEntries.append(PackedOppoCameraTailEntry(entry: entry, payloadStart: payloadStart))
+    }
+
+    let payloadLength = payload.count
+    var packedByName: [String: PackedOppoCameraTailEntry] = [:]
+    for packed in packedEntries {
+        packedByName[packed.entry.name] = packed
+    }
+    let manifestRecords: [OppoCameraTailManifestRecord] = selected
+        .sorted { $0.jsonOrder < $1.jsonOrder }
+        .compactMap { entry in
+            guard let packed = packedByName[entry.name] else { return nil }
+            return OppoCameraTailManifestRecord(
+                length: entry.length,
+                name: entry.name,
+                offset: payloadLength - packed.payloadStart,
+                version: manifestVersion(entry.version)
+            )
+        }
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let manifestJSON = try encoder.encode(manifestRecords)
+    var tail = Data()
+    tail.append(payload)
+    tail.append(manifestJSON)
+    tail.append(0)
+    tail.append(oppoCameraTailTag(in: sourceData))
+    appendUInt32LE(manifestJSON.count + 1 + 4 + 4, to: &tail)
+
+    let handle = try FileHandle(forWritingTo: outputURL)
+    defer { try? handle.close() }
+    try handle.seekToEnd()
+    try handle.write(contentsOf: tail)
+}
+
+private func hasValidOutput(
+    _ outputURL: URL,
+    oppoCameraTail: OppoCameraTail,
+    oppoCompatibility: OppoCompatibility
+) -> Bool {
+    guard gainMapEncodingMatchesTarget(at: outputURL, compatibility: oppoCompatibility) else { return false }
+    switch oppoCameraTail {
+    case .off:
+        return true
+    case .watermark, .compact, .preserve, .preserveWithoutPortrait, .preserveWithoutPrivateUHDR, .preserveWithoutPrivateHDR, .preserveNoUHDR, .preserveNoHDR:
+        return hasValidCompactOppoCameraTail(outputURL, mode: oppoCameraTail)
+    }
+}
+
+private func hasValidCompactOppoCameraTail(_ outputURL: URL, mode: OppoCameraTail) -> Bool {
+    guard let data = try? Data(contentsOf: outputURL, options: [.mappedIfSafe]),
+          data.count >= 9 else {
+        return false
+    }
+    let markerStart = data.count - 9
+    let tag = data.subdata(in: markerStart + 1..<markerStart + 5)
+    guard data[markerStart] == 0,
+          tag == Data("jxrs".utf8) || tag == Data("wtmk".utf8),
+          markerStart + 9 == data.count,
+          let jsonStart = lastIndex(of: Data("[{".utf8), in: data),
+          jsonStart < markerStart else {
+        return false
+    }
+
+    let footerOffset = markerStart + 5
+    let footerLength = Int(data[footerOffset])
+        | (Int(data[footerOffset + 1]) << 8)
+        | (Int(data[footerOffset + 2]) << 16)
+        | (Int(data[footerOffset + 3]) << 24)
+    guard footerLength == data.count - jsonStart,
+          let jsonEndBase = firstIndex(of: UInt8(ascii: "]"), in: data, startingAt: jsonStart),
+          jsonEndBase < markerStart else {
+        return false
+    }
+
+    let manifestData = data.subdata(in: jsonStart..<(jsonEndBase + 1))
+    guard let object = try? JSONSerialization.jsonObject(with: manifestData, options: []),
+          let manifest = object as? [[String: Any]] else {
+        return false
+    }
+    let names = manifest.compactMap { $0["name"] as? String }
+    if mode == .preserve {
+        return !names.isEmpty
+    }
+    if mode == .preserveWithoutPortrait {
+        return !names.isEmpty && names.allSatisfy { !oppoCameraPortraitEditingEntryNames.contains($0) }
+    }
+    if mode == .preserveWithoutPrivateUHDR {
+        return !names.isEmpty && names.allSatisfy { !oppoPrivateUHDRTailEntryNames.contains($0) }
+    }
+    if mode == .preserveWithoutPrivateHDR {
+        return !names.isEmpty && names.allSatisfy { !isOppoPrivateHDRTailEntry($0) }
+    }
+    if mode == .preserveNoUHDR {
+        return !names.isEmpty && names.allSatisfy { !oppoPrivateUHDRTailEntryNames.contains($0) }
+    }
+    if mode == .preserveNoHDR {
+        return !names.isEmpty && names.allSatisfy { !shouldNeutralizeOppoCameraTailEntry($0, mode: mode) }
+    }
+    return !names.isEmpty && names.allSatisfy {
+        shouldPreserveOppoCameraTailEntry($0, mode: mode) && !$0.hasPrefix("local.uhdr.")
+    }
+}
+
+private func manifestVersion(_ value: Any?) -> Int {
+    if let number = value as? NSNumber {
+        return number.intValue
+    }
+    if let string = value as? String, let parsed = Int(string) {
+        return parsed
+    }
+    return 1
+}
+
 private enum XDRemuxProductCore {
     private static let fileManager = FileManager.default
 
@@ -2059,8 +2479,10 @@ private enum XDRemuxProductCore {
         outputURL: URL,
         familyPreference: Family,
         debugRootURL: URL?,
-        oppoCompatibility: OppoCompatibility = .off,
-        inputProcessingBranch: InputProcessingBranch = .hybrid
+        oppoCompatibility: OppoCompatibility = .auto,
+        inputProcessingBranch: InputProcessingBranch = .hybrid,
+        oppoCameraTail: OppoCameraTail = .preserve,
+        tmapFormat: TmapFormat = .imageIO
     ) throws -> SampleReport {
         guard fileManager.fileExists(atPath: inputURL.path) else {
             throw XDRemuxError.inputNotFound(inputURL)
@@ -2076,6 +2498,7 @@ private enum XDRemuxProductCore {
             throw XDRemuxError.unableToRead(inputURL)
         }
 
+        try rejectLossyGainMapPromotion(inputURL: inputURL, compatibility: oppoCompatibility)
         let productInput = try prepareProductInput(
             inputURL: inputURL,
             sourceData: sourceData,
@@ -2094,14 +2517,41 @@ private enum XDRemuxProductCore {
             }
         }
 
+        // Complete OPPO preservation requires the source-primary graft path. ImageIO's
+        // direct writer and the experimental passthrough writer may normalize or omit
+        // non-HDR HEIF items before the opaque camera tail is restored.
+        let effectiveInputProcessingBranch: InputProcessingBranch = (
+            oppoCameraTail == .preserve
+                || oppoCameraTail == .preserveWithoutPortrait
+                || oppoCameraTail == .preserveWithoutPrivateUHDR
+                || oppoCameraTail == .preserveWithoutPrivateHDR
+                || tmapFormat == .strict
+        )
+            ? .hybrid
+            : inputProcessingBranch
         try ProductGainMapWriter.write(
             inputURL: inputURL,
             outputURL: actualOutputURL,
             sourceData: sourceData,
             productInput: productInput,
             oppoCompatibility: oppoCompatibility,
-            inputProcessingBranch: inputProcessingBranch
+            inputProcessingBranch: effectiveInputProcessingBranch,
+            strictISO21496: tmapFormat == .strict
         )
+        try restoreOppoUserCommentFromSource(
+            outputURL: actualOutputURL,
+            sourceData: sourceData,
+            compatibility: oppoCompatibility
+        )
+        try appendOppoCameraTailIfNeeded(
+            outputURL: actualOutputURL,
+            sourceData: sourceData,
+            extracted: productInput.extracted,
+            mode: oppoCameraTail
+        )
+        guard gainMapEncodingMatchesTarget(at: actualOutputURL, compatibility: oppoCompatibility) else {
+            throw XDRemuxError.invalidContainer("output Gain Map encoding does not match the selected compatibility target")
+        }
 
         if writesInPlace {
             _ = try fileManager.replaceItemAt(outputURL, withItemAt: actualOutputURL)
@@ -2256,10 +2706,11 @@ private enum ProductGainMapWriter {
         sourceData: Data,
         productInput: XDRemuxProductCore.ProductInput,
         oppoCompatibility: OppoCompatibility,
-        inputProcessingBranch: InputProcessingBranch
+        inputProcessingBranch: InputProcessingBranch,
+        strictISO21496: Bool
     ) throws {
         switch inputProcessingBranch {
-        case .system:
+        case .system, .systemDecoded:
             let writerInput = gainMapWriterInput(
                 productInput: productInput,
                 oppoCompatibility: oppoCompatibility
@@ -2270,7 +2721,7 @@ private enum ProductGainMapWriter {
                 style: writerInput.style,
                 outputURL: outputURL,
                 oppoCompatibility: oppoCompatibility,
-                inputProcessingBranch: .system
+                inputProcessingBranch: inputProcessingBranch
             )
         case .hybrid:
             try HybridGainMapWriter.write(
@@ -2278,7 +2729,8 @@ private enum ProductGainMapWriter {
                 outputURL: outputURL,
                 sourceData: sourceData,
                 productInput: productInput,
-                oppoCompatibility: oppoCompatibility
+                oppoCompatibility: oppoCompatibility,
+                strictISO21496: strictISO21496
             )
         case .passthrough:
             try DirectPassthroughGainMapWriter.write(
@@ -2311,7 +2763,8 @@ private enum HybridGainMapWriter {
         outputURL: URL,
         sourceData: Data,
         productInput: XDRemuxProductCore.ProductInput,
-        oppoCompatibility: OppoCompatibility
+        oppoCompatibility: OppoCompatibility,
+        strictISO21496: Bool
     ) throws {
         try writeImageIOPreservedGainMapPassthrough(
             inputURL: inputURL,
@@ -2319,7 +2772,8 @@ private enum HybridGainMapWriter {
             sourceData: sourceData,
             productInput: productInput,
             oppoCompatibility: oppoCompatibility,
-            temporaryLabel: "hybrid"
+            temporaryLabel: "hybrid",
+            strictISO21496: strictISO21496
         )
     }
 }
@@ -2332,7 +2786,7 @@ private enum DirectPassthroughGainMapWriter {
         productInput: XDRemuxProductCore.ProductInput,
         oppoCompatibility: OppoCompatibility
     ) throws {
-        if oppoCompatibility.wantsOppoCompat {
+        if oppoCompatibility.wantsOppoCompat && productInput.extracted.mode != .uhdr {
             try writeImageIOPreservedGainMapPassthrough(
                 inputURL: inputURL,
                 outputURL: outputURL,
@@ -2375,7 +2829,8 @@ private func writeImageIOPreservedGainMapPassthrough(
     sourceData: Data,
     productInput: XDRemuxProductCore.ProductInput,
     oppoCompatibility: OppoCompatibility,
-    temporaryLabel: String
+    temporaryLabel: String,
+    strictISO21496: Bool = false
 ) throws {
     let parent = outputURL.deletingLastPathComponent()
     let stem = outputURL.deletingPathExtension().lastPathComponent
@@ -2435,7 +2890,9 @@ private func writeImageIOPreservedGainMapPassthrough(
         preservedURL: preservedURL,
         outputURL: outputURL,
         patchedUserComment: patchedUserComment,
-        preserveTmapColor: oppoCompatibility.wantsOppoCompat
+        preserveTmapColor: oppoCompatibility.wantsOppoCompat,
+        strictISO21496Tmap: strictISO21496,
+        fallbackXMPPayload: makeHdrgmXMP(infoFloats: productInput.extracted.metaFloats)
     )
 }
 
@@ -2447,17 +2904,28 @@ enum XDRemuxCore {
             familyPreference: config.family,
             debugRootURL: config.debugDirectory,
             oppoCompatibility: config.oppoCompatibility,
-            inputProcessingBranch: config.inputProcessingBranch
+            inputProcessingBranch: config.inputProcessingBranch,
+            oppoCameraTail: config.oppoCameraTail,
+            tmapFormat: config.tmapFormat
         )
     }
 
     static func isValidISOGainMapOutput(_ outputURL: URL) -> Bool {
         (try? verifyImageIOISOGainMap(outputURL)) != nil
     }
+
+    static func isValidOutput(_ outputURL: URL, config: ConversionConfig) -> Bool {
+        hasValidOutput(
+            outputURL,
+            oppoCameraTail: config.oppoCameraTail,
+            oppoCompatibility: config.oppoCompatibility
+        )
+    }
 }
 
 private let oppoUltraHDRFlag = 0x20000000
-private let oppoPrivateHDRBranchFlags = 0x40000 | 0x200000 | oppoUltraHDRFlag
+private let isoUltraHDRFlag = 0x00200000
+private let localHDRFlag = 0x00040000
 private let oppoTagFlagPrefixes = [
     "ASCIIOplus_",
     "ASCIIoppo_",
@@ -2466,10 +2934,34 @@ private let oppoTagFlagPrefixes = [
     "oppo_"
 ]
 
-/// Extract OPPO tagflags and adjust only the private HDR branch bits.
-private func adjustedOppoUserComment(in data: Data, compatibility: OppoCompatibility) -> String? {
-    guard compatibility != .off else { return nil }
+private func targetOppoTagFlags(_ sourceFlags: Int, compatibility: OppoCompatibility) -> Int {
+    switch compatibility {
+    case .auto, .off:
+        return sourceFlags
+    case .on, .tail:
+        return sourceFlags | oppoUltraHDRFlag
+    case .iso:
+        return (sourceFlags & ~oppoUltraHDRFlag) | isoUltraHDRFlag
+    case .isoNoLocal:
+        return (sourceFlags & ~oppoUltraHDRFlag & ~localHDRFlag) | isoUltraHDRFlag
+    case .isoGraph:
+        return sourceFlags & ~oppoUltraHDRFlag & ~isoUltraHDRFlag
+    }
+}
 
+/// Extract OPPO tagflags and adjust only explicit HDR routing bits.
+private func adjustedOppoUserComment(in data: Data, compatibility: OppoCompatibility) -> String? {
+    if let userComment = oppoUserComment(in: data),
+       let source = oppoTagFlags(from: userComment) {
+        let adjustedFlags = targetOppoTagFlags(source.flags, compatibility: compatibility)
+        guard adjustedFlags != source.flags else { return nil }
+        let digits = String(adjustedFlags)
+        return source.prefix
+            + String(repeating: "0", count: max(0, source.digitCount - digits.count))
+            + digits
+    }
+
+    // Fallback for malformed vendor Exif that ImageIO cannot type as a string.
     for prefix in oppoTagFlagPrefixes {
         let prefixData = Data(prefix.utf8)
         var searchRange: Range<Data.Index>? = data.startIndex..<data.endIndex
@@ -2481,14 +2973,12 @@ private func adjustedOppoUserComment(in data: Data, compatibility: OppoCompatibi
             if digitEnd > range.upperBound,
                let flagStr = String(data: data.subdata(in: range.upperBound..<digitEnd), encoding: .utf8),
                let flags = Int(flagStr) {
-                let adjustedFlags: Int
-                if compatibility.wantsOppoActivationTagflags {
-                    adjustedFlags = flags | oppoUltraHDRFlag
-                } else {
-                    adjustedFlags = flags & ~oppoPrivateHDRBranchFlags
-                }
+                let adjustedFlags = targetOppoTagFlags(flags, compatibility: compatibility)
                 guard adjustedFlags != flags else { return nil }
-                return "\(prefix)\(adjustedFlags)"
+                let digits = String(adjustedFlags)
+                return prefix
+                    + String(repeating: "0", count: max(0, digitEnd - range.upperBound - digits.count))
+                    + digits
             }
             searchRange = range.upperBound..<data.endIndex
         }
@@ -2496,31 +2986,62 @@ private func adjustedOppoUserComment(in data: Data, compatibility: OppoCompatibi
     return nil
 }
 
-private func patchOppoUserComment(_ data: inout Data, patchedUserComment: String) -> Bool {
-    for prefix in oppoTagFlagPrefixes {
-        guard patchedUserComment.hasPrefix(prefix) else { continue }
-        let patchedDigits = String(patchedUserComment.dropFirst(prefix.count))
-        let prefixData = Data(prefix.utf8)
-        var searchRange: Range<Data.Index>? = data.startIndex..<data.endIndex
-        while let range = data.range(of: prefixData, options: [], in: searchRange) {
-            var digitEnd = range.upperBound
-            while digitEnd < data.count, (48...57).contains(data[digitEnd]) {
-                digitEnd += 1
-            }
-            let digitCount = digitEnd - range.upperBound
-            guard digitCount > 0, patchedDigits.count <= digitCount else {
-                searchRange = range.upperBound..<data.endIndex
-                continue
-            }
-
-            var replacement = prefixData
-            replacement.append(Data(repeating: UInt8(ascii: "0"), count: digitCount - patchedDigits.count))
-            replacement.append(Data(patchedDigits.utf8))
-            data.replaceSubrange(range.lowerBound..<digitEnd, with: replacement)
-            return true
-        }
+private func restoreOppoUserCommentFromSource(
+    outputURL: URL,
+    sourceData: Data,
+    compatibility: OppoCompatibility
+) throws {
+    guard let sourceUserComment = oppoUserComment(in: sourceData),
+          let sourceTagFlags = oppoTagFlags(from: sourceUserComment) else {
+        return
     }
-    return false
+
+    let targetFlags = targetOppoTagFlags(sourceTagFlags.flags, compatibility: compatibility)
+
+    var data = try Data(contentsOf: outputURL)
+    guard let outputUserComment = oppoUserComment(in: data),
+          let outputTagFlags = oppoTagFlags(from: outputUserComment) else {
+        return
+    }
+
+    guard outputTagFlags.flags != targetFlags else { return }
+
+    let originalBytes = Data(outputUserComment.utf8)
+    let targetDigits = String(targetFlags)
+    guard targetDigits.count <= outputTagFlags.digitCount else {
+        throw XDRemuxError.invalidContainer("unable to preserve source OPPO UserComment without resizing")
+    }
+    let patchedUserComment = outputTagFlags.prefix
+        + String(repeating: "0", count: outputTagFlags.digitCount - targetDigits.count)
+        + targetDigits
+    let patchedBytes = Data(patchedUserComment.utf8)
+    guard originalBytes.count == patchedBytes.count,
+          let range = data.range(of: originalBytes) else {
+        throw XDRemuxError.invalidContainer("unable to patch OPPO UserComment")
+    }
+
+    data.replaceSubrange(range, with: patchedBytes)
+    try data.write(to: outputURL, options: [.atomic])
+}
+
+private func oppoUserComment(in data: Data) -> String? {
+    guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+          let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+          let exif = properties[kCGImagePropertyExifDictionary] as? [CFString: Any],
+          let value = exif[kCGImagePropertyExifUserComment] else {
+        return nil
+    }
+    return value as? String
+}
+
+private func oppoTagFlags(from userComment: String) -> (prefix: String, digitCount: Int, flags: Int)? {
+    for prefix in oppoTagFlagPrefixes {
+        guard userComment.hasPrefix(prefix) else { continue }
+        let digits = String(userComment.dropFirst(prefix.count).prefix { $0.isNumber })
+        guard !digits.isEmpty, let flags = Int(digits) else { return nil }
+        return (prefix, digits.count, flags)
+    }
+    return nil
 }
 
 private struct OppoUserCommentPatch {
@@ -2529,38 +3050,125 @@ private struct OppoUserCommentPatch {
 }
 
 private func applyOppoUserCommentPatch(
-    _ data: inout Data,
-    sourceOffset: Int,
+    _ mdatPayload: inout Data,
+    mdatDataStart: Int,
+    exifEntry: ISOBMFFILocEntry,
     patchedUserComment: String
 ) -> OppoUserCommentPatch? {
-    for prefix in oppoTagFlagPrefixes {
-        guard patchedUserComment.hasPrefix(prefix) else { continue }
-        let patchedDigits = String(patchedUserComment.dropFirst(prefix.count))
-        let prefixData = Data(prefix.utf8)
-        var searchRange: Range<Data.Index>? = data.startIndex..<data.endIndex
-        while let range = data.range(of: prefixData, options: [], in: searchRange) {
-            var digitEnd = range.upperBound
-            while digitEnd < data.count, (48...57).contains(data[digitEnd]) {
-                digitEnd += 1
-            }
-            let digitCount = digitEnd - range.upperBound
-            guard digitCount > 0 else {
-                searchRange = range.upperBound..<data.endIndex
-                continue
-            }
+    guard exifEntry.constructionMethod == 0,
+          exifEntry.extents.count == 1,
+          let extent = exifEntry.extents.first else { return nil }
+    let localStart = extent.offset - mdatDataStart
+    let localEnd = localStart + extent.length
+    guard localStart >= 0, localEnd <= mdatPayload.count else { return nil }
+    var exifPayload = mdatPayload.subdata(in: localStart..<localEnd)
 
-            var replacement = prefixData
-            replacement.append(Data(repeating: UInt8(ascii: "0"), count: max(0, digitCount - patchedDigits.count)))
-            replacement.append(Data(patchedDigits.utf8))
-            let replacedRange = range.lowerBound..<digitEnd
-            data.replaceSubrange(replacedRange, with: replacement)
-            return OppoUserCommentPatch(
-                sourceRange: (sourceOffset + range.lowerBound)..<(sourceOffset + digitEnd),
-                delta: replacement.count - (digitEnd - range.lowerBound)
-            )
+    guard exifPayload.count >= 12 else { return nil }
+    let tiffStart = 4 + readUInt32BEUnchecked(exifPayload, at: 0)
+    guard tiffStart >= 4, tiffStart + 8 <= exifPayload.count else { return nil }
+    let isLittleEndian: Bool
+    if exifPayload[tiffStart] == UInt8(ascii: "I"), exifPayload[tiffStart + 1] == UInt8(ascii: "I") {
+        isLittleEndian = true
+    } else if exifPayload[tiffStart] == UInt8(ascii: "M"), exifPayload[tiffStart + 1] == UInt8(ascii: "M") {
+        isLittleEndian = false
+    } else {
+        return nil
+    }
+
+    func read16(_ offset: Int) -> Int? {
+        guard offset >= 0, offset + 2 <= exifPayload.count else { return nil }
+        if isLittleEndian {
+            return Int(exifPayload[offset]) | (Int(exifPayload[offset + 1]) << 8)
+        }
+        return (Int(exifPayload[offset]) << 8) | Int(exifPayload[offset + 1])
+    }
+    func read32(_ offset: Int) -> Int? {
+        guard offset >= 0, offset + 4 <= exifPayload.count else { return nil }
+        if isLittleEndian {
+            return Int(exifPayload[offset])
+                | (Int(exifPayload[offset + 1]) << 8)
+                | (Int(exifPayload[offset + 2]) << 16)
+                | (Int(exifPayload[offset + 3]) << 24)
+        }
+        return (Int(exifPayload[offset]) << 24)
+            | (Int(exifPayload[offset + 1]) << 16)
+            | (Int(exifPayload[offset + 2]) << 8)
+            | Int(exifPayload[offset + 3])
+    }
+    func write32(_ value: Int, at offset: Int) -> Bool {
+        guard value >= 0, value <= Int(UInt32.max), offset >= 0, offset + 4 <= exifPayload.count else { return false }
+        if isLittleEndian {
+            exifPayload[offset] = UInt8(value & 0xff)
+            exifPayload[offset + 1] = UInt8((value >> 8) & 0xff)
+            exifPayload[offset + 2] = UInt8((value >> 16) & 0xff)
+            exifPayload[offset + 3] = UInt8((value >> 24) & 0xff)
+        } else {
+            exifPayload[offset] = UInt8((value >> 24) & 0xff)
+            exifPayload[offset + 1] = UInt8((value >> 16) & 0xff)
+            exifPayload[offset + 2] = UInt8((value >> 8) & 0xff)
+            exifPayload[offset + 3] = UInt8(value & 0xff)
+        }
+        return true
+    }
+
+    guard read16(tiffStart + 2) == 42,
+          let firstIFDOffset = read32(tiffStart + 4) else { return nil }
+    var pendingIFDs = [firstIFDOffset]
+    var visitedIFDs = Set<Int>()
+    var userCommentEntryOffset: Int?
+    while let relativeIFD = pendingIFDs.popLast(), userCommentEntryOffset == nil {
+        guard visitedIFDs.insert(relativeIFD).inserted else { continue }
+        let ifd = tiffStart + relativeIFD
+        guard let count = read16(ifd), count <= 4096 else { return nil }
+        for index in 0..<count {
+            let entry = ifd + 2 + index * 12
+            guard let tag = read16(entry), entry + 12 <= exifPayload.count else { return nil }
+            if tag == 0x9286 {
+                userCommentEntryOffset = entry
+                break
+            }
+            if tag == 0x8769 || tag == 0x8825,
+               let childOffset = read32(entry + 8) {
+                pendingIFDs.append(childOffset)
+            }
         }
     }
-    return nil
+
+    guard let entry = userCommentEntryOffset,
+          let fieldType = read16(entry + 2), fieldType == 7,
+          let oldCount = read32(entry + 4), oldCount > 0,
+          let oldValueOffset = read32(entry + 8) else { return nil }
+    let oldValueStart = oldCount <= 4 ? entry + 8 : tiffStart + oldValueOffset
+    let oldValueEnd = oldValueStart + oldCount
+    guard oldValueStart >= 0, oldValueEnd <= exifPayload.count else { return nil }
+    var newValue = exifPayload.subdata(in: oldValueStart..<oldValueEnd)
+
+    var sourceCommentRange: Range<Int>?
+    for prefix in oppoTagFlagPrefixes {
+        let prefixData = Data(prefix.utf8)
+        guard let range = newValue.range(of: prefixData) else { continue }
+        var digitEnd = range.upperBound
+        while digitEnd < newValue.count, (48...57).contains(newValue[digitEnd]) {
+            digitEnd += 1
+        }
+        guard digitEnd > range.upperBound else { continue }
+        sourceCommentRange = range.lowerBound..<digitEnd
+        break
+    }
+    guard let sourceCommentRange else { return nil }
+    newValue.replaceSubrange(sourceCommentRange, with: Data(patchedUserComment.utf8))
+
+    while exifPayload.count % 4 != 0 { exifPayload.append(0) }
+    let newValueOffset = exifPayload.count - tiffStart
+    exifPayload.append(newValue)
+    guard write32(newValue.count, at: entry + 4),
+          write32(newValueOffset, at: entry + 8) else { return nil }
+
+    mdatPayload.replaceSubrange(localStart..<localEnd, with: exifPayload)
+    return OppoUserCommentPatch(
+        sourceRange: extent.offset..<(extent.offset + extent.length),
+        delta: exifPayload.count - extent.length
+    )
 }
 
 private func adjustedExtentForOppoUserCommentPatch(
@@ -2648,6 +3256,11 @@ private func appendUInt32BE(_ value: Int, to data: inout Data) {
     data.append(UInt8((value >> 16) & 0xff))
     data.append(UInt8((value >> 8) & 0xff))
     data.append(UInt8(value & 0xff))
+}
+
+private func appendUInt32LE(_ value: Int, to data: inout Data) {
+    var little = UInt32(value).littleEndian
+    withUnsafeBytes(of: &little) { data.append(contentsOf: $0) }
 }
 
 private func appendInt32BE(_ value: Int32, to data: inout Data) {
@@ -2961,14 +3574,45 @@ private func makeIrefFullBox(version: UInt8, refs: [ISOBMFFIRefEntry]) -> Data {
 }
 
 private func makeGrplAltrBox(groupID: Int, tmapID: Int, primaryID: Int) -> Data {
+    makeBox("grpl", payload: makeAltrEntityGroupBox(groupID: groupID, tmapID: tmapID, primaryID: primaryID))
+}
+
+private func makeAltrEntityGroupBox(groupID: Int, tmapID: Int, primaryID: Int) -> Data {
     var altrPayload = Data([0, 0, 0, 0])
     appendUInt32BE(groupID, to: &altrPayload)
     appendUInt32BE(2, to: &altrPayload)
     appendUInt32BE(tmapID, to: &altrPayload)
     appendUInt32BE(primaryID, to: &altrPayload)
-    var grplPayload = Data()
-    grplPayload.append(makeBox("altr", payload: altrPayload))
-    return makeBox("grpl", payload: grplPayload)
+    return makeBox("altr", payload: altrPayload)
+}
+
+private func preservedEntityGroupChildren(
+    in data: Data,
+    grpl: ISOBMFFBox,
+    dropping itemIDs: Set<Int>
+) -> (payload: Data, groupIDs: [Int]) {
+    var payload = Data()
+    var groupIDs: [Int] = []
+    for child in isobmffBoxes(in: data, start: grpl.dataStart, end: grpl.dataEnd) {
+        let raw = data.subdata(in: child.boxStart..<child.boxStart + child.size)
+        guard child.dataEnd - child.dataStart >= 12 else {
+            payload.append(raw)
+            continue
+        }
+        let groupID = readUInt32BEUnchecked(data, at: child.dataStart + 4)
+        let entityCount = readUInt32BEUnchecked(data, at: child.dataStart + 8)
+        groupIDs.append(groupID)
+        var pos = child.dataStart + 12
+        var entities: [Int] = []
+        for _ in 0..<entityCount where pos + 4 <= child.dataEnd {
+            entities.append(readUInt32BEUnchecked(data, at: pos))
+            pos += 4
+        }
+        if itemIDs.isDisjoint(with: entities) {
+            payload.append(raw)
+        }
+    }
+    return (payload, groupIDs)
 }
 
 private func itemPayload(in data: Data, entry: ISOBMFFILocEntry, idat: ISOBMFFBox?) throws -> Data {
@@ -3160,7 +3804,9 @@ private func writeHybridPrimaryPassthrough(
     preservedURL: URL,
     outputURL: URL,
     patchedUserComment: String?,
-    preserveTmapColor: Bool = false
+    preserveTmapColor: Bool = false,
+    strictISO21496Tmap: Bool = false,
+    fallbackXMPPayload: Data? = nil
 ) throws {
     let source = try Data(contentsOf: sourceURL)
     let preserved = try Data(contentsOf: preservedURL)
@@ -3247,23 +3893,34 @@ private func writeHybridPrimaryPassthrough(
         $0.type == "cdsc" && $0.to.contains(preservedTmapID) && preservedItemsByID[$0.from]?.type == "mime"
     }?.from
 
-    let sourceTmapIDs = Set(sourceItemInfo.items.filter { $0.type == "tmap" }.map(\.itemID))
-    var dropSourceIDs = Set(sourceItemInfo.items.filter { $0.type == "jpeg" }.map(\.itemID))
-    dropSourceIDs.formUnion(sourceTmapIDs)
-    var changed = true
-    while changed {
-        changed = false
-        for ref in sourceRefsInfo.refs where dropSourceIDs.contains(ref.from) {
-            for target in ref.to where target != sourcePrimaryID && !dropSourceIDs.contains(target) {
-                dropSourceIDs.insert(target)
-                changed = true
-            }
-        }
-        for ref in sourceRefsInfo.refs where ref.type == "cdsc" && !dropSourceIDs.isDisjoint(with: Set(ref.to)) {
-            if !dropSourceIDs.contains(ref.from) {
-                dropSourceIDs.insert(ref.from)
-                changed = true
-            }
+    let sourceTmapIDs = Set(sourceItemInfo.items.compactMap { item -> Int? in
+        guard item.type == "tmap",
+              sourceRefsInfo.refs.contains(where: {
+                  $0.type == "dimg" && $0.from == item.itemID && $0.to.contains(sourcePrimaryID)
+              }) else { return nil }
+        return item.itemID
+    })
+    let sourceGainRootIDs = Set(sourceRefsInfo.refs
+        .filter { $0.type == "dimg" && sourceTmapIDs.contains($0.from) }
+        .flatMap(\.to)
+        .filter { $0 != sourcePrimaryID })
+    var dropSourceIDs = sourceTmapIDs
+    let generatedHDRGMName = Data("hdrgm-xmp\u{0}".utf8)
+    let sourceGeneratedHDRGMXMPIDs = Set(sourceItemInfo.items.compactMap { item -> Int? in
+        guard item.type == "mime",
+              item.rawInfe.range(of: generatedHDRGMName) != nil,
+              sourceRefsInfo.refs.contains(where: {
+                  $0.type == "cdsc" && $0.from == item.itemID && !Set($0.to).isDisjoint(with: sourceTmapIDs)
+              }) else { return nil }
+        return item.itemID
+    })
+    dropSourceIDs.formUnion(sourceGeneratedHDRGMXMPIDs)
+    var pendingHDRInputs = Array(sourceGainRootIDs)
+    while let itemID = pendingHDRInputs.popLast() {
+        guard itemID != sourcePrimaryID, !dropSourceIDs.contains(itemID) else { continue }
+        dropSourceIDs.insert(itemID)
+        for ref in sourceRefsInfo.refs where ref.type == "dimg" && ref.from == itemID {
+            pendingHDRInputs.append(contentsOf: ref.to.filter { $0 != sourcePrimaryID })
         }
     }
 
@@ -3274,11 +3931,17 @@ private func writeHybridPrimaryPassthrough(
         throw XDRemuxError.invalidContainer("hybrid graft would drop primary item")
     }
     var sourceMdatPayload = source.subdata(in: sourceMdat.dataStart..<sourceMdat.dataEnd)
+    let sourceExifID = keptSourceItems.first(where: { $0.type == "Exif" })?.itemID
     let userCommentPatch: OppoUserCommentPatch?
     if let patchedUserComment {
+        guard let sourceExifID,
+              let sourceExifEntry = keptSourceIlocEntries.first(where: { $0.itemID == sourceExifID }) else {
+            throw XDRemuxError.invalidContainer("unable to locate source Exif item for OPPO UserComment patch")
+        }
         guard let patch = applyOppoUserCommentPatch(
             &sourceMdatPayload,
-            sourceOffset: sourceMdat.dataStart,
+            mdatDataStart: sourceMdat.dataStart,
+            exifEntry: sourceExifEntry,
             patchedUserComment: patchedUserComment
         ) else {
             throw XDRemuxError.invalidContainer("unable to patch OPPO UserComment in hybrid output")
@@ -3289,7 +3952,8 @@ private func writeHybridPrimaryPassthrough(
     }
 
     let maxSourceID = keptSourceItems.map(\.itemID).max() ?? sourcePrimaryID
-    let copiedItemCount = preservedGainTileIDs.count + 2 + (preservedXMPID == nil ? 0 : 1)
+    let hasOutputXMP = preservedXMPID != nil || fallbackXMPPayload != nil
+    let copiedItemCount = preservedGainTileIDs.count + 2 + (hasOutputXMP ? 1 : 0)
     guard maxSourceID + copiedItemCount < 0xffff else {
         throw XDRemuxError.invalidContainer("hybrid graft currently requires 16-bit item IDs")
     }
@@ -3304,7 +3968,7 @@ private func writeHybridPrimaryPassthrough(
     let outputTmapID = nextItemID
     nextItemID += 1
     let outputXMPID: Int?
-    if preservedXMPID != nil {
+    if hasOutputXMP {
         outputXMPID = nextItemID
         nextItemID += 1
     } else {
@@ -3322,7 +3986,17 @@ private func writeHybridPrimaryPassthrough(
         throw XDRemuxError.invalidContainer("preserve gain grid/tmap has no iloc entry")
     }
     let gainGridPayload = try itemPayload(in: preserved, entry: gainGridEntry, idat: preservedIDAT)
-    let tmapPayload = try itemPayload(in: preserved, entry: tmapEntry, idat: preservedIDAT)
+    let preservedTmapPayload = try itemPayload(in: preserved, entry: tmapEntry, idat: preservedIDAT)
+    let tmapPayload: Data
+    if strictISO21496Tmap, preservedTmapPayload.count == 62 || preservedTmapPayload.count == 142 {
+        // ImageIO omits the three reserved GainMapMetadata bytes. Restore them
+        // after the flags byte so one/three-channel ISO payloads are 65/145 B.
+        tmapPayload = preservedTmapPayload.prefix(6)
+            + Data([0x00, 0x00, 0x00])
+            + preservedTmapPayload.dropFirst(6)
+    } else {
+        tmapPayload = preservedTmapPayload
+    }
     let xmpPayload: Data?
     if let preservedXMPID {
         guard let xmpEntry = preservedIlocByID[preservedXMPID] else {
@@ -3330,7 +4004,7 @@ private func writeHybridPrimaryPassthrough(
         }
         xmpPayload = try itemPayload(in: preserved, entry: xmpEntry, idat: preservedIDAT)
     } else {
-        xmpPayload = nil
+        xmpPayload = fallbackXMPPayload
     }
 
     var ipcoPayload = Data()
@@ -3379,14 +4053,17 @@ private func writeHybridPrimaryPassthrough(
     }?.to.first
     let sourceBaselineColorAssoc = sourcePrimaryColorAssoc
         ?? sourceBaselineTileID.flatMap(sourceItemColorAssoc)
-    if let preservedPrimaryEntry = preservedIPMAByID[preservedPrimaryID] {
-        for value in preservedPrimaryEntry.associations {
-            let index = assocPropertyIndex(value, flags: preservedIPMA.flags)
-            guard let prop = preservedPropsByIndex[index],
-                  ["colr", "clli", "pixi", "irot"].contains(prop.type),
-                  !primaryHasPropertyType(prop.type) else { continue }
-            primaryAssocs.append((try mapPreservedProperty(index), assocIsEssential(value, flags: preservedIPMA.flags)))
-        }
+    if !primaryHasPropertyType("colr"), let sourceBaselineColorAssoc {
+        // Associate the source tile's existing color property with the source
+        // grid. This adds the ISO-required base color declaration without
+        // importing a newly normalized ImageIO profile.
+        primaryAssocs.append(sourceBaselineColorAssoc)
+    }
+    if !primaryHasPropertyType("irot") {
+        let irotOutputIndex = sourceProps.count + propertyIndexMap.count + 1
+        propertyIndexMap[-2] = irotOutputIndex
+        ipcoPayload.append(isoIrotBox)
+        primaryAssocs.append((irotOutputIndex, true))
     }
 
     var ipmaEntries = Data()
@@ -3462,8 +4139,9 @@ private func writeHybridPrimaryPassthrough(
     }
     rawInfes.append(makeInfeBox(itemID: outputGainGridID, type: "grid", flags: preservedItemsByID[preservedGainGridID]?.flags ?? 1))
     rawInfes.append(makeInfeBox(itemID: outputTmapID, type: "tmap", flags: preservedItemsByID[preservedTmapID]?.flags ?? 0))
-    if let outputXMPID, let preservedXMPID {
-        rawInfes.append(makeMimeInfeBox(itemID: outputXMPID, flags: preservedItemsByID[preservedXMPID]?.flags ?? 1))
+    if let outputXMPID {
+        let flags = preservedXMPID.flatMap { preservedItemsByID[$0]?.flags } ?? 1
+        rawInfes.append(makeMimeInfeBox(itemID: outputXMPID, flags: flags))
     }
 
     let sourceIDATPayload = sourceIDAT.map { source.subdata(in: $0.dataStart..<$0.dataEnd) } ?? Data()
@@ -3477,21 +4155,42 @@ private func writeHybridPrimaryPassthrough(
         appendedIDATPayload.append(xmpPayload)
     }
 
-    let sourceRefs = sourceRefsInfo.refs.filter { ref in
-        !dropSourceIDs.contains(ref.from) && dropSourceIDs.isDisjoint(with: Set(ref.to))
-    }
     var outputRefs: [ISOBMFFIRefEntry] = []
     var updatedSourceCdsc = false
-    for ref in sourceRefs {
-        if ref.type == "cdsc", ref.to.contains(sourcePrimaryID) {
-            outputRefs.append(ISOBMFFIRefEntry(type: ref.type, from: ref.from, to: [sourcePrimaryID, outputTmapID]))
+    for ref in sourceRefsInfo.refs where !dropSourceIDs.contains(ref.from) {
+        var replacedTmapTarget = false
+        var rewrittenTargets: [Int] = []
+        for target in ref.to {
+            let rewritten: Int?
+            if sourceTmapIDs.contains(target) {
+                rewritten = outputTmapID
+                replacedTmapTarget = true
+            } else if sourceGainRootIDs.contains(target) {
+                rewritten = outputGainGridID
+            } else if dropSourceIDs.contains(target) {
+                rewritten = nil
+            } else {
+                rewritten = target
+            }
+            if let rewritten, !rewrittenTargets.contains(rewritten) {
+                rewrittenTargets.append(rewritten)
+            }
+        }
+        guard !rewrittenTargets.isEmpty else { continue }
+        if ref.type == "cdsc",
+           ref.from == sourceExifID,
+           rewrittenTargets.contains(sourcePrimaryID),
+           !rewrittenTargets.contains(outputTmapID) {
+            rewrittenTargets.append(outputTmapID)
             updatedSourceCdsc = true
-        } else {
-            outputRefs.append(ref)
+        }
+        outputRefs.append(ISOBMFFIRefEntry(type: ref.type, from: ref.from, to: rewrittenTargets))
+        if ref.type == "cdsc", replacedTmapTarget {
+            updatedSourceCdsc = true
         }
     }
     if !updatedSourceCdsc,
-       let exifID = keptSourceItems.first(where: { $0.type == "Exif" })?.itemID {
+       let exifID = sourceExifID {
         outputRefs.append(ISOBMFFIRefEntry(type: "cdsc", from: exifID, to: [sourcePrimaryID, outputTmapID]))
     }
     outputRefs.append(ISOBMFFIRefEntry(type: "dimg", from: outputGainGridID, to: gainTilePayloads.map(\.newID)))
@@ -3517,6 +4216,14 @@ private func writeHybridPrimaryPassthrough(
     placeholderIlocEntries.append(ISOBMFFILocEntry(itemID: outputTmapID, constructionMethod: 1, dataReferenceIndex: 0, extents: [(tmapIDATOffset, tmapPayload.count)]))
     if let outputXMPID, let xmpPayload {
         placeholderIlocEntries.append(ISOBMFFILocEntry(itemID: outputXMPID, constructionMethod: 1, dataReferenceIndex: 0, extents: [(xmpIDATOffset, xmpPayload.count)]))
+    }
+
+    var preservedGroupPayload = Data()
+    var sourceGroupIDs: [Int] = []
+    for groupBox in sourceMetaChildren where groupBox.type == "grpl" {
+        let preserved = preservedEntityGroupChildren(in: source, grpl: groupBox, dropping: dropSourceIDs)
+        preservedGroupPayload.append(preserved.payload)
+        sourceGroupIDs.append(contentsOf: preserved.groupIDs)
     }
 
     var metaParts: [Data] = []
@@ -3551,8 +4258,9 @@ private func writeHybridPrimaryPassthrough(
     if sourceIDAT == nil {
         metaParts.append(makeBox("idat", payload: appendedIDATPayload))
     }
-    let groupID = max(nextItemID, outputTmapID) + 1
-    metaParts.append(makeGrplAltrBox(groupID: groupID, tmapID: outputTmapID, primaryID: sourcePrimaryID))
+    let groupID = max(max(nextItemID, outputTmapID), sourceGroupIDs.max() ?? 0) + 1
+    preservedGroupPayload.append(makeAltrEntityGroupBox(groupID: groupID, tmapID: outputTmapID, primaryID: sourcePrimaryID))
+    metaParts.append(makeBox("grpl", payload: preservedGroupPayload))
 
     var ftypPayload = source.subdata(in: sourceFtyp.dataStart..<sourceFtyp.dataEnd)
     var existingBrands = Set(stride(from: sourceFtyp.dataStart + 8, to: sourceFtyp.dataEnd, by: 4).compactMap { pos -> String? in
@@ -3695,6 +4403,25 @@ private func writePrivateJPEGPassthroughOutput(
     let oldIDATSize = idat.size - 8
     let tmapPayload = tmapPayload ?? makeAppleTmapPayload(infoFloats: infoFloats)
     let xmpPayload = makeHdrgmXMP(infoFloats: infoFloats)
+    var sourceMdatPayload = src.subdata(in: mdat.dataStart..<mdat.dataEnd)
+    let userCommentPatch: OppoUserCommentPatch?
+    if let patchedUserComment {
+        guard let exifID = iinfData.entries.first(where: { $0.value == "Exif" })?.key,
+              let exifEntry = ilocEntries.first(where: { $0.itemID == exifID }) else {
+            throw XDRemuxError.invalidContainer("unable to locate source Exif item for OPPO UserComment patch")
+        }
+        guard let patch = applyOppoUserCommentPatch(
+            &sourceMdatPayload,
+            mdatDataStart: mdat.dataStart,
+            exifEntry: exifEntry,
+            patchedUserComment: patchedUserComment
+        ) else {
+            throw XDRemuxError.invalidContainer("unable to patch OPPO UserComment in UHDR pass-through output")
+        }
+        userCommentPatch = patch
+    } else {
+        userCommentPatch = nil
+    }
 
     var metaParts: [Data] = []
     for part in metaChildren {
@@ -3832,7 +4559,7 @@ private func writePrivateJPEGPassthroughOutput(
     let betweenMetaAndMdat = src.subdata(in: meta.boxStart + meta.size..<mdat.boxStart)
     let newMdatDataStart = ftypPart.count + metaPart.count + betweenMetaAndMdat.count + 8
     let fileDelta = newMdatDataStart - mdat.dataStart
-    let gainMapOffset = newMdatDataStart + (mdat.dataEnd - mdat.dataStart)
+    let gainMapOffset = newMdatDataStart + sourceMdatPayload.count
 
     var ilocPayload = Data([1, 0, 0, 0, 0x44, 0x00])
     appendUInt16BE(ilocEntries.count + 3, to: &ilocPayload)
@@ -3842,8 +4569,16 @@ private func writePrivateJPEGPassthroughOutput(
         appendUInt16BE(entry.dataReferenceIndex, to: &ilocPayload)
         appendUInt16BE(entry.extents.count, to: &ilocPayload)
         for extent in entry.extents {
-            appendUInt32BE(entry.constructionMethod == 0 ? extent.offset + fileDelta : extent.offset, to: &ilocPayload)
-            appendUInt32BE(extent.length, to: &ilocPayload)
+            if entry.constructionMethod == 0 {
+                guard let adjusted = adjustedExtentForOppoUserCommentPatch(extent, patch: userCommentPatch) else {
+                    throw XDRemuxError.invalidContainer("OPPO UserComment patch crosses item extent boundary")
+                }
+                appendUInt32BE(adjusted.offset + fileDelta, to: &ilocPayload)
+                appendUInt32BE(adjusted.length, to: &ilocPayload)
+            } else {
+                appendUInt32BE(extent.offset, to: &ilocPayload)
+                appendUInt32BE(extent.length, to: &ilocPayload)
+            }
         }
     }
     appendUInt16BE(gainMapID, to: &ilocPayload); appendUInt16BE(0, to: &ilocPayload); appendUInt16BE(0, to: &ilocPayload); appendUInt16BE(1, to: &ilocPayload)
@@ -3863,7 +4598,7 @@ private func writePrivateJPEGPassthroughOutput(
     for part in finalMetaParts { finalMetaPayload.append(part) }
     let finalMetaPart = makeBox("meta", payload: finalMetaPayload)
 
-    var mdatPayload = src.subdata(in: mdat.dataStart..<mdat.dataEnd)
+    var mdatPayload = sourceMdatPayload
     mdatPayload.append(gainMapJPEG)
     let mdatPart = makeBox("mdat", payload: mdatPayload)
     var out = Data()
@@ -3871,11 +4606,6 @@ private func writePrivateJPEGPassthroughOutput(
     out.append(finalMetaPart)
     out.append(betweenMetaAndMdat)
     out.append(mdatPart)
-    if let patchedUserComment {
-        guard patchOppoUserComment(&out, patchedUserComment: patchedUserComment) else {
-            throw XDRemuxError.invalidContainer("unable to patch OPPO UserComment in UHDR pass-through output")
-        }
-    }
     try out.write(to: outputURL)
     return (primaryID, gainMapID)
 }

--- a/apps/macos/XDRemuxApp/Sources/XDRemuxViewModel.swift
+++ b/apps/macos/XDRemuxApp/Sources/XDRemuxViewModel.swift
@@ -348,7 +348,10 @@ final class XDRemuxViewModel {
         outputURL: URL,
         skipExisting: Bool
     ) throws -> OutputPreparationDisposition {
-        try prepareOutputForConversion(inputURL: inputURL, outputURL: outputURL, skipExisting: skipExisting)
+        var config = ConversionConfig()
+        config.skipExisting = skipExisting
+        config.oppoCameraTail = .off
+        return try prepareOutputForConversion(inputURL: inputURL, outputURL: outputURL, config: config)
     }
 
     nonisolated static func makeThumbnailPNGDataForTesting(for url: URL, maxPixelSize: Int) throws -> Data {
@@ -542,13 +545,13 @@ final class XDRemuxViewModel {
             }
 
             do {
-                if config.skipExisting, XDRemuxCore.isValidISOGainMapOutput(item.outputURL) {
+                if config.skipExisting, XDRemuxCore.isValidOutput(item.outputURL, config: config) {
                     return QueueWorkResult(id: item.id, status: .skippedExisting, errorMessage: nil, finishedAt: Date())
                 }
                 let disposition = try prepareOutputForConversion(
                     inputURL: item.inputURL,
                     outputURL: item.outputURL,
-                    skipExisting: config.skipExisting
+                    config: config
                 )
                 if disposition == .skippedExistingValidOutput {
                     return QueueWorkResult(id: item.id, status: .skippedExisting, errorMessage: nil, finishedAt: Date())
@@ -626,7 +629,7 @@ final class XDRemuxViewModel {
             return .ready
         }
 
-        if config.skipExisting, XDRemuxCore.isValidISOGainMapOutput(outputURL) {
+        if config.skipExisting, XDRemuxCore.isValidOutput(outputURL, config: config) {
             return .skipsExistingValidOutput
         }
         return .willOverwriteExisting
@@ -648,7 +651,7 @@ final class XDRemuxViewModel {
     nonisolated private static func prepareOutputForConversion(
         inputURL: URL,
         outputURL: URL,
-        skipExisting: Bool
+        config: ConversionConfig
     ) throws -> OutputPreparationDisposition {
         let fileManager = FileManager.default
         guard pathKey(inputURL) != pathKey(outputURL) else {
@@ -657,7 +660,7 @@ final class XDRemuxViewModel {
         guard fileManager.fileExists(atPath: outputURL.path) else {
             return .ready
         }
-        if skipExisting, XDRemuxCore.isValidISOGainMapOutput(outputURL) {
+        if config.skipExisting, XDRemuxCore.isValidOutput(outputURL, config: config) {
             return .skippedExistingValidOutput
         }
         try fileManager.removeItem(at: outputURL)

--- a/apps/macos/XDRemuxApp/Tests/XDRemuxAppConversionSmoke.swift
+++ b/apps/macos/XDRemuxApp/Tests/XDRemuxAppConversionSmoke.swift
@@ -7,7 +7,7 @@ enum ConversionSmokeError: Error, CustomStringConvertible {
     var description: String {
         switch self {
         case .usage:
-            return "Usage: XDRemuxAppConversionSmoke <input.heic> <output.heic> [--input-processing system|hybrid|passthrough] [--oppo-compat]"
+            return "Usage: XDRemuxAppConversionSmoke <input.heic> <output.heic> [--input-processing system|system-decoded|hybrid|passthrough] [--tmap-format strict|imageio] [--oppo-compat] [--oppo-compat-mode auto|iso|iso-no-local|iso-graph|on|tail|off] [--oppo-camera-tail preserve|preserve-without-portrait|preserve-without-private-uhdr|preserve-without-private-hdr|preserve-no-uhdr|preserve-no-hdr|watermark|compact|off]"
         case .invalidBranch(let value):
             return "invalid input processing branch: \(value)"
         }
@@ -41,6 +41,30 @@ struct XDRemuxAppConversionSmoke {
                 config.inputProcessingBranch = branch
             case "--oppo-compat":
                 config.oppoCompatibility = .on
+            case "--tmap-format":
+                guard index < args.count else { throw ConversionSmokeError.usage }
+                let value = args[index]
+                index += 1
+                guard let format = TmapFormat(rawValue: value) else {
+                    throw ConversionSmokeError.usage
+                }
+                config.tmapFormat = format
+            case "--oppo-compat-mode":
+                guard index < args.count else { throw ConversionSmokeError.usage }
+                let value = args[index]
+                index += 1
+                guard let mode = OppoCompatibility(rawValue: value) else {
+                    throw ConversionSmokeError.usage
+                }
+                config.oppoCompatibility = mode
+            case "--oppo-camera-tail":
+                guard index < args.count else { throw ConversionSmokeError.usage }
+                let value = args[index]
+                index += 1
+                guard let mode = OppoCameraTail(rawValue: value) else {
+                    throw ConversionSmokeError.usage
+                }
+                config.oppoCameraTail = mode
             default:
                 throw ConversionSmokeError.usage
             }

--- a/apps/macos/XDRemuxApp/Tests/XDRemuxAppModelTests.swift
+++ b/apps/macos/XDRemuxApp/Tests/XDRemuxAppModelTests.swift
@@ -47,6 +47,8 @@ struct XDRemuxAppModelTests {
         try testClearCompletedAndRetryFailedKeepQueuePredictable()
         try testThumbnailResultOnlyAppliesToExistingMatchingQueueItem()
         try testUserFacingCopyUsesClearConversionTerms()
+        try testProductPolicyDefaults()
+        try testSimplifiedProductSwitches()
         print("XDRemuxAppModelTests passed")
     }
 
@@ -183,7 +185,7 @@ struct XDRemuxAppModelTests {
 
     @MainActor
     private static func testThumbnailRendererProducesBoundedPNGData() throws {
-        let icon = URL(fileURLWithPath: "xdremux/swift/XDRemuxApp/Assets.xcassets/AppIcon.appiconset/icon_32x32.png")
+        let icon = URL(fileURLWithPath: "apps/macos/XDRemuxApp/Assets.xcassets/AppIcon.appiconset/icon_32x32.png")
         let data = try XDRemuxViewModel.makeThumbnailPNGDataForTesting(for: icon, maxPixelSize: 24)
 
         try expect(data.count > 8, "thumbnail renderer should produce image data")
@@ -277,5 +279,36 @@ struct XDRemuxAppModelTests {
         try expect(AppStrings.inputProcessingPassthroughHelp.contains("ISOBMFF box"), "passthrough mode help should explain container rebuilding")
         try expect(AppStrings.outputPlanOverwriteExisting.contains("覆盖"), "overwrite plan copy should make replacement explicit")
         try expect(AppStrings.previewUnavailable.contains("预览"), "thumbnail failure copy should name preview behavior")
+    }
+
+    @MainActor
+    private static func testProductPolicyDefaults() throws {
+        let config = ConversionConfig()
+
+        try expect(config.family == .auto, "product input family should be detected automatically")
+        try expect(config.inputProcessingBranch == .hybrid, "product output should use metadata-preserving remux")
+        try expect(config.tmapFormat == .imageIO, "product output should use the device-validated 142-byte tmap")
+        try expect(config.oppoCompatibility == .auto, "product output should preserve source HDR routing flags")
+        try expect(config.oppoCameraTail == .preserve, "product output should preserve the complete source tail")
+        try expect(config.oppoGalleryCompatibilityEnabled, "OPPO Gallery compatibility should default on")
+        try expect(config.preservesPortraitEditingData, "portrait editing data should default to preserved")
+    }
+
+    @MainActor
+    private static func testSimplifiedProductSwitches() throws {
+        var config = ConversionConfig()
+
+        config.oppoGalleryCompatibilityEnabled = false
+        try expect(config.oppoCompatibility == .off, "disabling compatibility should select Hybrid high-spec encoding")
+        try expect(config.oppoCameraTail == .preserve, "encoding mode must not change metadata preservation")
+
+        config.preservesPortraitEditingData = false
+        try expect(config.oppoCameraTail == .preserveWithoutPortrait, "portrait switch should select the filtered tail")
+        try expect(config.oppoCompatibility == .off, "portrait switch must not change Gain Map encoding")
+
+        config.oppoGalleryCompatibilityEnabled = true
+        config.preservesPortraitEditingData = true
+        try expect(config.oppoCompatibility == .auto, "enabling compatibility should restore automatic OPPO routing")
+        try expect(config.oppoCameraTail == .preserve, "enabling portrait preservation should restore the byte-preserving tail")
     }
 }

--- a/xdremux/python/heif_io.py
+++ b/xdremux/python/heif_io.py
@@ -460,6 +460,11 @@ def write_heic_passthrough(source_path: str, output_path: str,
 
     # mdat content: use ds (data start) to handle extended-size boxes
     src_mdat_content = src[src_mdat_ds:src_mdat_off + src_mdat_sz]
+    # Preserve every byte after mdat as an opaque OPPO metadata envelope.  This
+    # includes QTI/FileExtendedContainer depth, watermark, edit, live-photo,
+    # private HDR fallback, and unknown vendor data.  The ISO graph rewrite must
+    # not infer that unparsed tail bytes are disposable.
+    src_post_mdat = src[src_mdat_off + src_mdat_sz:]
 
     # ── 2. Parse source meta structure ─────────────────────────────
     _, _, meta_body = _fullbox(src, src_meta_ds)
@@ -1068,6 +1073,7 @@ def write_heic_passthrough(source_path: str, output_path: str,
     out += b'mdat'
     out += src_mdat_content
     out += gm_mdat_data
+    out += src_post_mdat
 
     with open(output_path, 'wb') as f:
         f.write(out)

--- a/xdremux/swift-cli/XDRemux.swift
+++ b/xdremux/swift-cli/XDRemux.swift
@@ -111,6 +111,7 @@ private enum Family: String {
 
 private enum InputProcessingBranch: String {
     case system
+    case systemDecoded = "system-decoded"
     case hybrid
     case passthrough
 }
@@ -118,9 +119,12 @@ private enum InputProcessingBranch: String {
 /// Controls OPPO Gallery compatibility behavior.
 /// - `auto`: ISO-only diagnostic path which avoids private OPPO HDR tagflags.
 /// - `on`/`tail`: OPPO activation path with private UHDR tagflags, but no compatibility tail.
-/// - `off`: clean Apple/ImageIO output with GitHub baseline metadata behavior.
+/// - `off`: Apple/ImageIO output without adding OPPO private HDR activation tagflags.
 private enum OppoCompatibility: String {
     case auto
+    case iso
+    case isoNoLocal = "iso-no-local"
+    case isoGraph = "iso-graph"
     case on
     case tail
     case off
@@ -128,8 +132,28 @@ private enum OppoCompatibility: String {
     /// Whether to apply OPPO-oriented tmap metadata preservation.
     var wantsOppoCompat: Bool { self != .off }
 
-    /// Whether to preserve/set OPPO private UHDR routing tagflags.
-    var wantsOppoActivationTagflags: Bool { self == .on || self == .tail }
+}
+
+/// Controls preservation of OPPO Camera FileExtendedContainer entries.
+///
+/// This is intentionally separate from `--oppo-compat`: OPPO HDR compatibility
+/// can remain no-tail, preserve selected metadata, or copy the complete source
+/// tail byte-for-byte after rebuilding the ISO 21496-1 HDR graph.
+private enum OppoCameraTail: String {
+    case off
+    case watermark
+    case compact
+    case preserve
+    case preserveWithoutPortrait = "preserve-without-portrait"
+    case preserveWithoutPrivateUHDR = "preserve-without-private-uhdr"
+    case preserveWithoutPrivateHDR = "preserve-without-private-hdr"
+    case preserveNoUHDR = "preserve-no-uhdr"
+    case preserveNoHDR = "preserve-no-hdr"
+}
+
+private enum TmapFormat: String {
+    case strict
+    case imageIO = "imageio"
 }
 
 private func fourCCString(_ value: UInt32?) -> String {
@@ -151,6 +175,8 @@ private struct ConvertCommand {
     let debugRootURL: URL?
     let oppoCompatibility: OppoCompatibility
     let inputProcessingBranch: InputProcessingBranch
+    let oppoCameraTail: OppoCameraTail
+    let tmapFormat: TmapFormat
 }
 
 private struct BatchCommand {
@@ -161,6 +187,8 @@ private struct BatchCommand {
     let debugRootURL: URL?
     let oppoCompatibility: OppoCompatibility
     let inputProcessingBranch: InputProcessingBranch
+    let oppoCameraTail: OppoCameraTail
+    let tmapFormat: TmapFormat
     let jobs: Int
     /// Nil means auto checkpoint path under output-dir.
     let checkpointURL: URL?
@@ -175,6 +203,7 @@ private struct ManifestEntry {
     let offset: Int
     let length: Int
     let version: Any?
+    let jsonOrder: Int
     let start: Int
     let end: Int
 }
@@ -732,7 +761,7 @@ private enum LHDRExtractor {
     }
 
     private static func locateManifest(in data: Data) throws -> ManifestInfo {
-        let extensionStart = try findExtensionStart(in: data)
+        let detectedExtensionStart = try? findExtensionStart(in: data)
         guard let manifestArray = parseManifest(in: data) else {
             throw CLIError.manifestNotFound
         }
@@ -742,9 +771,21 @@ private enum LHDRExtractor {
             throw CLIError.manifestNotFound
         }
         let jsonEnd = jsonEndBase + 1
+        let markerStart = lastIndex(of: Data([0] + "jxrs".utf8), in: data)
+        let hasValidJXRSFooter: Bool = markerStart.map { marker in
+            guard marker + 9 == data.count else { return false }
+            let footerLength = Int(data[marker + 5])
+                | (Int(data[marker + 6]) << 8)
+                | (Int(data[marker + 7]) << 16)
+                | (Int(data[marker + 8]) << 24)
+            return footerLength == data.count - jsonStart
+        } ?? false
+        guard detectedExtensionStart != nil || hasValidJXRSFooter else {
+            throw CLIError.qtiMarkerNotFound
+        }
 
         var entries: [ManifestEntry] = []
-        for raw in manifestArray {
+        for (jsonOrder, raw) in manifestArray.enumerated() {
             guard let dict = raw as? [String: Any],
                   let offset = dict["offset"] as? NSNumber,
                   let length = dict["length"] as? NSNumber else {
@@ -759,12 +800,16 @@ private enum LHDRExtractor {
                     offset: offsetValue,
                     length: lengthValue,
                     version: dict["version"],
+                    jsonOrder: jsonOrder,
                     start: offsetValue - lengthValue,
                     end: offsetValue
                 )
             )
         }
         entries.sort { $0.start < $1.start }
+        let extensionStart = detectedExtensionStart
+            ?? entries.map { jsonStart - $0.offset }.filter { $0 >= 0 }.min()
+            ?? jsonStart
 
         return ManifestInfo(
             extensionStart: extensionStart,
@@ -1600,7 +1645,8 @@ private enum ISOHDRWriter {
                 outputURL: outputURL,
                 gainMapChannelCount: gainMap.channelCount,
                 inputProcessingBranch: inputProcessingBranch,
-                oppoCompatibility: oppoCompatibility
+                oppoCompatibility: oppoCompatibility,
+                decodePrimaryImage: inputProcessingBranch == .systemDecoded
             )
             try verifyOutput(outputURL, requiredGainMapPixelFormat: requiredPixelFormat(for: inputProcessingBranch, channelCount: gainMap.channelCount))
         }
@@ -1738,7 +1784,8 @@ private enum ISOHDRWriter {
         outputURL: URL,
         gainMapChannelCount: Int,
         inputProcessingBranch: InputProcessingBranch,
-        oppoCompatibility: OppoCompatibility
+        oppoCompatibility: OppoCompatibility,
+        decodePrimaryImage: Bool = false
     ) throws {
         guard let destination = CGImageDestinationCreateWithURL(
             outputURL as CFURL,
@@ -1764,7 +1811,7 @@ private enum ISOHDRWriter {
             kCGImageDestinationMergeMetadata: primaryMetadata
         ]
         
-        if let originalProperties {
+        if let originalProperties, !decodePrimaryImage {
             for (key, value) in originalProperties {
                 imageOptions[key] = value
             }
@@ -1783,7 +1830,31 @@ private enum ISOHDRWriter {
             imageOptions[kCGImagePropertyExifDictionary] = exifDictionary as CFDictionary
         }
 
-        CGImageDestinationAddImageFromSource(destination, source, 0, imageOptions as CFDictionary)
+        if decodePrimaryImage {
+            guard let decodedImage = CGImageSourceCreateImageAtIndex(
+                source,
+                0,
+                [kCGImageSourceShouldCache: false] as CFDictionary
+            ),
+            let context = CGContext(
+                data: nil,
+                width: decodedImage.width,
+                height: decodedImage.height,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ) else {
+                throw CLIError.unableToLoadBaseImage(outputURL)
+            }
+            context.draw(decodedImage, in: CGRect(x: 0, y: 0, width: decodedImage.width, height: decodedImage.height))
+            guard let image8Bit = context.makeImage() else {
+                throw CLIError.unableToLoadBaseImage(outputURL)
+            }
+            CGImageDestinationAddImage(destination, image8Bit, imageOptions as CFDictionary)
+        } else {
+            CGImageDestinationAddImageFromSource(destination, source, 0, imageOptions as CFDictionary)
+        }
         CGImageDestinationAddAuxiliaryDataInfo(destination, kCGImageAuxiliaryDataTypeISOGainMap, auxiliaryDataInfo)
 
         guard CGImageDestinationFinalize(destination) else {
@@ -1895,7 +1966,7 @@ private enum ISOHDRWriter {
 
     private static func requiredPixelFormat(for branch: InputProcessingBranch, channelCount: Int) throws -> UInt32? {
         switch branch {
-        case .system, .hybrid, .passthrough:
+        case .system, .systemDecoded, .hybrid, .passthrough:
             return nil
         }
     }
@@ -1906,7 +1977,7 @@ private enum ISOHDRWriter {
         branch: InputProcessingBranch
     ) throws {
         switch branch {
-        case .system, .hybrid, .passthrough:
+        case .system, .systemDecoded, .hybrid, .passthrough:
             return
         }
     }
@@ -2072,6 +2143,345 @@ private func verifyImageIOISOGainMap(_ outputURL: URL) throws {
     }
 }
 
+private func isoGainMapPixelFormat(at url: URL) -> UInt32? {
+    guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+          let info = CGImageSourceCopyAuxiliaryDataInfoAtIndex(
+              source,
+              0,
+              kCGImageAuxiliaryDataTypeISOGainMap
+          ) as? [CFString: Any],
+          let description = info[kCGImageAuxiliaryDataInfoDataDescription] as? [CFString: Any] else {
+        return nil
+    }
+    if let number = description[kCGImagePropertyPixelFormat] as? NSNumber {
+        return number.uint32Value
+    }
+    if let string = description[kCGImagePropertyPixelFormat] as? String, string.utf8.count == 4 {
+        return pixelFormatFourCC(string)
+    }
+    return nil
+}
+
+private func isSubsampledGainMapPixelFormat(_ pixelFormat: UInt32) -> Bool {
+    pixelFormat == pixelFormatFourCC("420f")
+        || pixelFormat == pixelFormatFourCC("420v")
+        || pixelFormat == pixelFormatFourCC("x420")
+}
+
+private func gainMapEncodingMatchesTarget(at url: URL, compatibility: OppoCompatibility) -> Bool {
+    guard let pixelFormat = isoGainMapPixelFormat(at: url) else { return false }
+    if compatibility.wantsOppoCompat {
+        return isSubsampledGainMapPixelFormat(pixelFormat)
+    }
+    return pixelFormat == pixelFormatFourCC("444f")
+        || pixelFormat == pixelFormatFourCC("L008")
+}
+
+private func pixelFormatFourCC(_ value: String) -> UInt32 {
+    value.utf8.reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+}
+
+private func rejectLossyGainMapPromotion(inputURL: URL, compatibility: OppoCompatibility) throws {
+    guard !compatibility.wantsOppoCompat,
+          let pixelFormat = isoGainMapPixelFormat(at: inputURL),
+          isSubsampledGainMapPixelFormat(pixelFormat) else { return }
+    throw CLIError.invalidContainer(
+        "cannot promote an existing 4:2:0 Gain Map to high-spec 4:4:4 because chroma information has already been discarded"
+    )
+}
+
+private let oppoCameraWatermarkAuxiliaryEntryNames: Set<String> = [
+    "color.space",
+    "gr.effect.info",
+    "master.mode.preset.info",
+    "private.emptyspace"
+]
+
+private let oppoCameraPortraitEditingEntryNames: Set<String> = [
+    "crop.region",
+    "front.depth",
+    "front.depth.config",
+    "front.hair.mask",
+    "front.matter.info",
+    "front.negevimg",
+    "front.segment",
+    "mesh.coord",
+    "mesh.coord.config",
+    "rear.depth",
+    "rear.depth.config",
+    "rear.spotlight",
+    "src.image",
+    "src.image.block"
+]
+
+private let oppoCameraCompactPortraitTailEntryNames: Set<String> =
+    oppoCameraPortraitEditingEntryNames.union(["hdr.transform.data", "src.local.hdr.linear.mask"])
+
+private func shouldPreserveOppoCameraTailEntry(_ name: String, mode: OppoCameraTail) -> Bool {
+    switch mode {
+    case .off:
+        return false
+    case .watermark:
+        return name.hasPrefix("watermark.") || oppoCameraWatermarkAuxiliaryEntryNames.contains(name)
+    case .compact:
+        return shouldPreserveOppoCameraTailEntry(name, mode: .watermark)
+            || oppoCameraCompactPortraitTailEntryNames.contains(name)
+    case .preserveWithoutPortrait:
+        return !oppoCameraPortraitEditingEntryNames.contains(name)
+    case .preserveWithoutPrivateUHDR:
+        return !oppoPrivateUHDRTailEntryNames.contains(name)
+    case .preserveWithoutPrivateHDR:
+        return !isOppoPrivateHDRTailEntry(name)
+    case .preserve, .preserveNoUHDR, .preserveNoHDR:
+        return true
+    }
+}
+
+private let oppoPrivateUHDRTailEntryNames: Set<String> = [
+    "local.uhdr.gainmap.data",
+    "local.uhdr.gainmap.info"
+]
+
+private func isOppoPrivateHDRTailEntry(_ name: String) -> Bool {
+    oppoPrivateUHDRTailEntryNames.contains(name)
+        || name.hasPrefix("hdr.")
+        || name.hasPrefix("local.hdr.")
+        || name.hasPrefix("src.local.hdr.")
+}
+
+private func shouldNeutralizeOppoCameraTailEntry(_ name: String, mode: OppoCameraTail) -> Bool {
+    switch mode {
+    case .preserveNoUHDR:
+        return oppoPrivateUHDRTailEntryNames.contains(name)
+    case .preserveNoHDR:
+        return isOppoPrivateHDRTailEntry(name)
+    case .off, .watermark, .compact, .preserve, .preserveWithoutPortrait, .preserveWithoutPrivateUHDR, .preserveWithoutPrivateHDR:
+        return false
+    }
+}
+
+private func appendCompleteSourceTail(
+    outputURL: URL,
+    sourceData: Data,
+    manifestInfo: ManifestInfo,
+    mode: OppoCameraTail
+) throws {
+    guard let sourceMdat = isobmffBoxes(in: sourceData, start: 0, end: sourceData.count)
+        .first(where: { $0.type == "mdat" }) else {
+        throw CLIError.invalidContainer("source mdat missing while preserving OPPO metadata tail")
+    }
+    let tailStart = sourceMdat.boxStart + sourceMdat.size
+    guard tailStart < sourceData.count else { return }
+    var tail = sourceData.subdata(in: tailStart..<sourceData.count)
+
+    if mode == .preserveNoUHDR || mode == .preserveNoHDR {
+        let jsonStart = manifestInfo.jsonStart - tailStart
+        let jsonEnd = manifestInfo.jsonEnd - tailStart
+        guard jsonStart >= 0, jsonEnd <= tail.count, jsonStart < jsonEnd else {
+            throw CLIError.invalidContainer("OPPO manifest is outside preserved tail")
+        }
+        for entry in manifestInfo.entries where shouldNeutralizeOppoCameraTailEntry(entry.name, mode: mode) {
+            let nameBytes = Data(entry.name.utf8)
+            guard let range = tail.range(of: nameBytes, options: [], in: jsonStart..<jsonEnd),
+                  !range.isEmpty else {
+                throw CLIError.invalidContainer("unable to neutralize OPPO tail entry \(entry.name)")
+            }
+            tail[range.lowerBound] = UInt8(ascii: "x")
+        }
+    }
+
+    if let outputData = try? Data(contentsOf: outputURL, options: [.mappedIfSafe]),
+       outputData.count >= tail.count,
+       outputData.suffix(tail.count) == tail {
+        return
+    }
+
+    let handle = try FileHandle(forWritingTo: outputURL)
+    defer { try? handle.close() }
+    try handle.seekToEnd()
+    try handle.write(contentsOf: tail)
+}
+
+private struct PackedOppoCameraTailEntry {
+    let entry: ManifestEntry
+    let payloadStart: Int
+}
+
+private struct OppoCameraTailManifestRecord: Encodable {
+    let length: Int
+    let name: String
+    let offset: Int
+    let version: Int
+}
+
+private func oppoCameraTailTag(in sourceData: Data) -> Data {
+    guard sourceData.count >= 9,
+          sourceData[sourceData.count - 9] == 0 else {
+        return Data("jxrs".utf8)
+    }
+    let tag = sourceData.subdata(in: sourceData.count - 8..<sourceData.count - 4)
+    guard tag.allSatisfy({ (32...126).contains($0) }) else {
+        return Data("jxrs".utf8)
+    }
+    return tag
+}
+
+private func appendOppoCameraTailIfNeeded(
+    outputURL: URL,
+    sourceData: Data,
+    extracted: ExtractedLHDR,
+    mode: OppoCameraTail
+) throws {
+    guard mode != .off else { return }
+
+    if mode == .preserve || mode == .preserveNoUHDR || mode == .preserveNoHDR {
+        try appendCompleteSourceTail(
+            outputURL: outputURL,
+            sourceData: sourceData,
+            manifestInfo: extracted.manifestInfo,
+            mode: mode
+        )
+        return
+    }
+
+    let selected = extracted.manifestInfo.entries.filter {
+        shouldPreserveOppoCameraTailEntry($0.name, mode: mode)
+    }
+    guard !selected.isEmpty else { return }
+
+    var payload = Data()
+    var packedEntries: [PackedOppoCameraTailEntry] = []
+    let selectedWithSourceStart = selected.map { entry -> (entry: ManifestEntry, sourceStart: Int) in
+        let manifestRelativeStart = extracted.manifestInfo.jsonStart - entry.offset
+        if manifestRelativeStart >= 0,
+           manifestRelativeStart + entry.length <= sourceData.count {
+            return (entry, manifestRelativeStart)
+        }
+        return (entry, extracted.dataBase + entry.start)
+    }
+
+    for (entry, sourceStart) in selectedWithSourceStart.sorted(by: { $0.sourceStart < $1.sourceStart }) {
+        let sourceEnd = sourceStart + entry.length
+        guard sourceStart >= 0, sourceEnd <= sourceData.count else {
+            throw CLIError.invalidContainer("OPPO camera tail entry \(entry.name) is out of bounds")
+        }
+        let payloadStart = payload.count
+        payload.append(sourceData.subdata(in: sourceStart..<sourceEnd))
+        packedEntries.append(PackedOppoCameraTailEntry(entry: entry, payloadStart: payloadStart))
+    }
+
+    let payloadLength = payload.count
+    var packedByName: [String: PackedOppoCameraTailEntry] = [:]
+    for packed in packedEntries {
+        packedByName[packed.entry.name] = packed
+    }
+    let manifestRecords: [OppoCameraTailManifestRecord] = selected
+        .sorted { $0.jsonOrder < $1.jsonOrder }
+        .compactMap { entry in
+            guard let packed = packedByName[entry.name] else { return nil }
+            return OppoCameraTailManifestRecord(
+                length: entry.length,
+                name: entry.name,
+                offset: payloadLength - packed.payloadStart,
+                version: manifestVersion(entry.version)
+            )
+        }
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let manifestJSON = try encoder.encode(manifestRecords)
+    var tail = Data()
+    tail.append(payload)
+    tail.append(manifestJSON)
+    tail.append(0)
+    tail.append(oppoCameraTailTag(in: sourceData))
+    appendUInt32LE(manifestJSON.count + 1 + 4 + 4, to: &tail)
+
+    let handle = try FileHandle(forWritingTo: outputURL)
+    defer { try? handle.close() }
+    try handle.seekToEnd()
+    try handle.write(contentsOf: tail)
+}
+
+private func isValidOutput(
+    _ outputURL: URL,
+    oppoCameraTail: OppoCameraTail,
+    oppoCompatibility: OppoCompatibility
+) -> Bool {
+    guard gainMapEncodingMatchesTarget(at: outputURL, compatibility: oppoCompatibility) else { return false }
+    switch oppoCameraTail {
+    case .off:
+        return true
+    case .watermark, .compact, .preserve, .preserveWithoutPortrait, .preserveWithoutPrivateUHDR, .preserveWithoutPrivateHDR, .preserveNoUHDR, .preserveNoHDR:
+        return hasValidCompactOppoCameraTail(outputURL, mode: oppoCameraTail)
+    }
+}
+
+private func hasValidCompactOppoCameraTail(_ outputURL: URL, mode: OppoCameraTail) -> Bool {
+    guard let data = try? Data(contentsOf: outputURL, options: [.mappedIfSafe]),
+          data.count >= 9 else {
+        return false
+    }
+    let markerStart = data.count - 9
+    let tag = data.subdata(in: markerStart + 1..<markerStart + 5)
+    guard data[markerStart] == 0,
+          tag == Data("jxrs".utf8) || tag == Data("wtmk".utf8),
+          markerStart + 9 == data.count,
+          let jsonStart = lastIndex(of: Data("[{".utf8), in: data),
+          jsonStart < markerStart else {
+        return false
+    }
+
+    let footerOffset = markerStart + 5
+    let footerLength = Int(data[footerOffset])
+        | (Int(data[footerOffset + 1]) << 8)
+        | (Int(data[footerOffset + 2]) << 16)
+        | (Int(data[footerOffset + 3]) << 24)
+    guard footerLength == data.count - jsonStart,
+          let jsonEndBase = firstIndex(of: UInt8(ascii: "]"), in: data, startingAt: jsonStart),
+          jsonEndBase < markerStart else {
+        return false
+    }
+
+    let manifestData = data.subdata(in: jsonStart..<(jsonEndBase + 1))
+    guard let object = try? JSONSerialization.jsonObject(with: manifestData, options: []),
+          let manifest = object as? [[String: Any]] else {
+        return false
+    }
+    let names = manifest.compactMap { $0["name"] as? String }
+    if mode == .preserve {
+        return !names.isEmpty
+    }
+    if mode == .preserveWithoutPortrait {
+        return !names.isEmpty && names.allSatisfy { !oppoCameraPortraitEditingEntryNames.contains($0) }
+    }
+    if mode == .preserveWithoutPrivateUHDR {
+        return !names.isEmpty && names.allSatisfy { !oppoPrivateUHDRTailEntryNames.contains($0) }
+    }
+    if mode == .preserveWithoutPrivateHDR {
+        return !names.isEmpty && names.allSatisfy { !isOppoPrivateHDRTailEntry($0) }
+    }
+    if mode == .preserveNoUHDR {
+        return !names.isEmpty && names.allSatisfy { !oppoPrivateUHDRTailEntryNames.contains($0) }
+    }
+    if mode == .preserveNoHDR {
+        return !names.isEmpty && names.allSatisfy { !shouldNeutralizeOppoCameraTailEntry($0, mode: mode) }
+    }
+    return !names.isEmpty && names.allSatisfy {
+        shouldPreserveOppoCameraTailEntry($0, mode: mode) && !$0.hasPrefix("local.uhdr.")
+    }
+}
+
+private func manifestVersion(_ value: Any?) -> Int {
+    if let number = value as? NSNumber {
+        return number.intValue
+    }
+    if let string = value as? String, let parsed = Int(string) {
+        return parsed
+    }
+    return 1
+}
+
 private enum XDRemuxProductCore {
     private static let fileManager = FileManager.default
 
@@ -2080,8 +2490,10 @@ private enum XDRemuxProductCore {
         outputURL: URL,
         familyPreference: Family,
         debugRootURL: URL?,
-        oppoCompatibility: OppoCompatibility = .off,
-        inputProcessingBranch: InputProcessingBranch = .hybrid
+        oppoCompatibility: OppoCompatibility = .auto,
+        inputProcessingBranch: InputProcessingBranch = .hybrid,
+        oppoCameraTail: OppoCameraTail = .preserve,
+        tmapFormat: TmapFormat = .imageIO
     ) throws -> SampleReport {
         guard fileManager.fileExists(atPath: inputURL.path) else {
             throw CLIError.inputNotFound(inputURL)
@@ -2097,6 +2509,7 @@ private enum XDRemuxProductCore {
             throw CLIError.unableToRead(inputURL)
         }
 
+        try rejectLossyGainMapPromotion(inputURL: inputURL, compatibility: oppoCompatibility)
         let productInput = try prepareProductInput(
             inputURL: inputURL,
             sourceData: sourceData,
@@ -2115,14 +2528,41 @@ private enum XDRemuxProductCore {
             }
         }
 
+        // Complete OPPO preservation requires the source-primary graft path. ImageIO's
+        // direct writer and the experimental passthrough writer may normalize or omit
+        // non-HDR HEIF items before the opaque camera tail is restored.
+        let effectiveInputProcessingBranch: InputProcessingBranch = (
+            oppoCameraTail == .preserve
+                || oppoCameraTail == .preserveWithoutPortrait
+                || oppoCameraTail == .preserveWithoutPrivateUHDR
+                || oppoCameraTail == .preserveWithoutPrivateHDR
+                || tmapFormat == .strict
+        )
+            ? .hybrid
+            : inputProcessingBranch
         try ProductGainMapWriter.write(
             inputURL: inputURL,
             outputURL: actualOutputURL,
             sourceData: sourceData,
             productInput: productInput,
             oppoCompatibility: oppoCompatibility,
-            inputProcessingBranch: inputProcessingBranch
+            inputProcessingBranch: effectiveInputProcessingBranch,
+            strictISO21496: tmapFormat == .strict
         )
+        try restoreOppoUserCommentFromSource(
+            outputURL: actualOutputURL,
+            sourceData: sourceData,
+            compatibility: oppoCompatibility
+        )
+        try appendOppoCameraTailIfNeeded(
+            outputURL: actualOutputURL,
+            sourceData: sourceData,
+            extracted: productInput.extracted,
+            mode: oppoCameraTail
+        )
+        guard gainMapEncodingMatchesTarget(at: actualOutputURL, compatibility: oppoCompatibility) else {
+            throw CLIError.invalidContainer("output Gain Map encoding does not match the selected compatibility target")
+        }
 
         if writesInPlace {
             _ = try fileManager.replaceItemAt(outputURL, withItemAt: actualOutputURL)
@@ -2277,10 +2717,11 @@ private enum ProductGainMapWriter {
         sourceData: Data,
         productInput: XDRemuxProductCore.ProductInput,
         oppoCompatibility: OppoCompatibility,
-        inputProcessingBranch: InputProcessingBranch
+        inputProcessingBranch: InputProcessingBranch,
+        strictISO21496: Bool
     ) throws {
         switch inputProcessingBranch {
-        case .system:
+        case .system, .systemDecoded:
             let writerInput = gainMapWriterInput(
                 productInput: productInput,
                 oppoCompatibility: oppoCompatibility
@@ -2291,7 +2732,7 @@ private enum ProductGainMapWriter {
                 style: writerInput.style,
                 outputURL: outputURL,
                 oppoCompatibility: oppoCompatibility,
-                inputProcessingBranch: .system
+                inputProcessingBranch: inputProcessingBranch
             )
         case .hybrid:
             try HybridGainMapWriter.write(
@@ -2299,7 +2740,8 @@ private enum ProductGainMapWriter {
                 outputURL: outputURL,
                 sourceData: sourceData,
                 productInput: productInput,
-                oppoCompatibility: oppoCompatibility
+                oppoCompatibility: oppoCompatibility,
+                strictISO21496: strictISO21496
             )
         case .passthrough:
             try DirectPassthroughGainMapWriter.write(
@@ -2332,7 +2774,8 @@ private enum HybridGainMapWriter {
         outputURL: URL,
         sourceData: Data,
         productInput: XDRemuxProductCore.ProductInput,
-        oppoCompatibility: OppoCompatibility
+        oppoCompatibility: OppoCompatibility,
+        strictISO21496: Bool
     ) throws {
         try writeImageIOPreservedGainMapPassthrough(
             inputURL: inputURL,
@@ -2340,7 +2783,8 @@ private enum HybridGainMapWriter {
             sourceData: sourceData,
             productInput: productInput,
             oppoCompatibility: oppoCompatibility,
-            temporaryLabel: "hybrid"
+            temporaryLabel: "hybrid",
+            strictISO21496: strictISO21496
         )
     }
 }
@@ -2353,7 +2797,7 @@ private enum DirectPassthroughGainMapWriter {
         productInput: XDRemuxProductCore.ProductInput,
         oppoCompatibility: OppoCompatibility
     ) throws {
-        if oppoCompatibility.wantsOppoCompat {
+        if oppoCompatibility.wantsOppoCompat && productInput.extracted.mode != .uhdr {
             try writeImageIOPreservedGainMapPassthrough(
                 inputURL: inputURL,
                 outputURL: outputURL,
@@ -2396,7 +2840,8 @@ private func writeImageIOPreservedGainMapPassthrough(
     sourceData: Data,
     productInput: XDRemuxProductCore.ProductInput,
     oppoCompatibility: OppoCompatibility,
-    temporaryLabel: String
+    temporaryLabel: String,
+    strictISO21496: Bool = false
 ) throws {
     let parent = outputURL.deletingLastPathComponent()
     let stem = outputURL.deletingPathExtension().lastPathComponent
@@ -2456,7 +2901,9 @@ private func writeImageIOPreservedGainMapPassthrough(
         preservedURL: preservedURL,
         outputURL: outputURL,
         patchedUserComment: patchedUserComment,
-        preserveTmapColor: oppoCompatibility.wantsOppoCompat
+        preserveTmapColor: oppoCompatibility.wantsOppoCompat,
+        strictISO21496Tmap: strictISO21496,
+        fallbackXMPPayload: makeHdrgmXMP(infoFloats: productInput.extracted.metaFloats)
     )
 }
 
@@ -2464,28 +2911,22 @@ struct LHDRToISOHDRCLI {
     private static let fileManager = FileManager.default
     private static let usage = """
     Usage:
-            XDRemux.swift convert --input <file.heic> [--output <out.heic>] [--debug-dir <dir>] [--oppo-compat [auto|on|tail|off]] [--no-oppo-compat] [--input-processing system|hybrid|passthrough]
-            XDRemux.swift batch --input-dir <dir> [--output-dir <dir>] [--glob *.heic] [--jobs <n>] [--checkpoint <file>] [--resume|--no-resume] [--skip-existing|--no-skip-existing] [--debug-dir <dir>] [--oppo-compat [auto|on|tail|off]] [--no-oppo-compat] [--input-processing system|hybrid|passthrough]
+            XDRemux.swift convert --input <file.heic> [--output <out.heic>] [--oppo-compatible|--no-oppo-compat] [--discard-portrait-data] [--debug-dir <dir>]
+            XDRemux.swift batch --input-dir <dir> [--output-dir <dir>] [--glob *.heic] [--jobs <n>] [--oppo-compatible|--no-oppo-compat] [--discard-portrait-data] [--checkpoint <file>] [--resume|--no-resume] [--skip-existing|--no-skip-existing] [--debug-dir <dir>]
 
     Notes:
-      - Input processing defaults to hybrid.
-      - XDRemux neutralizes stale OPPO private HDR UserComment tagflags in converted ISO outputs.
-      - OPPO Gallery compatibility is opt-in for the ImageIO-native 142B tmap + PQ tmap color path.
-        Bare --oppo-compat and --oppo-compat on use the OPPO activation path without appending any private tail.
-        --oppo-compat auto keeps the ISO-only diagnostic path without appending a private tail.
-        --oppo-compat tail is a backwards-compatible alias for the activation path.
+      - Product output always uses the metadata-preserving source-primary remux path.
+      - Default Gain Maps use HEVC Main Still Picture, 4:2:0, 8-bit with ImageIO 142-byte tmap metadata.
+      - --no-oppo-compat selects the metadata-preserving Hybrid 4:4:4/HEVC Range Extensions path.
+      - --oppo-compatible explicitly converts a 4:4:4/RExt Gain Map to the OPPO-compatible 4:2:0 representation.
+      - Existing 4:2:0 Gain Maps cannot be promoted to high-spec 4:4:4 because the discarded chroma is unrecoverable.
+      - Source UserComment routing flags and, by default, the complete OPPO/QTI/FileExtendedContainer tail are preserved.
+      - --discard-portrait-data removes large depth/re-edit resources while retaining watermark, master-mode, HDR, and small metadata.
+      - Only the active Gain Map graph and its required container descriptions may change.
       - Batch defaults: --jobs min(cpu,4), --resume, --skip-existing.
       - A JSONL checkpoint is written under output-dir by default; it is deleted only when the batch finishes with zero failures.
-      - system: ImageIO writes the final HEIC directly (HEVC gain map, compact file size).
-      - hybrid: XDRemux preserves the source primary subtree and grafts the ImageIO-preserved ISO gain map.
-      - passthrough: experimental direct ISOBMFF rewrite that keeps ImageIO ISO gain-map readability.
-      - OPPO compatibility automatically writes LHDR gain maps as RGB-copy because that is the
-        verified OPPO Gallery activation path. Non-OPPO LHDR outputs keep the original grayscale gain map.
       - If --output is omitted, the input file is overwritten in place.
       - If --output-dir is omitted, files are written to the input directory.
-      - Strict ISO validation and ImageIO-native compatibility are separate concerns. ImageIO may produce
-        a 142-byte tmap payload instead of the strict ISO 145-byte three-channel metadata; strict mode
-        will flag this as expected.
     """
 
     static func main() {
@@ -2531,7 +2972,9 @@ struct LHDRToISOHDRCLI {
             familyPreference: cmd.family,
             debugRootURL: cmd.debugRootURL,
             oppoCompatibility: cmd.oppoCompatibility,
-            inputProcessingBranch: cmd.inputProcessingBranch
+            inputProcessingBranch: cmd.inputProcessingBranch,
+            oppoCameraTail: cmd.oppoCameraTail,
+            tmapFormat: cmd.tmapFormat
         )
         print("converted \(report.inputURL.lastPathComponent) -> \(report.outputURL.path)")
     }
@@ -2620,12 +3063,11 @@ struct LHDRToISOHDRCLI {
 
                     func isOutputValid() -> Bool {
                         guard fileManager.fileExists(atPath: item.outputURL.path) else { return false }
-                        do {
-                            try verifyImageIOISOGainMap(item.outputURL)
-                            return true
-                        } catch {
-                            return false
-                        }
+                        return isValidOutput(
+                            item.outputURL,
+                            oppoCameraTail: cmd.oppoCameraTail,
+                            oppoCompatibility: cmd.oppoCompatibility
+                        )
                     }
 
                     // Resume: only treat checkpoint success/skipped as done. Failures always retry.
@@ -2673,7 +3115,9 @@ struct LHDRToISOHDRCLI {
                             familyPreference: cmd.family,
                             debugRootURL: cmd.debugRootURL,
                             oppoCompatibility: cmd.oppoCompatibility,
-                            inputProcessingBranch: cmd.inputProcessingBranch
+                            inputProcessingBranch: cmd.inputProcessingBranch,
+                            oppoCameraTail: cmd.oppoCameraTail,
+                            tmapFormat: cmd.tmapFormat
                         )
                         statsLock.lock(); convertedCount += 1; statsLock.unlock()
                         record(status: .success)
@@ -2915,7 +3359,9 @@ struct LHDRToISOHDRCLI {
             ("family", cmd.family.rawValue),
             ("inputDir", cmd.inputDirURL.standardizedFileURL.path),
             ("inputProcessing", cmd.inputProcessingBranch.rawValue),
+            ("oppoCameraTail", cmd.oppoCameraTail.rawValue),
             ("oppoCompat", cmd.oppoCompatibility.rawValue),
+            ("tmapFormat", cmd.tmapFormat.rawValue),
             ("outputDir", cmd.outputDirURL.standardizedFileURL.path)
         ]
         let stable = entries.sorted(by: { $0.0 < $1.0 }).map { "\($0.0)=\($0.1)" }.joined(separator: "\n")
@@ -2946,8 +3392,10 @@ struct LHDRToISOHDRCLI {
         var outputPath: String?
         var family = Family.auto
         var debugDirPath: String?
-        var oppoCompatibility: OppoCompatibility = .off
+        var oppoCompatibility: OppoCompatibility = .auto
         var inputProcessingBranch = InputProcessingBranch.hybrid
+        var oppoCameraTail = OppoCameraTail.preserve
+        var tmapFormat = TmapFormat.imageIO
 
         var index = 0
         while index < rawArgs.count {
@@ -2981,6 +3429,18 @@ struct LHDRToISOHDRCLI {
                 inputProcessingBranch = parsed
             case "--debug-dir":
                 debugDirPath = try nextValue(for: option)
+            case "--oppo-camera-tail":
+                let value = try nextValue(for: option)
+                guard let parsed = OppoCameraTail(rawValue: value) else {
+                    throw CLIError.invalidValue(option: option, value: value)
+                }
+                oppoCameraTail = parsed
+            case "--tmap-format":
+                let value = try nextValue(for: option)
+                guard let parsed = TmapFormat(rawValue: value) else {
+                    throw CLIError.invalidValue(option: option, value: value)
+                }
+                tmapFormat = parsed
             case "--oppo-compat":
                 // Bare --oppo-compat means "on"; --oppo-compat auto|on|tail|off for explicit mode.
                 if index < rawArgs.count, let parsed = OppoCompatibility(rawValue: rawArgs[index]) {
@@ -2991,6 +3451,10 @@ struct LHDRToISOHDRCLI {
                 }
             case "--no-oppo-compat":
                 oppoCompatibility = .off
+            case "--oppo-compatible":
+                oppoCompatibility = .auto
+            case "--discard-portrait-data":
+                oppoCameraTail = .preserveWithoutPortrait
             default:
                 throw CLIError.unknownOption(option)
             }
@@ -3004,7 +3468,9 @@ struct LHDRToISOHDRCLI {
             family: family,
             debugRootURL: debugDirPath.map { URL(fileURLWithPath: $0) },
             oppoCompatibility: oppoCompatibility,
-            inputProcessingBranch: inputProcessingBranch
+            inputProcessingBranch: inputProcessingBranch,
+            oppoCameraTail: oppoCameraTail,
+            tmapFormat: tmapFormat
         )
     }
 
@@ -3014,8 +3480,10 @@ struct LHDRToISOHDRCLI {
         var family = Family.auto
         var glob = "*.heic"
         var debugDirPath: String?
-        var oppoCompatibility: OppoCompatibility = .off
+        var oppoCompatibility: OppoCompatibility = .auto
         var inputProcessingBranch = InputProcessingBranch.hybrid
+        var oppoCameraTail = OppoCameraTail.preserve
+        var tmapFormat = TmapFormat.imageIO
         var jobs = min(ProcessInfo.processInfo.activeProcessorCount, 4)
         var checkpointPath: String?
         var resume = true
@@ -3071,6 +3539,18 @@ struct LHDRToISOHDRCLI {
                 skipExisting = false
             case "--debug-dir":
                 debugDirPath = try nextValue(for: option)
+            case "--oppo-camera-tail":
+                let value = try nextValue(for: option)
+                guard let parsed = OppoCameraTail(rawValue: value) else {
+                    throw CLIError.invalidValue(option: option, value: value)
+                }
+                oppoCameraTail = parsed
+            case "--tmap-format":
+                let value = try nextValue(for: option)
+                guard let parsed = TmapFormat(rawValue: value) else {
+                    throw CLIError.invalidValue(option: option, value: value)
+                }
+                tmapFormat = parsed
             case "--oppo-compat":
                 if index < rawArgs.count, let parsed = OppoCompatibility(rawValue: rawArgs[index]) {
                     oppoCompatibility = parsed
@@ -3080,6 +3560,10 @@ struct LHDRToISOHDRCLI {
                 }
             case "--no-oppo-compat":
                 oppoCompatibility = .off
+            case "--oppo-compatible":
+                oppoCompatibility = .auto
+            case "--discard-portrait-data":
+                oppoCameraTail = .preserveWithoutPortrait
             default:
                 throw CLIError.unknownOption(option)
             }
@@ -3095,6 +3579,8 @@ struct LHDRToISOHDRCLI {
             debugRootURL: debugDirPath.map { URL(fileURLWithPath: $0) },
             oppoCompatibility: oppoCompatibility,
             inputProcessingBranch: inputProcessingBranch,
+            oppoCameraTail: oppoCameraTail,
+            tmapFormat: tmapFormat,
             jobs: jobs,
             checkpointURL: checkpointPath.map { URL(fileURLWithPath: $0) },
             resume: resume,
@@ -3151,7 +3637,8 @@ struct LHDRToISOHDRCLI {
 }
 
 private let oppoUltraHDRFlag = 0x20000000
-private let oppoPrivateHDRBranchFlags = 0x40000 | 0x200000 | oppoUltraHDRFlag
+private let isoUltraHDRFlag = 0x00200000
+private let localHDRFlag = 0x00040000
 private let oppoTagFlagPrefixes = [
     "ASCIIOplus_",
     "ASCIIoppo_",
@@ -3160,15 +3647,34 @@ private let oppoTagFlagPrefixes = [
     "oppo_"
 ]
 
-/// Extract OPPO tagflags and adjust only the private HDR branch bits.
-///
-/// Converted ISO gain-map HEICs keep OPPO's private UHDR routing flags only on
-/// the explicit OPPO activation path. The activation path no longer appends any
-/// private OPPO tail; the standard ISO gain-map/tmap structure remains the gain
-/// map payload source.
-private func adjustedOppoUserComment(in data: Data, compatibility: OppoCompatibility) -> String? {
-    guard compatibility != .off else { return nil }
+private func targetOppoTagFlags(_ sourceFlags: Int, compatibility: OppoCompatibility) -> Int {
+    switch compatibility {
+    case .auto, .off:
+        return sourceFlags
+    case .on, .tail:
+        return sourceFlags | oppoUltraHDRFlag
+    case .iso:
+        return (sourceFlags & ~oppoUltraHDRFlag) | isoUltraHDRFlag
+    case .isoNoLocal:
+        return (sourceFlags & ~oppoUltraHDRFlag & ~localHDRFlag) | isoUltraHDRFlag
+    case .isoGraph:
+        return sourceFlags & ~oppoUltraHDRFlag & ~isoUltraHDRFlag
+    }
+}
 
+/// Extract OPPO tagflags and adjust only explicit HDR routing bits.
+private func adjustedOppoUserComment(in data: Data, compatibility: OppoCompatibility) -> String? {
+    if let userComment = oppoUserComment(in: data),
+       let source = oppoTagFlags(from: userComment) {
+        let adjustedFlags = targetOppoTagFlags(source.flags, compatibility: compatibility)
+        guard adjustedFlags != source.flags else { return nil }
+        let digits = String(adjustedFlags)
+        return source.prefix
+            + String(repeating: "0", count: max(0, source.digitCount - digits.count))
+            + digits
+    }
+
+    // Fallback for malformed vendor Exif that ImageIO cannot type as a string.
     for prefix in oppoTagFlagPrefixes {
         let prefixData = Data(prefix.utf8)
         var searchRange: Range<Data.Index>? = data.startIndex..<data.endIndex
@@ -3180,14 +3686,12 @@ private func adjustedOppoUserComment(in data: Data, compatibility: OppoCompatibi
             if digitEnd > range.upperBound,
                let flagStr = String(data: data.subdata(in: range.upperBound..<digitEnd), encoding: .utf8),
                let flags = Int(flagStr) {
-                let adjustedFlags: Int
-                if compatibility.wantsOppoActivationTagflags {
-                    adjustedFlags = flags | oppoUltraHDRFlag
-                } else {
-                    adjustedFlags = flags & ~oppoPrivateHDRBranchFlags
-                }
+                let adjustedFlags = targetOppoTagFlags(flags, compatibility: compatibility)
                 guard adjustedFlags != flags else { return nil }
-                return "\(prefix)\(adjustedFlags)"
+                let digits = String(adjustedFlags)
+                return prefix
+                    + String(repeating: "0", count: max(0, digitEnd - range.upperBound - digits.count))
+                    + digits
             }
             searchRange = range.upperBound..<data.endIndex
         }
@@ -3195,31 +3699,62 @@ private func adjustedOppoUserComment(in data: Data, compatibility: OppoCompatibi
     return nil
 }
 
-private func patchOppoUserComment(_ data: inout Data, patchedUserComment: String) -> Bool {
-    for prefix in oppoTagFlagPrefixes {
-        guard patchedUserComment.hasPrefix(prefix) else { continue }
-        let patchedDigits = String(patchedUserComment.dropFirst(prefix.count))
-        let prefixData = Data(prefix.utf8)
-        var searchRange: Range<Data.Index>? = data.startIndex..<data.endIndex
-        while let range = data.range(of: prefixData, options: [], in: searchRange) {
-            var digitEnd = range.upperBound
-            while digitEnd < data.count, (48...57).contains(data[digitEnd]) {
-                digitEnd += 1
-            }
-            let digitCount = digitEnd - range.upperBound
-            guard digitCount > 0, patchedDigits.count <= digitCount else {
-                searchRange = range.upperBound..<data.endIndex
-                continue
-            }
-
-            var replacement = prefixData
-            replacement.append(Data(repeating: UInt8(ascii: "0"), count: digitCount - patchedDigits.count))
-            replacement.append(Data(patchedDigits.utf8))
-            data.replaceSubrange(range.lowerBound..<digitEnd, with: replacement)
-            return true
-        }
+private func restoreOppoUserCommentFromSource(
+    outputURL: URL,
+    sourceData: Data,
+    compatibility: OppoCompatibility
+) throws {
+    guard let sourceUserComment = oppoUserComment(in: sourceData),
+          let sourceTagFlags = oppoTagFlags(from: sourceUserComment) else {
+        return
     }
-    return false
+
+    let targetFlags = targetOppoTagFlags(sourceTagFlags.flags, compatibility: compatibility)
+
+    var data = try Data(contentsOf: outputURL)
+    guard let outputUserComment = oppoUserComment(in: data),
+          let outputTagFlags = oppoTagFlags(from: outputUserComment) else {
+        return
+    }
+
+    guard outputTagFlags.flags != targetFlags else { return }
+
+    let originalBytes = Data(outputUserComment.utf8)
+    let targetDigits = String(targetFlags)
+    guard targetDigits.count <= outputTagFlags.digitCount else {
+        throw CLIError.invalidContainer("unable to preserve source OPPO UserComment without resizing")
+    }
+    let patchedUserComment = outputTagFlags.prefix
+        + String(repeating: "0", count: outputTagFlags.digitCount - targetDigits.count)
+        + targetDigits
+    let patchedBytes = Data(patchedUserComment.utf8)
+    guard originalBytes.count == patchedBytes.count,
+          let range = data.range(of: originalBytes) else {
+        throw CLIError.invalidContainer("unable to patch OPPO UserComment")
+    }
+
+    data.replaceSubrange(range, with: patchedBytes)
+    try data.write(to: outputURL, options: [.atomic])
+}
+
+private func oppoUserComment(in data: Data) -> String? {
+    guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+          let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+          let exif = properties[kCGImagePropertyExifDictionary] as? [CFString: Any],
+          let value = exif[kCGImagePropertyExifUserComment] else {
+        return nil
+    }
+    return value as? String
+}
+
+private func oppoTagFlags(from userComment: String) -> (prefix: String, digitCount: Int, flags: Int)? {
+    for prefix in oppoTagFlagPrefixes {
+        guard userComment.hasPrefix(prefix) else { continue }
+        let digits = String(userComment.dropFirst(prefix.count).prefix { $0.isNumber })
+        guard !digits.isEmpty, let flags = Int(digits) else { return nil }
+        return (prefix, digits.count, flags)
+    }
+    return nil
 }
 
 private struct OppoUserCommentPatch {
@@ -3228,38 +3763,125 @@ private struct OppoUserCommentPatch {
 }
 
 private func applyOppoUserCommentPatch(
-    _ data: inout Data,
-    sourceOffset: Int,
+    _ mdatPayload: inout Data,
+    mdatDataStart: Int,
+    exifEntry: ISOBMFFILocEntry,
     patchedUserComment: String
 ) -> OppoUserCommentPatch? {
-    for prefix in oppoTagFlagPrefixes {
-        guard patchedUserComment.hasPrefix(prefix) else { continue }
-        let patchedDigits = String(patchedUserComment.dropFirst(prefix.count))
-        let prefixData = Data(prefix.utf8)
-        var searchRange: Range<Data.Index>? = data.startIndex..<data.endIndex
-        while let range = data.range(of: prefixData, options: [], in: searchRange) {
-            var digitEnd = range.upperBound
-            while digitEnd < data.count, (48...57).contains(data[digitEnd]) {
-                digitEnd += 1
-            }
-            let digitCount = digitEnd - range.upperBound
-            guard digitCount > 0 else {
-                searchRange = range.upperBound..<data.endIndex
-                continue
-            }
+    guard exifEntry.constructionMethod == 0,
+          exifEntry.extents.count == 1,
+          let extent = exifEntry.extents.first else { return nil }
+    let localStart = extent.offset - mdatDataStart
+    let localEnd = localStart + extent.length
+    guard localStart >= 0, localEnd <= mdatPayload.count else { return nil }
+    var exifPayload = mdatPayload.subdata(in: localStart..<localEnd)
 
-            var replacement = prefixData
-            replacement.append(Data(repeating: UInt8(ascii: "0"), count: max(0, digitCount - patchedDigits.count)))
-            replacement.append(Data(patchedDigits.utf8))
-            let replacedRange = range.lowerBound..<digitEnd
-            data.replaceSubrange(replacedRange, with: replacement)
-            return OppoUserCommentPatch(
-                sourceRange: (sourceOffset + range.lowerBound)..<(sourceOffset + digitEnd),
-                delta: replacement.count - (digitEnd - range.lowerBound)
-            )
+    guard exifPayload.count >= 12 else { return nil }
+    let tiffStart = 4 + readUInt32BEUnchecked(exifPayload, at: 0)
+    guard tiffStart >= 4, tiffStart + 8 <= exifPayload.count else { return nil }
+    let isLittleEndian: Bool
+    if exifPayload[tiffStart] == UInt8(ascii: "I"), exifPayload[tiffStart + 1] == UInt8(ascii: "I") {
+        isLittleEndian = true
+    } else if exifPayload[tiffStart] == UInt8(ascii: "M"), exifPayload[tiffStart + 1] == UInt8(ascii: "M") {
+        isLittleEndian = false
+    } else {
+        return nil
+    }
+
+    func read16(_ offset: Int) -> Int? {
+        guard offset >= 0, offset + 2 <= exifPayload.count else { return nil }
+        if isLittleEndian {
+            return Int(exifPayload[offset]) | (Int(exifPayload[offset + 1]) << 8)
+        }
+        return (Int(exifPayload[offset]) << 8) | Int(exifPayload[offset + 1])
+    }
+    func read32(_ offset: Int) -> Int? {
+        guard offset >= 0, offset + 4 <= exifPayload.count else { return nil }
+        if isLittleEndian {
+            return Int(exifPayload[offset])
+                | (Int(exifPayload[offset + 1]) << 8)
+                | (Int(exifPayload[offset + 2]) << 16)
+                | (Int(exifPayload[offset + 3]) << 24)
+        }
+        return (Int(exifPayload[offset]) << 24)
+            | (Int(exifPayload[offset + 1]) << 16)
+            | (Int(exifPayload[offset + 2]) << 8)
+            | Int(exifPayload[offset + 3])
+    }
+    func write32(_ value: Int, at offset: Int) -> Bool {
+        guard value >= 0, value <= Int(UInt32.max), offset >= 0, offset + 4 <= exifPayload.count else { return false }
+        if isLittleEndian {
+            exifPayload[offset] = UInt8(value & 0xff)
+            exifPayload[offset + 1] = UInt8((value >> 8) & 0xff)
+            exifPayload[offset + 2] = UInt8((value >> 16) & 0xff)
+            exifPayload[offset + 3] = UInt8((value >> 24) & 0xff)
+        } else {
+            exifPayload[offset] = UInt8((value >> 24) & 0xff)
+            exifPayload[offset + 1] = UInt8((value >> 16) & 0xff)
+            exifPayload[offset + 2] = UInt8((value >> 8) & 0xff)
+            exifPayload[offset + 3] = UInt8(value & 0xff)
+        }
+        return true
+    }
+
+    guard read16(tiffStart + 2) == 42,
+          let firstIFDOffset = read32(tiffStart + 4) else { return nil }
+    var pendingIFDs = [firstIFDOffset]
+    var visitedIFDs = Set<Int>()
+    var userCommentEntryOffset: Int?
+    while let relativeIFD = pendingIFDs.popLast(), userCommentEntryOffset == nil {
+        guard visitedIFDs.insert(relativeIFD).inserted else { continue }
+        let ifd = tiffStart + relativeIFD
+        guard let count = read16(ifd), count <= 4096 else { return nil }
+        for index in 0..<count {
+            let entry = ifd + 2 + index * 12
+            guard let tag = read16(entry), entry + 12 <= exifPayload.count else { return nil }
+            if tag == 0x9286 {
+                userCommentEntryOffset = entry
+                break
+            }
+            if tag == 0x8769 || tag == 0x8825,
+               let childOffset = read32(entry + 8) {
+                pendingIFDs.append(childOffset)
+            }
         }
     }
-    return nil
+
+    guard let entry = userCommentEntryOffset,
+          let fieldType = read16(entry + 2), fieldType == 7,
+          let oldCount = read32(entry + 4), oldCount > 0,
+          let oldValueOffset = read32(entry + 8) else { return nil }
+    let oldValueStart = oldCount <= 4 ? entry + 8 : tiffStart + oldValueOffset
+    let oldValueEnd = oldValueStart + oldCount
+    guard oldValueStart >= 0, oldValueEnd <= exifPayload.count else { return nil }
+    var newValue = exifPayload.subdata(in: oldValueStart..<oldValueEnd)
+
+    var sourceCommentRange: Range<Int>?
+    for prefix in oppoTagFlagPrefixes {
+        let prefixData = Data(prefix.utf8)
+        guard let range = newValue.range(of: prefixData) else { continue }
+        var digitEnd = range.upperBound
+        while digitEnd < newValue.count, (48...57).contains(newValue[digitEnd]) {
+            digitEnd += 1
+        }
+        guard digitEnd > range.upperBound else { continue }
+        sourceCommentRange = range.lowerBound..<digitEnd
+        break
+    }
+    guard let sourceCommentRange else { return nil }
+    newValue.replaceSubrange(sourceCommentRange, with: Data(patchedUserComment.utf8))
+
+    while exifPayload.count % 4 != 0 { exifPayload.append(0) }
+    let newValueOffset = exifPayload.count - tiffStart
+    exifPayload.append(newValue)
+    guard write32(newValue.count, at: entry + 4),
+          write32(newValueOffset, at: entry + 8) else { return nil }
+
+    mdatPayload.replaceSubrange(localStart..<localEnd, with: exifPayload)
+    return OppoUserCommentPatch(
+        sourceRange: extent.offset..<(extent.offset + extent.length),
+        delta: exifPayload.count - extent.length
+    )
 }
 
 private func adjustedExtentForOppoUserCommentPatch(
@@ -3347,6 +3969,11 @@ private func appendUInt32BE(_ value: Int, to data: inout Data) {
     data.append(UInt8((value >> 16) & 0xff))
     data.append(UInt8((value >> 8) & 0xff))
     data.append(UInt8(value & 0xff))
+}
+
+private func appendUInt32LE(_ value: Int, to data: inout Data) {
+    var little = UInt32(value).littleEndian
+    withUnsafeBytes(of: &little) { data.append(contentsOf: $0) }
 }
 
 private func appendInt32BE(_ value: Int32, to data: inout Data) {
@@ -3660,14 +4287,45 @@ private func makeIrefFullBox(version: UInt8, refs: [ISOBMFFIRefEntry]) -> Data {
 }
 
 private func makeGrplAltrBox(groupID: Int, tmapID: Int, primaryID: Int) -> Data {
+    makeBox("grpl", payload: makeAltrEntityGroupBox(groupID: groupID, tmapID: tmapID, primaryID: primaryID))
+}
+
+private func makeAltrEntityGroupBox(groupID: Int, tmapID: Int, primaryID: Int) -> Data {
     var altrPayload = Data([0, 0, 0, 0])
     appendUInt32BE(groupID, to: &altrPayload)
     appendUInt32BE(2, to: &altrPayload)
     appendUInt32BE(tmapID, to: &altrPayload)
     appendUInt32BE(primaryID, to: &altrPayload)
-    var grplPayload = Data()
-    grplPayload.append(makeBox("altr", payload: altrPayload))
-    return makeBox("grpl", payload: grplPayload)
+    return makeBox("altr", payload: altrPayload)
+}
+
+private func preservedEntityGroupChildren(
+    in data: Data,
+    grpl: ISOBMFFBox,
+    dropping itemIDs: Set<Int>
+) -> (payload: Data, groupIDs: [Int]) {
+    var payload = Data()
+    var groupIDs: [Int] = []
+    for child in isobmffBoxes(in: data, start: grpl.dataStart, end: grpl.dataEnd) {
+        let raw = data.subdata(in: child.boxStart..<child.boxStart + child.size)
+        guard child.dataEnd - child.dataStart >= 12 else {
+            payload.append(raw)
+            continue
+        }
+        let groupID = readUInt32BEUnchecked(data, at: child.dataStart + 4)
+        let entityCount = readUInt32BEUnchecked(data, at: child.dataStart + 8)
+        groupIDs.append(groupID)
+        var pos = child.dataStart + 12
+        var entities: [Int] = []
+        for _ in 0..<entityCount where pos + 4 <= child.dataEnd {
+            entities.append(readUInt32BEUnchecked(data, at: pos))
+            pos += 4
+        }
+        if itemIDs.isDisjoint(with: entities) {
+            payload.append(raw)
+        }
+    }
+    return (payload, groupIDs)
 }
 
 private func itemPayload(in data: Data, entry: ISOBMFFILocEntry, idat: ISOBMFFBox?) throws -> Data {
@@ -3868,7 +4526,9 @@ private func writeHybridPrimaryPassthrough(
     preservedURL: URL,
     outputURL: URL,
     patchedUserComment: String?,
-    preserveTmapColor: Bool = false
+    preserveTmapColor: Bool = false,
+    strictISO21496Tmap: Bool = false,
+    fallbackXMPPayload: Data? = nil
 ) throws {
     let source = try Data(contentsOf: sourceURL)
     let preserved = try Data(contentsOf: preservedURL)
@@ -3955,23 +4615,34 @@ private func writeHybridPrimaryPassthrough(
         $0.type == "cdsc" && $0.to.contains(preservedTmapID) && preservedItemsByID[$0.from]?.type == "mime"
     }?.from
 
-    let sourceTmapIDs = Set(sourceItemInfo.items.filter { $0.type == "tmap" }.map(\.itemID))
-    var dropSourceIDs = Set(sourceItemInfo.items.filter { $0.type == "jpeg" }.map(\.itemID))
-    dropSourceIDs.formUnion(sourceTmapIDs)
-    var changed = true
-    while changed {
-        changed = false
-        for ref in sourceRefsInfo.refs where dropSourceIDs.contains(ref.from) {
-            for target in ref.to where target != sourcePrimaryID && !dropSourceIDs.contains(target) {
-                dropSourceIDs.insert(target)
-                changed = true
-            }
-        }
-        for ref in sourceRefsInfo.refs where ref.type == "cdsc" && !dropSourceIDs.isDisjoint(with: Set(ref.to)) {
-            if !dropSourceIDs.contains(ref.from) {
-                dropSourceIDs.insert(ref.from)
-                changed = true
-            }
+    let sourceTmapIDs = Set(sourceItemInfo.items.compactMap { item -> Int? in
+        guard item.type == "tmap",
+              sourceRefsInfo.refs.contains(where: {
+                  $0.type == "dimg" && $0.from == item.itemID && $0.to.contains(sourcePrimaryID)
+              }) else { return nil }
+        return item.itemID
+    })
+    let sourceGainRootIDs = Set(sourceRefsInfo.refs
+        .filter { $0.type == "dimg" && sourceTmapIDs.contains($0.from) }
+        .flatMap(\.to)
+        .filter { $0 != sourcePrimaryID })
+    var dropSourceIDs = sourceTmapIDs
+    let generatedHDRGMName = Data("hdrgm-xmp\u{0}".utf8)
+    let sourceGeneratedHDRGMXMPIDs = Set(sourceItemInfo.items.compactMap { item -> Int? in
+        guard item.type == "mime",
+              item.rawInfe.range(of: generatedHDRGMName) != nil,
+              sourceRefsInfo.refs.contains(where: {
+                  $0.type == "cdsc" && $0.from == item.itemID && !Set($0.to).isDisjoint(with: sourceTmapIDs)
+              }) else { return nil }
+        return item.itemID
+    })
+    dropSourceIDs.formUnion(sourceGeneratedHDRGMXMPIDs)
+    var pendingHDRInputs = Array(sourceGainRootIDs)
+    while let itemID = pendingHDRInputs.popLast() {
+        guard itemID != sourcePrimaryID, !dropSourceIDs.contains(itemID) else { continue }
+        dropSourceIDs.insert(itemID)
+        for ref in sourceRefsInfo.refs where ref.type == "dimg" && ref.from == itemID {
+            pendingHDRInputs.append(contentsOf: ref.to.filter { $0 != sourcePrimaryID })
         }
     }
 
@@ -3982,11 +4653,17 @@ private func writeHybridPrimaryPassthrough(
         throw CLIError.invalidContainer("hybrid graft would drop primary item")
     }
     var sourceMdatPayload = source.subdata(in: sourceMdat.dataStart..<sourceMdat.dataEnd)
+    let sourceExifID = keptSourceItems.first(where: { $0.type == "Exif" })?.itemID
     let userCommentPatch: OppoUserCommentPatch?
     if let patchedUserComment {
+        guard let sourceExifID,
+              let sourceExifEntry = keptSourceIlocEntries.first(where: { $0.itemID == sourceExifID }) else {
+            throw CLIError.invalidContainer("unable to locate source Exif item for OPPO UserComment patch")
+        }
         guard let patch = applyOppoUserCommentPatch(
             &sourceMdatPayload,
-            sourceOffset: sourceMdat.dataStart,
+            mdatDataStart: sourceMdat.dataStart,
+            exifEntry: sourceExifEntry,
             patchedUserComment: patchedUserComment
         ) else {
             throw CLIError.invalidContainer("unable to patch OPPO UserComment in hybrid output")
@@ -3997,7 +4674,8 @@ private func writeHybridPrimaryPassthrough(
     }
 
     let maxSourceID = keptSourceItems.map(\.itemID).max() ?? sourcePrimaryID
-    let copiedItemCount = preservedGainTileIDs.count + 2 + (preservedXMPID == nil ? 0 : 1)
+    let hasOutputXMP = preservedXMPID != nil || fallbackXMPPayload != nil
+    let copiedItemCount = preservedGainTileIDs.count + 2 + (hasOutputXMP ? 1 : 0)
     guard maxSourceID + copiedItemCount < 0xffff else {
         throw CLIError.invalidContainer("hybrid graft currently requires 16-bit item IDs")
     }
@@ -4012,7 +4690,7 @@ private func writeHybridPrimaryPassthrough(
     let outputTmapID = nextItemID
     nextItemID += 1
     let outputXMPID: Int?
-    if preservedXMPID != nil {
+    if hasOutputXMP {
         outputXMPID = nextItemID
         nextItemID += 1
     } else {
@@ -4030,7 +4708,17 @@ private func writeHybridPrimaryPassthrough(
         throw CLIError.invalidContainer("preserve gain grid/tmap has no iloc entry")
     }
     let gainGridPayload = try itemPayload(in: preserved, entry: gainGridEntry, idat: preservedIDAT)
-    let tmapPayload = try itemPayload(in: preserved, entry: tmapEntry, idat: preservedIDAT)
+    let preservedTmapPayload = try itemPayload(in: preserved, entry: tmapEntry, idat: preservedIDAT)
+    let tmapPayload: Data
+    if strictISO21496Tmap, preservedTmapPayload.count == 62 || preservedTmapPayload.count == 142 {
+        // ImageIO omits the three reserved GainMapMetadata bytes. Restore them
+        // after the flags byte so one/three-channel ISO payloads are 65/145 B.
+        tmapPayload = preservedTmapPayload.prefix(6)
+            + Data([0x00, 0x00, 0x00])
+            + preservedTmapPayload.dropFirst(6)
+    } else {
+        tmapPayload = preservedTmapPayload
+    }
     let xmpPayload: Data?
     if let preservedXMPID {
         guard let xmpEntry = preservedIlocByID[preservedXMPID] else {
@@ -4038,7 +4726,7 @@ private func writeHybridPrimaryPassthrough(
         }
         xmpPayload = try itemPayload(in: preserved, entry: xmpEntry, idat: preservedIDAT)
     } else {
-        xmpPayload = nil
+        xmpPayload = fallbackXMPPayload
     }
 
     var ipcoPayload = Data()
@@ -4087,14 +4775,17 @@ private func writeHybridPrimaryPassthrough(
     }?.to.first
     let sourceBaselineColorAssoc = sourcePrimaryColorAssoc
         ?? sourceBaselineTileID.flatMap(sourceItemColorAssoc)
-    if let preservedPrimaryEntry = preservedIPMAByID[preservedPrimaryID] {
-        for value in preservedPrimaryEntry.associations {
-            let index = assocPropertyIndex(value, flags: preservedIPMA.flags)
-            guard let prop = preservedPropsByIndex[index],
-                  ["colr", "clli", "pixi", "irot"].contains(prop.type),
-                  !primaryHasPropertyType(prop.type) else { continue }
-            primaryAssocs.append((try mapPreservedProperty(index), assocIsEssential(value, flags: preservedIPMA.flags)))
-        }
+    if !primaryHasPropertyType("colr"), let sourceBaselineColorAssoc {
+        // Associate the source tile's existing color property with the source
+        // grid. This adds the ISO-required base color declaration without
+        // importing a newly normalized ImageIO profile.
+        primaryAssocs.append(sourceBaselineColorAssoc)
+    }
+    if !primaryHasPropertyType("irot") {
+        let irotOutputIndex = sourceProps.count + propertyIndexMap.count + 1
+        propertyIndexMap[-2] = irotOutputIndex
+        ipcoPayload.append(isoIrotBox)
+        primaryAssocs.append((irotOutputIndex, true))
     }
 
     var ipmaEntries = Data()
@@ -4171,8 +4862,9 @@ private func writeHybridPrimaryPassthrough(
     }
     rawInfes.append(makeInfeBox(itemID: outputGainGridID, type: "grid", flags: preservedItemsByID[preservedGainGridID]?.flags ?? 1))
     rawInfes.append(makeInfeBox(itemID: outputTmapID, type: "tmap", flags: preservedItemsByID[preservedTmapID]?.flags ?? 0))
-    if let outputXMPID, let preservedXMPID {
-        rawInfes.append(makeMimeInfeBox(itemID: outputXMPID, flags: preservedItemsByID[preservedXMPID]?.flags ?? 1))
+    if let outputXMPID {
+        let flags = preservedXMPID.flatMap { preservedItemsByID[$0]?.flags } ?? 1
+        rawInfes.append(makeMimeInfeBox(itemID: outputXMPID, flags: flags))
     }
 
     let sourceIDATPayload = sourceIDAT.map { source.subdata(in: $0.dataStart..<$0.dataEnd) } ?? Data()
@@ -4186,21 +4878,42 @@ private func writeHybridPrimaryPassthrough(
         appendedIDATPayload.append(xmpPayload)
     }
 
-    let sourceRefs = sourceRefsInfo.refs.filter { ref in
-        !dropSourceIDs.contains(ref.from) && dropSourceIDs.isDisjoint(with: Set(ref.to))
-    }
     var outputRefs: [ISOBMFFIRefEntry] = []
     var updatedSourceCdsc = false
-    for ref in sourceRefs {
-        if ref.type == "cdsc", ref.to.contains(sourcePrimaryID) {
-            outputRefs.append(ISOBMFFIRefEntry(type: ref.type, from: ref.from, to: [sourcePrimaryID, outputTmapID]))
+    for ref in sourceRefsInfo.refs where !dropSourceIDs.contains(ref.from) {
+        var replacedTmapTarget = false
+        var rewrittenTargets: [Int] = []
+        for target in ref.to {
+            let rewritten: Int?
+            if sourceTmapIDs.contains(target) {
+                rewritten = outputTmapID
+                replacedTmapTarget = true
+            } else if sourceGainRootIDs.contains(target) {
+                rewritten = outputGainGridID
+            } else if dropSourceIDs.contains(target) {
+                rewritten = nil
+            } else {
+                rewritten = target
+            }
+            if let rewritten, !rewrittenTargets.contains(rewritten) {
+                rewrittenTargets.append(rewritten)
+            }
+        }
+        guard !rewrittenTargets.isEmpty else { continue }
+        if ref.type == "cdsc",
+           ref.from == sourceExifID,
+           rewrittenTargets.contains(sourcePrimaryID),
+           !rewrittenTargets.contains(outputTmapID) {
+            rewrittenTargets.append(outputTmapID)
             updatedSourceCdsc = true
-        } else {
-            outputRefs.append(ref)
+        }
+        outputRefs.append(ISOBMFFIRefEntry(type: ref.type, from: ref.from, to: rewrittenTargets))
+        if ref.type == "cdsc", replacedTmapTarget {
+            updatedSourceCdsc = true
         }
     }
     if !updatedSourceCdsc,
-       let exifID = keptSourceItems.first(where: { $0.type == "Exif" })?.itemID {
+       let exifID = sourceExifID {
         outputRefs.append(ISOBMFFIRefEntry(type: "cdsc", from: exifID, to: [sourcePrimaryID, outputTmapID]))
     }
     outputRefs.append(ISOBMFFIRefEntry(type: "dimg", from: outputGainGridID, to: gainTilePayloads.map(\.newID)))
@@ -4226,6 +4939,14 @@ private func writeHybridPrimaryPassthrough(
     placeholderIlocEntries.append(ISOBMFFILocEntry(itemID: outputTmapID, constructionMethod: 1, dataReferenceIndex: 0, extents: [(tmapIDATOffset, tmapPayload.count)]))
     if let outputXMPID, let xmpPayload {
         placeholderIlocEntries.append(ISOBMFFILocEntry(itemID: outputXMPID, constructionMethod: 1, dataReferenceIndex: 0, extents: [(xmpIDATOffset, xmpPayload.count)]))
+    }
+
+    var preservedGroupPayload = Data()
+    var sourceGroupIDs: [Int] = []
+    for groupBox in sourceMetaChildren where groupBox.type == "grpl" {
+        let preserved = preservedEntityGroupChildren(in: source, grpl: groupBox, dropping: dropSourceIDs)
+        preservedGroupPayload.append(preserved.payload)
+        sourceGroupIDs.append(contentsOf: preserved.groupIDs)
     }
 
     var metaParts: [Data] = []
@@ -4260,8 +4981,9 @@ private func writeHybridPrimaryPassthrough(
     if sourceIDAT == nil {
         metaParts.append(makeBox("idat", payload: appendedIDATPayload))
     }
-    let groupID = max(nextItemID, outputTmapID) + 1
-    metaParts.append(makeGrplAltrBox(groupID: groupID, tmapID: outputTmapID, primaryID: sourcePrimaryID))
+    let groupID = max(max(nextItemID, outputTmapID), sourceGroupIDs.max() ?? 0) + 1
+    preservedGroupPayload.append(makeAltrEntityGroupBox(groupID: groupID, tmapID: outputTmapID, primaryID: sourcePrimaryID))
+    metaParts.append(makeBox("grpl", payload: preservedGroupPayload))
 
     var ftypPayload = source.subdata(in: sourceFtyp.dataStart..<sourceFtyp.dataEnd)
     var existingBrands = Set(stride(from: sourceFtyp.dataStart + 8, to: sourceFtyp.dataEnd, by: 4).compactMap { pos -> String? in
@@ -4404,6 +5126,25 @@ private func writePrivateJPEGPassthroughOutput(
     let oldIDATSize = idat.size - 8
     let tmapPayload = tmapPayload ?? makeAppleTmapPayload(infoFloats: infoFloats)
     let xmpPayload = makeHdrgmXMP(infoFloats: infoFloats)
+    var sourceMdatPayload = src.subdata(in: mdat.dataStart..<mdat.dataEnd)
+    let userCommentPatch: OppoUserCommentPatch?
+    if let patchedUserComment {
+        guard let exifID = iinfData.entries.first(where: { $0.value == "Exif" })?.key,
+              let exifEntry = ilocEntries.first(where: { $0.itemID == exifID }) else {
+            throw CLIError.invalidContainer("unable to locate source Exif item for OPPO UserComment patch")
+        }
+        guard let patch = applyOppoUserCommentPatch(
+            &sourceMdatPayload,
+            mdatDataStart: mdat.dataStart,
+            exifEntry: exifEntry,
+            patchedUserComment: patchedUserComment
+        ) else {
+            throw CLIError.invalidContainer("unable to patch OPPO UserComment in UHDR pass-through output")
+        }
+        userCommentPatch = patch
+    } else {
+        userCommentPatch = nil
+    }
 
     var metaParts: [Data] = []
     for part in metaChildren {
@@ -4541,7 +5282,7 @@ private func writePrivateJPEGPassthroughOutput(
     let betweenMetaAndMdat = src.subdata(in: meta.boxStart + meta.size..<mdat.boxStart)
     let newMdatDataStart = ftypPart.count + metaPart.count + betweenMetaAndMdat.count + 8
     let fileDelta = newMdatDataStart - mdat.dataStart
-    let gainMapOffset = newMdatDataStart + (mdat.dataEnd - mdat.dataStart)
+    let gainMapOffset = newMdatDataStart + sourceMdatPayload.count
 
     var ilocPayload = Data([1, 0, 0, 0, 0x44, 0x00])
     appendUInt16BE(ilocEntries.count + 3, to: &ilocPayload)
@@ -4551,8 +5292,16 @@ private func writePrivateJPEGPassthroughOutput(
         appendUInt16BE(entry.dataReferenceIndex, to: &ilocPayload)
         appendUInt16BE(entry.extents.count, to: &ilocPayload)
         for extent in entry.extents {
-            appendUInt32BE(entry.constructionMethod == 0 ? extent.offset + fileDelta : extent.offset, to: &ilocPayload)
-            appendUInt32BE(extent.length, to: &ilocPayload)
+            if entry.constructionMethod == 0 {
+                guard let adjusted = adjustedExtentForOppoUserCommentPatch(extent, patch: userCommentPatch) else {
+                    throw CLIError.invalidContainer("OPPO UserComment patch crosses item extent boundary")
+                }
+                appendUInt32BE(adjusted.offset + fileDelta, to: &ilocPayload)
+                appendUInt32BE(adjusted.length, to: &ilocPayload)
+            } else {
+                appendUInt32BE(extent.offset, to: &ilocPayload)
+                appendUInt32BE(extent.length, to: &ilocPayload)
+            }
         }
     }
     appendUInt16BE(gainMapID, to: &ilocPayload); appendUInt16BE(0, to: &ilocPayload); appendUInt16BE(0, to: &ilocPayload); appendUInt16BE(1, to: &ilocPayload)
@@ -4572,7 +5321,7 @@ private func writePrivateJPEGPassthroughOutput(
     for part in finalMetaParts { finalMetaPayload.append(part) }
     let finalMetaPart = makeBox("meta", payload: finalMetaPayload)
 
-    var mdatPayload = src.subdata(in: mdat.dataStart..<mdat.dataEnd)
+    var mdatPayload = sourceMdatPayload
     mdatPayload.append(gainMapJPEG)
     let mdatPart = makeBox("mdat", payload: mdatPayload)
     var out = Data()
@@ -4580,11 +5329,6 @@ private func writePrivateJPEGPassthroughOutput(
     out.append(finalMetaPart)
     out.append(betweenMetaAndMdat)
     out.append(mdatPart)
-    if let patchedUserComment {
-        guard patchOppoUserComment(&out, patchedUserComment: patchedUserComment) else {
-            throw CLIError.invalidContainer("unable to patch OPPO UserComment in UHDR pass-through output")
-        }
-    }
     try out.write(to: outputURL)
     return (primaryID, gainMapID)
 }


### PR DESCRIPTION
## Summary

- simplify XDRemux to two Gain Map output choices: OPPO-compatible HEVC Main Still Picture 4:2:0 and high-spec HEVC Range Extensions 4:4:4
- keep the metadata-preserving Hybrid remux path for both choices
- preserve the source primary image, Exif, MakerNote, XMP, UserComment routing flags, and complete OPPO/QTI/FileExtendedContainer tail by default
- add an independent option to remove large portrait re-edit payloads while retaining watermark, master-mode, HDR, and small metadata
- reject 4:2:0 to 4:4:4 promotion because discarded chroma cannot be reconstructed
- update the macOS UI, CLI, Python policy plumbing, model tests, and conversion smoke runner

## Why

The previous product surface mixed output encoding choices with internal processing modes. The new policy keeps container preservation as an invariant while exposing only the Gain Map compatibility choice and portrait-data retention choice.

## Validation

- `swiftc -typecheck xdremux/swift-cli/XDRemux.swift`
- Python bytecode compilation for `heif_io.py` and `isobmff_patch.py`
- unsigned macOS Debug build with `xcodebuild`
- `XDRemuxAppModelTests passed`
- App Core conversion smoke passed on a real OPPO portrait HEIC
- real 4:4:4/profile 4 Gain Map converted to 4:2:0/profile 3
- all 54 primary-image tile hashes unchanged
- Exif, MakerNote, XMP, and complete OPPO tail hashes unchanged
- reverse 4:2:0 to 4:4:4 request rejected as expected

## Scope and known limitation

This is a code-only PR. It contains no local research documents and does not include the separate portrait auxiliary-image graft work.

The previously observed 10-bit LHDR standardized path still has an OPPO watermark-editor limitation and is not claimed as fully supported by this PR.