### PR TITLE
Fix default Swift CLI ISO gain-map verification

### DIFF
--- a/xdremux/swift-cli/XDRemux.swift
+++ b/xdremux/swift-cli/XDRemux.swift
@@ -2894,6 +2894,11 @@ private func writeImageIOPreservedGainMapPassthrough(
                 oppoCompatibility: oppoCompatibility,
                 inputProcessingBranch: .system
             )
+        } else if gainMapEncodingMatchesTarget(at: inputURL, compatibility: oppoCompatibility) {
+            // The input already has the requested high-spec ISO Gain Map. Reusing
+            // that graph avoids appending a second temporary JPEG/tmap graph,
+            // which ImageIO rejects as ambiguous during preserve re-encoding.
+            try FileManager.default.copyItem(at: inputURL, to: preservedURL)
         } else {
             _ = try writePrivateJPEGPassthroughOutput(
                 inputURL: inputURL,


### PR DESCRIPTION
## What changed

Reuse an input's existing high-spec ISO gain-map graph in the default Swift CLI path instead of appending a second temporary JPEG/tmap graph.

## Root cause

When an input already contained a valid `444f` ISO gain map, the default UHDR path appended another gain-map graph to a temporary intermediate. ImageIO rejected the ambiguous intermediate and reported `output verification failed (no ISO gain-map auxiliary data found)`. `--oppo-compatible` used a different writer path, so it appeared to be required.

## User impact

Default standard-ISO conversion now succeeds for an existing `444f` ISO gain-map input without enabling OPPO compatibility.

## Validation

- Swift CLI typecheck and build passed.
- Original failing existing-ISO sample: default `444f` passed.
- Existing-ISO in-place conversion: `444f` passed.
- Ordinary UHDR default: `444f` passed.
- LHDR default: `L008` passed.
- OPPO-compatible UHDR: `420f` passed.
- Commit GPG signature verified.
