### PR TITLE
Fix Swift CLI ISO verification and add completion gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ xdremux_py/
 .claude/
 .sisyphus/
 .flake8
-AGENTS.md
 CLAUDE.md
 HANDOFF.md
 Makefile
@@ -37,6 +36,7 @@ test-samples/
 tmp-samples/
 tmp/
 tools/
+.codex/verification-receipts/
 
 # Recreatable
 final-output/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# XDRemux Agent Acceptance Contract
+
+## Completion claims are gated
+
+An agent must not say a change is complete, accepted, ready, or fully working
+until the repository completion gate passes for the exact committed `HEAD`.
+Passing an individual compiler, parser, or smoke command is not a substitute
+for the gate.
+
+The required flow is:
+
+1. Identify the affected product paths and their acceptance criteria.
+2. Implement and commit the intended changes without unrelated files.
+3. Create a verification plan using the schema documented in
+   `docs/validation/README.md`.
+4. Run:
+
+   ```bash
+   python3 scripts/agent_completion_gate.py run \
+     --base origin/main \
+     --plan /tmp/xdremux-agent-verification.json
+   ```
+
+5. Confirm the generated receipt independently:
+
+   ```bash
+   python3 scripts/agent_completion_gate.py verify \
+     .codex/verification-receipts/$(git rev-parse HEAD).json
+   ```
+
+The receipt is bound to `HEAD`, the base commit, the changed-file set, and a
+clean tracked worktree. Any later commit or tracked edit invalidates it.
+
+## Required evidence
+
+- Every source change needs a targeted regression check that would fail for
+  the original defect or contract violation.
+- Every production converter or app-core change also needs a real functional,
+  integration, or device check. Type-checking and syntax checks are static
+  checks, not functional checks.
+- The verification plan must cover every affected entry point. If Swift CLI,
+  Python CLI, and macOS app behavior all change, all three need evidence.
+- A device-dependent product claim requires device evidence. If the device or
+  closed component is unavailable, report the task as blocked or explicitly
+  limit the claim to offline behavior; do not mark the device claim complete.
+- Strict ISO parser success alone is not acceptance evidence for OPPO Gallery
+  behavior. Keep structural, ImageIO, renderer, and device gates distinct.
+- All declared checks are mandatory. Do not relabel a static check as a
+  regression or functional check to satisfy the gate.
+
+## Scope
+
+Use targeted verification by default. Full repository verification is needed
+for release/preflight work, cross-module changes, or verification-framework
+changes. The gate enforces evidence completeness; it does not justify running
+unrelated expensive checks.
+
+Large/private media stays outside Git. Verification plans may reference local
+fixtures, but receipts under `.codex/verification-receipts/` remain ignored.

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -10,3 +10,92 @@ Good validation documents should distinguish:
 - Device checks: real-device observations such as HDR badge visibility or EDR brightness changes.
 
 Keep actual test executables under `tests/` or `scripts/`; keep the rationale, acceptance criteria, and runbooks here.
+
+## Agent completion gate
+
+Agents must use `scripts/agent_completion_gate.py` before declaring a committed
+change complete. The gate is deliberately separate from any one build system:
+it executes the checks selected for the actual change and writes a JSON receipt
+bound to the current commit.
+
+Run it only after committing the intended change and returning the tracked
+worktree to a clean state:
+
+```bash
+python3 scripts/agent_completion_gate.py run \
+  --base origin/main \
+  --plan /tmp/xdremux-agent-verification.json
+
+python3 scripts/agent_completion_gate.py verify \
+  .codex/verification-receipts/$(git rev-parse HEAD).json
+```
+
+The verification plan uses this schema:
+
+```json
+{
+  "schema_version": 1,
+  "scope": "Fix default Swift CLI conversion for an existing ISO gain-map input",
+  "checks": [
+    {
+      "name": "swift-cli-typecheck",
+      "kind": "static",
+      "command": ["swiftc", "-typecheck", "xdremux/swift-cli/XDRemux.swift"],
+      "timeout_seconds": 120
+    },
+    {
+      "name": "existing-iso-default-regression",
+      "kind": "regression",
+      "command": [
+        "python3",
+        "tests/validation/verify_swift_cli_sample.py",
+        "--input",
+        "/absolute/path/to/existing-iso-sample.heic",
+        "--expected-pixel-format",
+        "444f"
+      ],
+      "timeout_seconds": 300
+    },
+    {
+      "name": "real-sample-output-matrix",
+      "kind": "functional",
+      "command": [
+        "python3",
+        "tests/validation/verify_swift_cli_sample.py",
+        "--input",
+        "/absolute/path/to/private-uhdr-sample.heic",
+        "--expected-pixel-format",
+        "420f",
+        "--oppo-compatible"
+      ],
+      "timeout_seconds": 900
+    }
+  ]
+}
+```
+
+`command` is an argument array and is executed without implicit shell parsing.
+If shell composition is genuinely required, make it explicit with
+`["/bin/zsh", "-lc", "..."]`. An optional `env` object may provide per-check
+string environment variables.
+
+`tests/validation/verify_swift_cli_sample.py` is the reusable real-sample
+harness for Swift CLI plans. It compiles the production CLI, converts a
+temporary output (or temporary in-place copy), and asks ImageIO to assert the
+expected gain-map pixel format. Private samples remain outside Git.
+
+Kinds are `static`, `regression`, `functional`, `integration`, and `device`.
+All listed checks are mandatory. Source changes require a `regression` check;
+changes under `xdremux/` or the macOS app `Sources/` additionally require a
+`functional`, `integration`, or `device` check. The gate also requires:
+
+- a non-empty diff against the selected base;
+- `git diff --check` success;
+- a clean tracked worktree before and after checks;
+- an unchanged `HEAD` while checks run;
+- zero exit status from every declared check.
+
+Receipts record commands, durations, exit status, bounded output tails, the
+base/head commits, and changed paths. A later commit or tracked edit makes the
+receipt unverifiable. Missing device access is not a pass: either restrict the
+claim to offline behavior or report the device-dependent acceptance as blocked.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,5 +5,6 @@ This directory contains checked-in helper scripts for local development, build, 
 ## Available scripts
 
 - `build_and_run.sh` builds and launches the macOS `XDRemuxApp` Xcode project from `apps/macos/XDRemuxApp`. It supports `run`, `--debug`, `--logs`, `--telemetry`, and `--verify`.
+- `agent_completion_gate.py` executes a committed change's declared checks and writes a HEAD-bound acceptance receipt. Production code changes cannot pass without regression plus functional/integration/device evidence.
 
 Keep reusable automation here. One-off scratch scripts should stay outside the repository or under an explicitly named experiment directory.

--- a/scripts/agent_completion_gate.py
+++ b/scripts/agent_completion_gate.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Run and verify HEAD-bound completion evidence for XDRemux agents."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+CHECK_KINDS = {"static", "regression", "functional", "integration", "device"}
+FUNCTIONAL_KINDS = {"functional", "integration", "device"}
+PRODUCTION_PREFIXES = (
+    "xdremux/",
+    "apps/macos/XDRemuxApp/Sources/",
+)
+SOURCE_SUFFIXES = {".swift", ".py", ".sh", ".c", ".cc", ".cpp", ".h", ".m", ".mm"}
+OUTPUT_TAIL_LIMIT = 16_000
+
+
+class GateConfigurationError(RuntimeError):
+    pass
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def run_process(
+    command: list[str],
+    *,
+    cwd: Path,
+    timeout_seconds: int | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=timeout_seconds,
+        check=False,
+    )
+
+
+def git(repo: Path, *arguments: str, check: bool = True) -> str:
+    result = run_process(["git", *arguments], cwd=repo)
+    if check and result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise GateConfigurationError(f"git {' '.join(arguments)} failed: {detail}")
+    return result.stdout.strip()
+
+
+def repository_root() -> Path:
+    result = run_process(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd())
+    if result.returncode != 0:
+        raise GateConfigurationError("completion gate must run inside a Git repository")
+    return Path(result.stdout.strip()).resolve()
+
+
+def resolve_commit(repo: Path, revision: str) -> str:
+    return git(repo, "rev-parse", "--verify", f"{revision}^{{commit}}")
+
+
+def changed_files(repo: Path, base_commit: str, head_commit: str) -> list[str]:
+    merge_base = git(repo, "merge-base", base_commit, head_commit)
+    output = git(
+        repo,
+        "diff",
+        "--name-only",
+        "--diff-filter=ACMRTUXB",
+        f"{merge_base}...{head_commit}",
+    )
+    return [line for line in output.splitlines() if line]
+
+
+def tracked_status(repo: Path) -> list[str]:
+    output = git(repo, "status", "--porcelain=v1", "--untracked-files=no")
+    return [line for line in output.splitlines() if line]
+
+
+def load_plan(path: Path) -> dict[str, Any]:
+    try:
+        plan = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise GateConfigurationError(f"cannot read verification plan {path}: {error}") from error
+    if not isinstance(plan, dict):
+        raise GateConfigurationError("verification plan must be a JSON object")
+    if plan.get("schema_version") != SCHEMA_VERSION:
+        raise GateConfigurationError(f"verification plan schema_version must be {SCHEMA_VERSION}")
+    if not isinstance(plan.get("scope"), str) or not plan["scope"].strip():
+        raise GateConfigurationError("verification plan requires a non-empty scope")
+    checks = plan.get("checks")
+    if not isinstance(checks, list) or not checks:
+        raise GateConfigurationError("verification plan requires at least one check")
+
+    names: set[str] = set()
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            raise GateConfigurationError(f"check {index} must be a JSON object")
+        name = check.get("name")
+        kind = check.get("kind")
+        command = check.get("command")
+        timeout_seconds = check.get("timeout_seconds", 300)
+        if not isinstance(name, str) or not name.strip():
+            raise GateConfigurationError(f"check {index} requires a non-empty name")
+        if name in names:
+            raise GateConfigurationError(f"duplicate check name: {name}")
+        names.add(name)
+        if kind not in CHECK_KINDS:
+            raise GateConfigurationError(f"check {name} has unsupported kind: {kind}")
+        if (
+            not isinstance(command, list)
+            or not command
+            or not all(isinstance(value, str) and value for value in command)
+        ):
+            raise GateConfigurationError(f"check {name} command must be a non-empty string array")
+        if not isinstance(timeout_seconds, int) or not 1 <= timeout_seconds <= 3600:
+            raise GateConfigurationError(f"check {name} timeout_seconds must be between 1 and 3600")
+        check_env = check.get("env", {})
+        if not isinstance(check_env, dict) or not all(
+            isinstance(key, str) and isinstance(value, str) for key, value in check_env.items()
+        ):
+            raise GateConfigurationError(f"check {name} env must be a string-to-string object")
+    return plan
+
+
+def enforce_evidence_policy(plan: dict[str, Any], files: list[str]) -> dict[str, bool]:
+    kinds = {check["kind"] for check in plan["checks"]}
+    production_changed = any(path.startswith(PRODUCTION_PREFIXES) for path in files)
+    source_changed = any(Path(path).suffix in SOURCE_SUFFIXES for path in files)
+    if source_changed and "regression" not in kinds:
+        raise GateConfigurationError("source changes require at least one regression check")
+    if production_changed and not kinds.intersection(FUNCTIONAL_KINDS):
+        raise GateConfigurationError(
+            "production changes require at least one functional, integration, or device check"
+        )
+    return {
+        "production_changed": production_changed,
+        "source_changed": source_changed,
+    }
+
+
+def output_tail(value: str) -> str:
+    return value[-OUTPUT_TAIL_LIMIT:]
+
+
+def execute_check(repo: Path, check: dict[str, Any]) -> dict[str, Any]:
+    started_at = utc_now()
+    started = time.monotonic()
+    environment = os.environ.copy()
+    environment["AGENT_COMPLETION_GATE"] = "1"
+    environment.update(check.get("env", {}))
+    timed_out = False
+    try:
+        result = run_process(
+            check["command"],
+            cwd=repo,
+            timeout_seconds=check.get("timeout_seconds", 300),
+            env=environment,
+        )
+        return_code = result.returncode
+        stdout = result.stdout
+        stderr = result.stderr
+    except subprocess.TimeoutExpired as error:
+        timed_out = True
+        return_code = 124
+        stdout = error.stdout or ""
+        stderr = error.stderr or ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode(errors="replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode(errors="replace")
+    except OSError as error:
+        return_code = 127
+        stdout = ""
+        stderr = str(error)
+    return {
+        "name": check["name"],
+        "kind": check["kind"],
+        "command": check["command"],
+        "started_at": started_at,
+        "finished_at": utc_now(),
+        "duration_seconds": round(time.monotonic() - started, 3),
+        "timeout_seconds": check.get("timeout_seconds", 300),
+        "timed_out": timed_out,
+        "return_code": return_code,
+        "passed": return_code == 0 and not timed_out,
+        "stdout_tail": output_tail(stdout),
+        "stderr_tail": output_tail(stderr),
+    }
+
+
+def default_receipt_path(repo: Path, head_commit: str) -> Path:
+    return repo / ".codex" / "verification-receipts" / f"{head_commit}.json"
+
+
+def write_receipt(path: Path, receipt: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def run_gate(arguments: argparse.Namespace) -> int:
+    repo = repository_root()
+    plan = load_plan(arguments.plan.resolve())
+    base_commit = resolve_commit(repo, arguments.base)
+    head_commit = resolve_commit(repo, "HEAD")
+    files = changed_files(repo, base_commit, head_commit)
+    if not files:
+        raise GateConfigurationError("HEAD has no changes relative to the selected base")
+    policy = enforce_evidence_policy(plan, files)
+    initial_status = tracked_status(repo)
+    diff_check = run_process(["git", "diff", "--check", f"{base_commit}...{head_commit}"], cwd=repo)
+
+    results = [execute_check(repo, check) for check in plan["checks"]]
+    final_head = resolve_commit(repo, "HEAD")
+    final_status = tracked_status(repo)
+    builtins = {
+        "initial_tracked_tree_clean": not initial_status,
+        "diff_check_passed": diff_check.returncode == 0,
+        "head_unchanged": final_head == head_commit,
+        "final_tracked_tree_clean": not final_status,
+    }
+    passed = all(builtins.values()) and all(result["passed"] for result in results)
+    receipt = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": utc_now(),
+        "passed": passed,
+        "scope": plan["scope"],
+        "repository": str(repo),
+        "base_revision": arguments.base,
+        "base_commit": base_commit,
+        "head_commit": head_commit,
+        "changed_files": files,
+        "policy": policy,
+        "builtins": builtins,
+        "initial_tracked_status": initial_status,
+        "final_tracked_status": final_status,
+        "diff_check_output": output_tail(diff_check.stdout + diff_check.stderr),
+        "checks": results,
+    }
+    receipt_path = arguments.receipt.resolve() if arguments.receipt else default_receipt_path(repo, head_commit)
+    write_receipt(receipt_path, receipt)
+
+    for result in results:
+        state = "PASS" if result["passed"] else "FAIL"
+        print(f"{state} [{result['kind']}] {result['name']} ({result['duration_seconds']:.3f}s)")
+    state = "PASS" if passed else "FAIL"
+    print(f"{state} completion gate for {head_commit}")
+    print(f"receipt: {receipt_path}")
+    return 0 if passed else 1
+
+
+def verify_receipt(arguments: argparse.Namespace) -> int:
+    repo = repository_root()
+    try:
+        receipt = json.loads(arguments.receipt.resolve().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise GateConfigurationError(f"cannot read receipt {arguments.receipt}: {error}") from error
+    current_head = resolve_commit(repo, "HEAD")
+    expected_files = changed_files(repo, receipt.get("base_commit", ""), current_head)
+    checks = receipt.get("checks", [])
+    builtins = receipt.get("builtins", {})
+    required_builtins = {
+        "initial_tracked_tree_clean",
+        "diff_check_passed",
+        "head_unchanged",
+        "final_tracked_tree_clean",
+    }
+    valid = (
+        receipt.get("schema_version") == SCHEMA_VERSION
+        and receipt.get("passed") is True
+        and receipt.get("head_commit") == current_head
+        and receipt.get("changed_files") == expected_files
+        and not tracked_status(repo)
+        and isinstance(checks, list)
+        and bool(checks)
+        and all(check.get("passed") is True for check in checks)
+        and isinstance(builtins, dict)
+        and set(builtins) == required_builtins
+        and all(value is True for value in builtins.values())
+    )
+    if not valid:
+        print("FAIL receipt is stale, incomplete, failed, or does not match the current clean HEAD")
+        return 1
+    print(f"PASS verified completion receipt for {current_head}")
+    return 0
+
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    run_parser = subparsers.add_parser("run", help="execute a verification plan and write a receipt")
+    run_parser.add_argument("--base", required=True, help="base revision for the completed change")
+    run_parser.add_argument("--plan", required=True, type=Path, help="verification-plan JSON")
+    run_parser.add_argument("--receipt", type=Path, help="override the default HEAD-bound receipt path")
+    run_parser.set_defaults(handler=run_gate)
+
+    verify_parser = subparsers.add_parser("verify", help="verify a receipt against the current HEAD")
+    verify_parser.add_argument("receipt", type=Path)
+    verify_parser.set_defaults(handler=verify_receipt)
+    return parser
+
+
+def main() -> int:
+    parser = make_parser()
+    arguments = parser.parse_args()
+    try:
+        return arguments.handler(arguments)
+    except GateConfigurationError as error:
+        print(f"configuration error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,4 +10,13 @@ Recommended split:
 - `tests/golden/` for expected metadata snapshots, hashes, or text outputs.
 - `tests/validation/` for scripts that inspect output files without requiring a graphical app.
 
+`tests/validation/test_agent_completion_gate.py` verifies that the agent
+completion gate rejects missing evidence and failed commands, accepts complete
+plans, and invalidates receipts after `HEAD` changes.
+
+`tests/validation/verify_swift_cli_sample.py` is a parameterized real-sample
+functional check for Swift CLI completion plans. It keeps private HEIC inputs
+outside Git while verifying conversion success and the ImageIO gain-map pixel
+format.
+
 macOS app-specific UI and ViewModel tests can remain under `apps/macos/XDRemuxApp/Tests/`. Converter correctness tests should live here so they are not coupled to the app project layout.

--- a/tests/validation/test_agent_completion_gate.py
+++ b/tests/validation/test_agent_completion_gate.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Regression tests for scripts/agent_completion_gate.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+GATE = REPOSITORY_ROOT / "scripts" / "agent_completion_gate.py"
+
+
+class CompletionGateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temporary.name)
+        self.git("init", "-q")
+        self.git("config", "user.name", "Completion Gate Test")
+        self.git("config", "user.email", "gate@example.invalid")
+        (self.repo / "README.md").write_text("base\n", encoding="utf-8")
+        self.commit_all("base")
+        self.base = self.git("rev-parse", "HEAD").stdout.strip()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def git(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *arguments],
+            cwd=self.repo,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+    def commit_all(self, message: str) -> None:
+        self.git("add", "--all")
+        self.git("commit", "-q", "-m", message)
+
+    def write_plan(self, checks: list[dict[str, object]]) -> Path:
+        path = self.repo / "plan.json"
+        path.write_text(
+            json.dumps({"schema_version": 1, "scope": "gate regression", "checks": checks}),
+            encoding="utf-8",
+        )
+        return path
+
+    def run_gate(self, plan: Path, receipt: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(GATE),
+                "run",
+                "--base",
+                self.base,
+                "--plan",
+                str(plan),
+                "--receipt",
+                str(receipt),
+            ],
+            cwd=self.repo,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    @staticmethod
+    def passing_check(name: str, kind: str) -> dict[str, object]:
+        return {
+            "name": name,
+            "kind": kind,
+            "command": [sys.executable, "-c", "print('ok')"],
+            "timeout_seconds": 30,
+        }
+
+    def test_docs_change_passes_and_receipt_verifies(self) -> None:
+        (self.repo / "README.md").write_text("updated\n", encoding="utf-8")
+        self.commit_all("docs")
+        receipt = self.repo / "receipt.json"
+        result = self.run_gate(
+            self.write_plan([self.passing_check("docs-static", "static")]),
+            receipt,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        verify = subprocess.run(
+            [sys.executable, str(GATE), "verify", str(receipt)],
+            cwd=self.repo,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(verify.returncode, 0, verify.stderr + verify.stdout)
+
+    def test_source_change_requires_regression_check(self) -> None:
+        source = self.repo / "scripts" / "tool.py"
+        source.parent.mkdir()
+        source.write_text("print('tool')\n", encoding="utf-8")
+        self.commit_all("source")
+        result = self.run_gate(
+            self.write_plan([self.passing_check("static-only", "static")]),
+            self.repo / "receipt.json",
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("regression check", result.stderr)
+
+    def test_production_change_requires_functional_evidence(self) -> None:
+        source = self.repo / "xdremux" / "tool.py"
+        source.parent.mkdir()
+        source.write_text("print('tool')\n", encoding="utf-8")
+        self.commit_all("production")
+        result = self.run_gate(
+            self.write_plan([self.passing_check("regression", "regression")]),
+            self.repo / "receipt.json",
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("functional, integration, or device", result.stderr)
+
+    def test_production_change_passes_with_regression_and_functional_checks(self) -> None:
+        source = self.repo / "xdremux" / "tool.py"
+        source.parent.mkdir()
+        source.write_text("print('tool')\n", encoding="utf-8")
+        self.commit_all("production")
+        checks = [
+            self.passing_check("regression", "regression"),
+            self.passing_check("real-sample", "functional"),
+        ]
+        result = self.run_gate(self.write_plan(checks), self.repo / "receipt.json")
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+
+    def test_failed_check_writes_failed_receipt(self) -> None:
+        (self.repo / "README.md").write_text("updated\n", encoding="utf-8")
+        self.commit_all("docs")
+        plan = self.write_plan(
+            [{
+                "name": "failure",
+                "kind": "static",
+                "command": [sys.executable, "-c", "raise SystemExit(7)"],
+                "timeout_seconds": 30,
+            }]
+        )
+        receipt = self.repo / "receipt.json"
+        result = self.run_gate(plan, receipt)
+        self.assertEqual(result.returncode, 1)
+        self.assertFalse(json.loads(receipt.read_text(encoding="utf-8"))["passed"])
+
+    def test_new_commit_invalidates_existing_receipt(self) -> None:
+        (self.repo / "README.md").write_text("updated\n", encoding="utf-8")
+        self.commit_all("docs")
+        receipt = self.repo / "receipt.json"
+        result = self.run_gate(
+            self.write_plan([self.passing_check("docs-static", "static")]),
+            receipt,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        (self.repo / "README.md").write_text("changed again\n", encoding="utf-8")
+        self.commit_all("later")
+        verify = subprocess.run(
+            [sys.executable, str(GATE), "verify", str(receipt)],
+            cwd=self.repo,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(verify.returncode, 1)
+        self.assertIn("stale", verify.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/verify_swift_cli_sample.py
+++ b/tests/validation/verify_swift_cli_sample.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Compile/run the Swift CLI on one real sample and assert ImageIO pixel format."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+PIXEL_FORMAT_INSPECTOR = r'''
+import Foundation
+import ImageIO
+
+guard CommandLine.arguments.count == 3 else { exit(64) }
+let url = URL(fileURLWithPath: CommandLine.arguments[1])
+let expected = CommandLine.arguments[2]
+guard let data = try? Data(contentsOf: url),
+      let source = CGImageSourceCreateWithData(data as CFData, nil),
+      let info = CGImageSourceCopyAuxiliaryDataInfoAtIndex(
+          source,
+          0,
+          kCGImageAuxiliaryDataTypeISOGainMap
+      ) as? [CFString: Any],
+      let description = info[kCGImageAuxiliaryDataInfoDataDescription] as? [CFString: Any],
+      let number = description[kCGImagePropertyPixelFormat] as? NSNumber else {
+    fputs("no ImageIO ISO gain-map pixel format\n", stderr)
+    exit(1)
+}
+let value = number.uint32Value
+let bytes = [
+    UInt8((value >> 24) & 0xff),
+    UInt8((value >> 16) & 0xff),
+    UInt8((value >> 8) & 0xff),
+    UInt8(value & 0xff),
+]
+let actual = String(bytes: bytes, encoding: .ascii) ?? "????"
+guard actual == expected else {
+    fputs("gain-map pixel format mismatch: expected \(expected), got \(actual)\n", stderr)
+    exit(1)
+}
+print("gain-map pixel format: \(actual)")
+'''
+
+
+def run(command: list[str], *, cwd: Path) -> None:
+    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True, check=False)
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--expected-pixel-format", required=True, choices=("444f", "420f", "420v", "x420", "L008"))
+    parser.add_argument("--cli", type=Path, default=Path("xdremux/swift-cli/XDRemux.swift"))
+    parser.add_argument("--binary", type=Path, help="reuse an already compiled Swift CLI")
+    parser.add_argument("--oppo-compatible", action="store_true")
+    parser.add_argument("--in-place", action="store_true", help="convert a temporary copy in place")
+    return parser.parse_args()
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    repo = Path.cwd().resolve()
+    input_path = arguments.input.expanduser().resolve()
+    cli_path = arguments.cli.resolve()
+    if not input_path.is_file():
+        print(f"input sample not found: {input_path}", file=sys.stderr)
+        return 2
+    if not cli_path.is_file():
+        print(f"Swift CLI not found: {cli_path}", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory(prefix="xdremux-swift-sample-") as directory:
+        temporary = Path(directory)
+        if arguments.binary:
+            binary = arguments.binary.expanduser().resolve()
+            if not binary.is_file():
+                print(f"Swift CLI binary not found: {binary}", file=sys.stderr)
+                return 2
+        else:
+            binary = temporary / "xdremux"
+            run(["swiftc", str(cli_path), "-o", str(binary)], cwd=repo)
+
+        if arguments.in_place:
+            output = temporary / input_path.name
+            shutil.copy2(input_path, output)
+            command = [str(binary), "convert", "--input", str(output)]
+        else:
+            output = temporary / "output.heic"
+            command = [
+                str(binary),
+                "convert",
+                "--input",
+                str(input_path),
+                "--output",
+                str(output),
+            ]
+        if arguments.oppo_compatible:
+            command.append("--oppo-compatible")
+        run(command, cwd=repo)
+        run(
+            ["swift", "-e", PIXEL_FORMAT_INSPECTOR, str(output), arguments.expected_pixel_format],
+            cwd=repo,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/xdremux/swift-cli/XDRemux.swift
+++ b/xdremux/swift-cli/XDRemux.swift
@@ -2894,6 +2894,11 @@ private func writeImageIOPreservedGainMapPassthrough(
                 oppoCompatibility: oppoCompatibility,
                 inputProcessingBranch: .system
             )
+        } else if gainMapEncodingMatchesTarget(at: inputURL, compatibility: oppoCompatibility) {
+            // The input already has the requested high-spec ISO Gain Map. Reusing
+            // that graph avoids appending a second temporary JPEG/tmap graph,
+            // which ImageIO rejects as ambiguous during preserve re-encoding.
+            try FileManager.default.copyItem(at: inputURL, to: preservedURL)
         } else {
             _ = try writePrivateJPEGPassthroughOutput(
                 inputURL: inputURL,


### PR DESCRIPTION
## What changed

- Reuse an input's existing high-spec ISO gain-map graph in the default Swift CLI path instead of appending a second temporary JPEG/tmap graph.
- Add a HEAD-bound agent completion gate, repository instructions, receipt verification, policy regression tests, and a reusable real-sample Swift CLI harness.

## Why

An input that already contained a valid `444f` ISO gain map could fail default conversion with `output verification failed (no ISO gain-map auxiliary data found)`. The temporary default UHDR path appended another gain-map graph, and ImageIO rejected the ambiguous intermediate. `--oppo-compatible` avoided that path, which made the compatibility switch appear mandatory.

The new completion gate prevents future agents from declaring production changes complete using only static checks. Production changes require regression plus functional/integration/device evidence, and the generated receipt is invalidated by a later commit or tracked edit.

## User impact

- Default standard-ISO conversion now succeeds for an existing `444f` ISO gain-map input without enabling OPPO compatibility.
- Ordinary UHDR, LHDR, OPPO-compatible, and in-place conversion behavior remains covered by real samples.
- Future completion claims have a reproducible, machine-readable acceptance record.

## Validation

- Completion gate: 8/8 checks passed for `dd410fd07a3ed5337c2ed2dcc6909b13e49b7b62`.
- Gate policy regression suite: 6/6 tests passed.
- Original failing existing-ISO sample: default `444f` PASS.
- Existing-ISO in-place conversion: `444f` PASS.
- Ordinary UHDR default: `444f` PASS.
- LHDR default: `L008` PASS.
- OPPO-compatible UHDR: `420f` PASS.
- Independent receipt verification passed.
- Both commits have valid GPG signatures.
