### PR TITLE
Add shooting-mode categorization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,14 @@ jobs:
           XDREMUX_DERIVED_DATA: ${{ runner.temp }}/xdremuxapp-derived
         run: |
           echo "::group::macOS App build"
-          scripts/build_and_run.sh build
+          xcodebuild \
+            -quiet \
+            -project apps/macos/XDRemuxApp/XDRemuxApp.xcodeproj \
+            -scheme XDRemuxApp \
+            -configuration Debug \
+            -derivedDataPath "$XDREMUX_DERIVED_DATA" \
+            CODE_SIGNING_ALLOWED=NO \
+            build
           xcodebuild \
             -quiet \
             -project apps/macos/XDRemuxApp/XDRemuxApp.xcodeproj \

--- a/README.en.md
+++ b/README.en.md
@@ -14,6 +14,7 @@ It reads the private HDR Gain Map and related metadata from a photo and repackag
 | OPPO Gallery compatibility | `--oppo-compatible` | Generates a 4:2:0 Gain Map that is easier for OPPO Gallery to recognize |
 | Apple Photographic Styles | `--apple-photographic-styles` | Makes the Photographic Styles editing interface available in Apple Photos |
 | Apple Portrait | `--apple-portrait` | Converts OPPO portrait mode data into portrait mode data supported by Apple Photos |
+| Shooting-mode categorization | `categorize` / `batch --categorize` | Organizes originals or converted results using the shooting mode in UserComment |
 
 Apple Photographic Styles and Apple Portrait can be enabled together and written into the same HEIC. Apple-related output options cannot be used together with `--oppo-compatible`.
 
@@ -190,6 +191,35 @@ For more checkpoint, overwrite, and diagnostic options, run:
 swift run xdremux --help
 ```
 
+## Categorize by shooting mode
+
+Standalone categorization recursively scans HEIC, HEIF, and JPEG files. It only copies photos and never modifies or deletes the sources:
+
+```bash
+swift run xdremux categorize \
+  --input photo_dump/ \
+  --input another_photo.heic \
+  --output-dir categorized/ \
+  --jobs 4
+```
+
+Add `--dry-run` to preview the plan without writing files. Folder names are fixed in Chinese: 普通拍照, 大师模式, RICOH GR, 专业模式, 人像, 夜景, 全景, 延时摄影, 超清, 证件照, 贴纸, 超级文本, 合影, 双重曝光, and 美颜.
+
+Photos with a missing or malformed UserComment, read failures, or only unknown flags with no confirmed primary mode remain in the output root. Malformed comments and read failures are still copied, but the command exits nonzero; missing UserComment and unknown primary modes are not errors. Normal photos and photos containing only known supplemental flags such as HDR, filters, or watermarks go to `普通拍照/`. Identical same-name files are skipped; different same-name files receive stable names such as `filename (2).heic`.
+
+Batch conversion can write converted results directly into shooting-mode folders:
+
+```bash
+swift run xdremux batch \
+  --input-dir photo_dump/ \
+  --output-dir converted/ \
+  --categorize
+```
+
+`convert` does not accept `--categorize`; the switch applies only to `batch`.
+
+Categorization reads EXIF/UserComment from local files only. It does not claim or emulate OPPO Gallery recognition on a device.
+
 ## Validate output
 
 Validate Apple Photographic Styles or combined output:
@@ -217,7 +247,7 @@ Offline validation only proves that the file structure satisfies the current val
 
 ## Python CLI
 
-The Python CLI provides standard HDR and OPPO Gallery-compatible conversion. It does not include Apple Photographic Styles or Apple Portrait features.
+The Python CLI provides standard HDR and OPPO Gallery-compatible conversion plus the same shooting-mode categorization as Swift. It does not include Apple Photographic Styles or Apple Portrait features.
 
 Install the dependencies:
 
@@ -237,6 +267,21 @@ Convert a directory:
 ```bash
 python3 xdremux/python/XDRemux.py batch \
   --input-dir photo_dump/
+```
+
+Standalone categorization and categorized batch output:
+
+```bash
+python3 xdremux/python/XDRemux.py categorize \
+  --input photo_dump/ \
+  --input another_photo.heic \
+  --output-dir categorized/ \
+  --dry-run
+
+python3 xdremux/python/XDRemux.py batch \
+  --input-dir photo_dump/ \
+  --output-dir converted/ \
+  --categorize
 ```
 
 Create OPPO Gallery-compatible output:
@@ -260,6 +305,8 @@ Build and run it locally:
 ```bash
 scripts/build_and_run.sh run
 ```
+
+Use the segmented control at the top of the App to switch between conversion and shooting-mode categorization. The categorization view accepts multiple files and directories, previews mode counts and destination paths, supports copy and cancel, and can reveal results in Finder. Without a shared output directory, each photo's parent directory is its categorization root. The conversion setting for categorized output writes converted files into the same Chinese mode folders.
 
 ## Use as a Swift Package
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ XDRemux 将 OPPO、OnePlus 和 realme 设备拍摄的 ProXDR 照片转换为兼�
 | OPPO 相册兼容 | `--oppo-compatible` | 生成更适合 OPPO 相册识别的 4:2:0 Gain Map |
 | Apple 摄影风格 | `--apple-photographic-styles` | 让照片在 Apple Photos 中显示摄影风格编辑界面 |
 | Apple 人像 | `--apple-portrait` | 将 OPPO 人像模式数据转换为 Apple Photos 支持的人像模式数据 |
+| 拍摄模式分类 | `categorize` / `batch --categorize` | 按 UserComment 中的拍摄模式整理原片或转换结果 |
 
 Apple 摄影风格和 Apple 人像可以同时启用，并写入同一个 HEIC。Apple 相关的输出选项与 `--oppo-compatible` 不能同时使用。
 
@@ -190,6 +191,35 @@ swift run xdremux batch \
 swift run xdremux --help
 ```
 
+## 按拍摄模式分类
+
+独立分类会递归扫描 HEIC、HEIF 和 JPEG，只复制照片，不修改或删除源文件：
+
+```bash
+swift run xdremux categorize \
+  --input photo_dump/ \
+  --input another_photo.heic \
+  --output-dir categorized/ \
+  --jobs 4
+```
+
+使用 `--dry-run` 可以只查看规划结果。分类目录使用固定中文名称：普通拍照、大师模式、RICOH GR、专业模式、人像、夜景、全景、延时摄影、超清、证件照、贴纸、超级文本、合影、双重曝光和美颜。
+
+缺少 UserComment、格式错误、读取失败，或只有未知标记且无法确定主模式的照片会保留在目标根目录。格式错误或读取失败仍会复制文件，但命令返回非零；缺少 UserComment 或未知主模式不视为错误。普通拍照以及只有 HDR、滤镜、水印等已知附加标记的照片会进入 `普通拍照/`。同名同内容文件会跳过；同名但内容不同的文件会稳定命名为 `文件名 (2).heic` 等。
+
+批量转换时可直接按拍摄模式写入转换结果：
+
+```bash
+swift run xdremux batch \
+  --input-dir photo_dump/ \
+  --output-dir converted/ \
+  --categorize
+```
+
+`convert` 不接受 `--categorize`；该开关只用于 `batch`。
+
+分类只读取本地文件中的 EXIF/UserComment，不声明或模拟 OPPO 相册在设备端的识别行为。
+
 ## 验证输出
 
 验证 Apple 摄影风格或组合输出：
@@ -217,7 +247,7 @@ Apple 人像转换可能还会在输出旁生成 `*.portrait-manifest.json`，�
 
 ## Python CLI
 
-Python CLI 提供标准 HDR 和 OPPO 相册兼容转换，不包含 Apple 摄影风格和 Apple 人像功能。
+Python CLI 提供标准 HDR、OPPO 相册兼容转换和与 Swift 一致的拍摄模式分类，不包含 Apple 摄影风格和 Apple 人像功能。
 
 安装依赖：
 
@@ -237,6 +267,21 @@ python3 xdremux/python/XDRemux.py convert \
 ```bash
 python3 xdremux/python/XDRemux.py batch \
   --input-dir photo_dump/
+```
+
+独立分类与分类输出：
+
+```bash
+python3 xdremux/python/XDRemux.py categorize \
+  --input photo_dump/ \
+  --input another_photo.heic \
+  --output-dir categorized/ \
+  --dry-run
+
+python3 xdremux/python/XDRemux.py batch \
+  --input-dir photo_dump/ \
+  --output-dir converted/ \
+  --categorize
 ```
 
 OPPO 相册兼容输出：
@@ -260,6 +305,8 @@ apps/macos/XDRemuxApp/
 ```bash
 scripts/build_and_run.sh run
 ```
+
+App 顶部可在“转换”和“按模式分类”之间切换。分类页支持一次添加多个文件或目录、扫描预览模式数量和目标路径、复制、取消，以及在 Finder 中显示结果；不选择统一目标目录时，每张照片以自身所在目录为分类根。转换设置中的“按拍摄模式分类输出”开关会把转换结果写入相同的中文模式目录。
 
 ## 作为 Swift Package 使用
 

--- a/Sources/XDRemuxCLI/Commands/XDRemuxCommand.swift
+++ b/Sources/XDRemuxCLI/Commands/XDRemuxCommand.swift
@@ -8,7 +8,8 @@ enum XDRemuxCommand {
     private static let usage = """
     Usage:
          XDRemux.swift convert --input <file.heic|portrait.jpg> [--output <out.heic>] [--apple-photographic-styles] [--apple-styles-raw-dng <file.dng>] [--apple-style-data-producer constrained-solver|learn-node|identity-fallback] [--apple-portrait] [--oppo-compatible] [--discard-portrait-data] [--debug-dir <dir>]
-         XDRemux.swift batch --input-dir <dir> [--output-dir <dir>] [--glob *.heic] [--jobs <n>] [--apple-photographic-styles] [--apple-styles-raw-dng <file.dng>] [--apple-style-data-producer constrained-solver|learn-node|identity-fallback] [--apple-portrait] [--oppo-compatible] [--discard-portrait-data] [--checkpoint <file>] [--resume|--no-resume] [--skip-existing|--no-skip-existing] [--debug-dir <dir>]
+         XDRemux.swift batch --input-dir <dir> [--output-dir <dir>] [--glob *.heic] [--jobs <n>] [--categorize] [--apple-photographic-styles] [--apple-styles-raw-dng <file.dng>] [--apple-style-data-producer constrained-solver|learn-node|identity-fallback] [--apple-portrait] [--oppo-compatible] [--discard-portrait-data] [--checkpoint <file>] [--resume|--no-resume] [--skip-existing|--no-skip-existing] [--debug-dir <dir>]
+         XDRemux.swift categorize --input <file-or-dir> [--input <file-or-dir> ...] --output-dir <dir> [--jobs <n>] [--dry-run]
              XDRemux.swift validate-apple --input <file.heic> [--expect-portrait] [--json <report.json>]
              XDRemux.swift validate-portrait --input <file.heic> [--json <report.json>]
              XDRemux.swift portrait-self-test
@@ -26,6 +27,8 @@ enum XDRemuxCommand {
       - --discard-portrait-data removes large depth/re-edit resources without reintroducing private HDR tail entries.
       - Only the active Gain Map graph and its required container descriptions may change.
       - Batch defaults: --jobs min(cpu,4), --resume, --skip-existing.
+      - batch --categorize writes results under Chinese shooting-mode directories.
+      - categorize copies HEIC, HEIF, and JPEG files without modifying the inputs.
       - A JSONL checkpoint is written under output-dir by default; it is deleted only when the batch finishes with zero failures.
       - --apple-photographic-styles enables donor-free Apple Photographic Styles generation.
         --apple-styles is accepted as a short alias; manifests and documentation use the canonical name.
@@ -74,6 +77,9 @@ enum XDRemuxCommand {
             case "batch":
                 let cmd = try ConversionArgumentParser.parseBatch(Array(args.dropFirst()))
                 try runBatch(cmd)
+            case "categorize":
+                let cmd = try ConversionArgumentParser.parseCategorize(Array(args.dropFirst()))
+                try runCategorize(cmd)
             case "validate-apple":
                 try runAppleValidation(Array(args.dropFirst()))
             case "validate-portrait":
@@ -229,9 +235,23 @@ enum XDRemuxCommand {
         let checkpointURL = resolvedCheckpointURL(cmd: cmd, configHash: configHash)
 
         // Precompute outputs and fail fast on collisions.
+        var reservedOutputPaths = Set<String>()
         let workItems = matched.map { inputURL -> BatchWorkItem in
             let stem = inputURL.deletingPathExtension().lastPathComponent
-            let outputURL = cmd.outputDirURL.appendingPathComponent("\(stem).heic")
+            let directory: URL
+            if cmd.categorizeOutput,
+               let folderName = PhotoCategorizationEngine.categorizedDirectory(for: inputURL) {
+                directory = cmd.outputDirURL.appendingPathComponent(folderName, isDirectory: true)
+            } else {
+                directory = cmd.outputDirURL
+            }
+            var sequence = 1
+            var outputURL = directory.appendingPathComponent("\(stem).heic")
+            while reservedOutputPaths.contains(outputURL.standardizedFileURL.path) {
+                sequence += 1
+                outputURL = directory.appendingPathComponent("\(stem) (\(sequence)).heic")
+            }
+            reservedOutputPaths.insert(outputURL.standardizedFileURL.path)
             return BatchWorkItem(inputURL: inputURL, outputURL: outputURL)
         }
         try assertNoOutputCollisions(workItems)
@@ -362,6 +382,7 @@ enum XDRemuxCommand {
                     }
 
                     do {
+                        try ensureDirectory(item.outputURL.deletingLastPathComponent(), fileManager: fileManager)
                         if cmd.appleFeatures.photographicStyles {
                             try AppleFeatureConversionEngine.convert(
                                 inputURL: item.inputURL,
@@ -402,6 +423,35 @@ enum XDRemuxCommand {
         } else {
             log("checkpoint kept (failures present): \(checkpointURL.path)")
             throw CLIError.batchFailed(failures: failureCount, checkpoint: checkpointURL)
+        }
+    }
+
+    private static func runCategorize(_ cmd: CategorizeCommand) throws {
+        let plan = try PhotoCategorizationEngine.makePlan(
+            inputs: cmd.inputURLs,
+            outputDirectory: cmd.outputDirURL,
+            fileManager: fileManager
+        )
+        let result = PhotoCategorizationEngine.execute(
+            plan,
+            jobs: cmd.jobs,
+            dryRun: cmd.dryRun,
+            fileManager: fileManager
+        )
+        for item in result.items {
+            let mode = item.classification.mode?.folderName
+                ?? "根目录 (\(item.classification.status.rawValue))"
+            let detail = item.errorDescription.map { " error=\($0)" } ?? ""
+            print("\(item.disposition.rawValue) [\(mode)] \(item.sourceURL.path) -> \(item.destinationURL.path)\(detail)")
+        }
+        print(
+            "categorize complete: \(result.categorizedCount) categorized, "
+                + "\(result.rootCount) kept at root, \(result.copiedCount) copied, "
+                + "\(result.dryRunCount) dry-run, \(result.duplicateCount) duplicate, "
+                + "\(result.issueCount) failed"
+        )
+        if result.issueCount > 0 {
+            throw CLIError.categorizationFailed(failures: result.issueCount)
         }
     }
 
@@ -646,7 +696,8 @@ enum XDRemuxCommand {
             ("appleFeatures", cmd.appleFeatures.stableDescription),
             ("appleStyleDataProducer", cmd.appleStyleDataProducer.rawValue),
             ("tmapFormat", cmd.tmapFormat.rawValue),
-            ("outputDir", cmd.outputDirURL.standardizedFileURL.path)
+            ("outputDir", cmd.outputDirURL.standardizedFileURL.path),
+            ("categorizeOutput", cmd.categorizeOutput ? "true" : "false")
         ]
         let stable = entries.sorted(by: { $0.0 < $1.0 }).map { "\($0.0)=\($0.1)" }.joined(separator: "\n")
         return sha256Hex(Data(stable.utf8))

--- a/Sources/XDRemuxCLI/Parsing/CommandModels.swift
+++ b/Sources/XDRemuxCLI/Parsing/CommandModels.swift
@@ -48,6 +48,7 @@ struct BatchCommand {
     let checkpointURL: URL?
     let resume: Bool
     let skipExisting: Bool
+    let categorizeOutput: Bool
 
     var conversionConfiguration: ConversionConfiguration {
         ConversionConfiguration(
@@ -59,6 +60,7 @@ struct BatchCommand {
             debugDirectory: debugRootURL,
             skipExisting: skipExisting,
             maxConcurrentJobs: jobs,
+            categorizeOutputByCaptureMode: categorizeOutput,
             applePhotographicStyles: appleFeatures.photographicStyles,
             applePortrait: appleFeatures.portrait,
             appleStylesRawDNGURL: appleStylesRawDNGURL,
@@ -66,4 +68,11 @@ struct BatchCommand {
             eventHandler: CLIOutput.conversionEventHandler
         )
     }
+}
+
+struct CategorizeCommand {
+    let inputURLs: [URL]
+    let outputDirURL: URL
+    let jobs: Int
+    let dryRun: Bool
 }

--- a/Sources/XDRemuxCLI/Parsing/ConversionArgumentParser.swift
+++ b/Sources/XDRemuxCLI/Parsing/ConversionArgumentParser.swift
@@ -202,6 +202,7 @@ enum ConversionArgumentParser {
         var checkpointPath: String?
         var resume = true
         var skipExisting = true
+        var categorizeOutput = false
 
         while let option = cursor.nextOption() {
             if try common.consume(option, cursor: &cursor) { continue }
@@ -228,6 +229,8 @@ enum ConversionArgumentParser {
                 skipExisting = true
             case "--no-skip-existing":
                 skipExisting = false
+            case "--categorize":
+                categorizeOutput = true
             default:
                 throw CLIError.unknownOption(option)
             }
@@ -253,7 +256,44 @@ enum ConversionArgumentParser {
             jobs: jobs,
             checkpointURL: checkpointPath.map { URL(fileURLWithPath: $0) },
             resume: resume,
-            skipExisting: skipExisting
+            skipExisting: skipExisting,
+            categorizeOutput: categorizeOutput
+        )
+    }
+
+    static func parseCategorize(_ rawArguments: [String]) throws -> CategorizeCommand {
+        var cursor = ArgumentCursor(arguments: rawArguments)
+        var inputPaths: [String] = []
+        var outputDirectoryPath: String?
+        var jobs = min(ProcessInfo.processInfo.activeProcessorCount, 4)
+        var dryRun = false
+
+        while let option = cursor.nextOption() {
+            switch option {
+            case "--input":
+                inputPaths.append(try cursor.nextValue(for: option))
+            case "--output-dir":
+                outputDirectoryPath = try cursor.nextValue(for: option)
+            case "--jobs":
+                let value = try cursor.nextValue(for: option)
+                guard let parsed = Int(value), parsed > 0 else {
+                    throw CLIError.invalidValue(option: option, value: value)
+                }
+                jobs = parsed
+            case "--dry-run":
+                dryRun = true
+            default:
+                throw CLIError.unknownOption(option)
+            }
+        }
+
+        guard !inputPaths.isEmpty else { throw CLIError.missingArgument("--input") }
+        guard let outputDirectoryPath else { throw CLIError.missingArgument("--output-dir") }
+        return CategorizeCommand(
+            inputURLs: inputPaths.map { URL(fileURLWithPath: $0) },
+            outputDirURL: URL(fileURLWithPath: outputDirectoryPath),
+            jobs: jobs,
+            dryRun: dryRun
         )
     }
 }

--- a/Sources/XDRemuxCore/Conversion/Models.swift
+++ b/Sources/XDRemuxCore/Conversion/Models.swift
@@ -24,6 +24,7 @@ public enum XDRemuxError: Error, CustomStringConvertible {
     case invalidCheckpoint(URL, String)
     case checkpointConfigMismatch(URL, expected: String, actual: String)
     case batchFailed(failures: Int, checkpoint: URL)
+    case categorizationFailed(failures: Int)
     case unableToCreateDirectory(URL)
     case outputParentIsNotDirectory(URL)
     case outputPathCollision(output: URL, firstInput: URL, secondInput: URL)
@@ -70,6 +71,8 @@ public enum XDRemuxError: Error, CustomStringConvertible {
             return "checkpoint config mismatch in \(url.path): expected \(expected), got \(actual) (use --no-resume or a different --checkpoint)"
         case .batchFailed(let failures, let checkpoint):
             return "batch failed for \(failures) file(s); checkpoint kept at \(checkpoint.path)"
+        case .categorizationFailed(let failures):
+            return "categorize failed for \(failures) file(s)"
         case .unableToCreateDirectory(let url):
             return "unable to create directory: \(url.path)"
         case .outputParentIsNotDirectory(let url):
@@ -220,6 +223,7 @@ public struct ConversionConfiguration: Sendable {
     public var fileNameSuffix: String
     public var skipExisting: Bool
     public var maxConcurrentJobs: Int
+    public var categorizeOutputByCaptureMode: Bool
     public var applePhotographicStyles: Bool
     public var applePortrait: Bool
     public var appleStylesRawDNGURL: URL?
@@ -237,6 +241,7 @@ public struct ConversionConfiguration: Sendable {
         fileNameSuffix: String = "_iso",
         skipExisting: Bool = true,
         maxConcurrentJobs: Int = min(ProcessInfo.processInfo.activeProcessorCount, 4),
+        categorizeOutputByCaptureMode: Bool = false,
         applePhotographicStyles: Bool = false,
         applePortrait: Bool = false,
         appleStylesRawDNGURL: URL? = nil,
@@ -253,6 +258,7 @@ public struct ConversionConfiguration: Sendable {
         self.fileNameSuffix = fileNameSuffix
         self.skipExisting = skipExisting
         self.maxConcurrentJobs = maxConcurrentJobs
+        self.categorizeOutputByCaptureMode = categorizeOutputByCaptureMode
         self.applePhotographicStyles = applePhotographicStyles
         self.applePortrait = applePortrait
         self.appleStylesRawDNGURL = appleStylesRawDNGURL

--- a/Sources/XDRemuxCore/Metadata/OppoMetadata.swift
+++ b/Sources/XDRemuxCore/Metadata/OppoMetadata.swift
@@ -109,7 +109,12 @@ package func oppoUserComment(in data: Data) -> String? {
           let value = exif[kCGImagePropertyExifUserComment] else {
         return nil
     }
-    return value as? String
+    if let string = value as? String { return string }
+    if let bytes = value as? Data {
+        let payload = bytes.count >= 8 ? bytes.dropFirst(8) : bytes[...]
+        return String(data: payload, encoding: .utf8)?.trimmingCharacters(in: .controlCharacters)
+    }
+    return nil
 }
 
 package func oppoTagFlags(from userComment: String) -> (prefix: String, digitCount: Int, flags: Int)? {

--- a/Sources/XDRemuxCore/Metadata/PhotoCategorization.swift
+++ b/Sources/XDRemuxCore/Metadata/PhotoCategorization.swift
@@ -1,0 +1,538 @@
+import CryptoKit
+import Foundation
+import ImageIO
+
+public enum OppoCaptureMode: String, CaseIterable, Codable, Sendable, Identifiable, Hashable {
+    case normal
+    case master
+    case ricohGR = "ricoh-gr"
+    case professional
+    case portrait
+    case night
+    case panorama
+    case timeLapse = "time-lapse"
+    case ultraHighResolution = "ultra-high-resolution"
+    case idPhoto = "id-photo"
+    case sticker
+    case enhancedText = "enhanced-text"
+    case groupPhoto = "group-photo"
+    case doubleExposure = "double-exposure"
+    case beauty
+
+    public var id: String { rawValue }
+
+    public var folderName: String {
+        switch self {
+        case .normal: return "普通拍照"
+        case .master: return "大师模式"
+        case .ricohGR: return "RICOH GR"
+        case .professional: return "专业模式"
+        case .portrait: return "人像"
+        case .night: return "夜景"
+        case .panorama: return "全景"
+        case .timeLapse: return "延时摄影"
+        case .ultraHighResolution: return "超清"
+        case .idPhoto: return "证件照"
+        case .sticker: return "贴纸"
+        case .enhancedText: return "超级文本"
+        case .groupPhoto: return "合影"
+        case .doubleExposure: return "双重曝光"
+        case .beauty: return "美颜"
+        }
+    }
+
+    fileprivate var bit: UInt64 {
+        switch self {
+        case .normal: return 0
+        case .master: return 0x1_0000_0000
+        case .ricohGR: return 0x8000_0000
+        case .professional: return 0x100
+        case .portrait: return 0x10
+        case .night: return 0x800
+        case .panorama: return 0x4
+        case .timeLapse: return 0x8
+        case .ultraHighResolution: return 0x2000
+        case .idPhoto: return 0x4000
+        case .sticker: return 0x200
+        case .enhancedText: return 0x1000
+        case .groupPhoto: return 0x40_0000
+        case .doubleExposure: return 0x8000
+        case .beauty: return 0x2
+        }
+    }
+
+    fileprivate static let priority = allCases.filter { $0 != .normal }
+}
+
+public enum OppoPhotoClassificationStatus: String, Codable, Sendable, Equatable {
+    case categorized
+    case missingUserComment = "missing-user-comment"
+    case malformedUserComment = "malformed-user-comment"
+    case unknownFlags = "unknown-flags"
+    case unreadableImage = "unreadable-image"
+}
+
+public struct OppoPhotoClassification: Sendable, Equatable {
+    public let rawUserComment: String?
+    public let tagFlags: UInt64?
+    public let unknownFlags: UInt64
+    public let mode: OppoCaptureMode?
+    public let status: OppoPhotoClassificationStatus
+
+    public init(
+        rawUserComment: String?,
+        tagFlags: UInt64?,
+        unknownFlags: UInt64,
+        mode: OppoCaptureMode?,
+        status: OppoPhotoClassificationStatus
+    ) {
+        self.rawUserComment = rawUserComment
+        self.tagFlags = tagFlags
+        self.unknownFlags = unknownFlags
+        self.mode = mode
+        self.status = status
+    }
+}
+
+public enum PhotoCategorizationDisposition: String, Codable, Sendable {
+    case copy
+    case duplicate
+    case copied
+    case failed
+    case dryRun = "dry-run"
+}
+
+public struct PhotoCategorizationItem: Sendable, Identifiable {
+    public let sourceURL: URL
+    public let destinationURL: URL
+    public let classification: OppoPhotoClassification
+    public let disposition: PhotoCategorizationDisposition
+    public let errorDescription: String?
+
+    public var id: String { sourceURL.standardizedFileURL.path }
+
+    public init(
+        sourceURL: URL,
+        destinationURL: URL,
+        classification: OppoPhotoClassification,
+        disposition: PhotoCategorizationDisposition,
+        errorDescription: String? = nil
+    ) {
+        self.sourceURL = sourceURL
+        self.destinationURL = destinationURL
+        self.classification = classification
+        self.disposition = disposition
+        self.errorDescription = errorDescription
+    }
+}
+
+public struct PhotoCategorizationPlan: Sendable {
+    public let outputDirectory: URL?
+    public let items: [PhotoCategorizationItem]
+
+    public init(outputDirectory: URL?, items: [PhotoCategorizationItem]) {
+        self.outputDirectory = outputDirectory
+        self.items = items
+    }
+}
+
+public struct PhotoCategorizationResult: Sendable {
+    public let items: [PhotoCategorizationItem]
+
+    public var copiedCount: Int { items.count { $0.disposition == .copied } }
+    public var dryRunCount: Int { items.count { $0.disposition == .dryRun } }
+    public var duplicateCount: Int { items.count { $0.disposition == .duplicate } }
+    public var failedCount: Int { items.count { $0.disposition == .failed } }
+    public var categorizedCount: Int { items.count { $0.classification.mode != nil } }
+    public var rootCount: Int { items.count { $0.classification.mode == nil } }
+    public var issueCount: Int {
+        items.count {
+            $0.disposition == .failed
+                || $0.classification.status == .malformedUserComment
+                || $0.classification.status == .unreadableImage
+        }
+    }
+
+    public init(items: [PhotoCategorizationItem]) {
+        self.items = items
+    }
+}
+
+public enum PhotoCategorizationEngine {
+    private static let supportedExtensions = Set(["heic", "heif", "jpg", "jpeg"])
+    private static let captureModeFolderNames = Set(OppoCaptureMode.allCases.map(\.folderName))
+    private static let knownFlagsMask: UInt64 = [
+        0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
+        0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000, 0x8000,
+        0x1_0000, 0x2_0000, 0x4_0000, 0x8_0000, 0x10_0000, 0x20_0000,
+        0x40_0000, 0x80_0000, 0x100_0000, 0x200_0000, 0x400_0000,
+        0x800_0000, 0x1000_0000, 0x2000_0000, 0x4000_0000, 0x8000_0000,
+        0x1_0000_0000, 0x2_0000_0000, 0x4000_0000_0000_0000
+    ].reduce(0, |)
+
+    public static func classify(userComment: String?) -> OppoPhotoClassification {
+        guard let raw = userComment?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+            return OppoPhotoClassification(
+                rawUserComment: userComment,
+                tagFlags: nil,
+                unknownFlags: 0,
+                mode: nil,
+                status: .missingUserComment
+            )
+        }
+        guard let flags = parseFlags(from: raw) else {
+            return OppoPhotoClassification(
+                rawUserComment: raw,
+                tagFlags: nil,
+                unknownFlags: 0,
+                mode: nil,
+                status: .malformedUserComment
+            )
+        }
+
+        let unknown = flags & ~knownFlagsMask
+        let mode = OppoCaptureMode.priority.first { flags & $0.bit != 0 }
+        if mode == nil, unknown != 0 {
+            return OppoPhotoClassification(
+                rawUserComment: raw,
+                tagFlags: flags,
+                unknownFlags: unknown,
+                mode: nil,
+                status: .unknownFlags
+            )
+        }
+        return OppoPhotoClassification(
+            rawUserComment: raw,
+            tagFlags: flags,
+            unknownFlags: unknown,
+            mode: mode ?? .normal,
+            status: .categorized
+        )
+    }
+
+    public static func classify(at url: URL) -> OppoPhotoClassification {
+        guard let data = try? Data(contentsOf: url) else {
+            return OppoPhotoClassification(
+                rawUserComment: nil,
+                tagFlags: nil,
+                unknownFlags: 0,
+                mode: nil,
+                status: .unreadableImage
+            )
+        }
+        return classify(userComment: extractedUserComment(from: data))
+    }
+
+    public static func makePlan(
+        inputs: [URL],
+        outputDirectory: URL?,
+        fileManager: FileManager = .default
+    ) throws -> PhotoCategorizationPlan {
+        let sources = try collectInputFiles(inputs, excluding: outputDirectory, fileManager: fileManager)
+        var reserved: [String: (url: URL, digest: String)] = [:]
+        var items: [PhotoCategorizationItem] = []
+
+        for source in sources {
+            let classification = classify(at: source)
+            let destinationRoot = outputDirectory ?? source.deletingLastPathComponent()
+            let destinationDirectory = classification.mode.map {
+                destinationRoot.appendingPathComponent($0.folderName, isDirectory: true)
+            } ?? destinationRoot
+            let sourceDigest = try sha256Hex(source)
+            var sequence = 1
+            while true {
+                let destination = destinationURL(
+                    directory: destinationDirectory,
+                    sourceName: source.lastPathComponent,
+                    sequence: sequence
+                )
+                let key = destination.standardizedFileURL.path
+                if let prior = reserved[key] {
+                    if prior.digest == sourceDigest {
+                        items.append(PhotoCategorizationItem(
+                            sourceURL: source,
+                            destinationURL: prior.url,
+                            classification: classification,
+                            disposition: .duplicate
+                        ))
+                        break
+                    }
+                    sequence += 1
+                    continue
+                }
+                if fileManager.fileExists(atPath: destination.path) {
+                    if try filesMatch(source, destination) {
+                        reserved[key] = (destination, sourceDigest)
+                        items.append(PhotoCategorizationItem(
+                            sourceURL: source,
+                            destinationURL: destination,
+                            classification: classification,
+                            disposition: .duplicate
+                        ))
+                        break
+                    }
+                    sequence += 1
+                    continue
+                }
+                reserved[key] = (destination, sourceDigest)
+                items.append(PhotoCategorizationItem(
+                    sourceURL: source,
+                    destinationURL: destination,
+                    classification: classification,
+                    disposition: .copy
+                ))
+                break
+            }
+        }
+        return PhotoCategorizationPlan(outputDirectory: outputDirectory, items: items)
+    }
+
+    public static func execute(
+        _ plan: PhotoCategorizationPlan,
+        jobs: Int = min(ProcessInfo.processInfo.activeProcessorCount, 4),
+        dryRun: Bool = false,
+        fileManager: FileManager = .default
+    ) -> PhotoCategorizationResult {
+        let lock = NSLock()
+        var completed: [String: PhotoCategorizationItem] = [:]
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = max(1, jobs)
+        queue.qualityOfService = .userInitiated
+
+        for item in plan.items {
+            queue.addOperation {
+                let result: PhotoCategorizationItem
+                if item.disposition == .duplicate {
+                    result = item
+                } else if dryRun {
+                    result = PhotoCategorizationItem(
+                        sourceURL: item.sourceURL,
+                        destinationURL: item.destinationURL,
+                        classification: item.classification,
+                        disposition: .dryRun
+                    )
+                } else {
+                    do {
+                        try copyAtomically(item.sourceURL, to: item.destinationURL, fileManager: fileManager)
+                        result = PhotoCategorizationItem(
+                            sourceURL: item.sourceURL,
+                            destinationURL: item.destinationURL,
+                            classification: item.classification,
+                            disposition: .copied
+                        )
+                    } catch {
+                        result = PhotoCategorizationItem(
+                            sourceURL: item.sourceURL,
+                            destinationURL: item.destinationURL,
+                            classification: item.classification,
+                            disposition: .failed,
+                            errorDescription: String(describing: error)
+                        )
+                    }
+                }
+                lock.lock()
+                completed[item.sourceURL.standardizedFileURL.path] = result
+                lock.unlock()
+            }
+        }
+        queue.waitUntilAllOperationsAreFinished()
+        let ordered = plan.items.compactMap { completed[$0.sourceURL.standardizedFileURL.path] }
+        return PhotoCategorizationResult(items: ordered)
+    }
+
+    public static func categorizedDirectory(for url: URL) -> String? {
+        classify(at: url).mode?.folderName
+    }
+
+    private static func parseFlags(from raw: String) -> UInt64? {
+        if let data = raw.data(using: .utf8),
+           let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let value = object.first(where: { $0.key.caseInsensitiveCompare("oplustag") == .orderedSame })?.value {
+            if let number = value as? NSNumber { return UInt64(number.stringValue) }
+            if let string = value as? String {
+                return UInt64(string.trimmingCharacters(in: .whitespacesAndNewlines))
+            }
+        }
+
+        let normalized = raw.replacingOccurrences(of: "\0", with: "")
+        let lower = normalized.lowercased()
+        for prefix in ["oplus_", "oppo_"] {
+            guard let range = lower.range(of: prefix) else { continue }
+            let suffix = normalized[range.upperBound...]
+            let digits = suffix.prefix { $0.isNumber }
+            guard !digits.isEmpty else { continue }
+            return UInt64(digits)
+        }
+        return nil
+    }
+
+    private static func extractedUserComment(from data: Data) -> String? {
+        if let source = CGImageSourceCreateWithData(data as CFData, nil),
+           let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+           let exif = properties[kCGImagePropertyExifDictionary] as? [CFString: Any],
+           let value = exif[kCGImagePropertyExifUserComment] {
+            if let string = value as? String { return string }
+            if let bytes = value as? Data, let decoded = decodeUserComment(bytes) { return decoded }
+        }
+
+        if let decoded = extractTIFFUserComment(from: data) {
+            return decoded
+        }
+
+        for prefix in ["Oplus_", "oplus_", "Oppo_", "oppo_"] {
+            guard let range = data.range(of: Data(prefix.utf8)) else { continue }
+            var end = range.upperBound
+            while end < data.endIndex, (48...57).contains(data[end]) { end += 1 }
+            guard end > range.upperBound else { continue }
+            return String(data: data[range.lowerBound..<end], encoding: .ascii)
+        }
+        if let text = String(data: data, encoding: .isoLatin1),
+           let match = text.range(
+               of: #"\{\s*[\"']oplustag[\"']\s*:\s*[\"']?[0-9]+[\"']?\s*\}"#,
+               options: [.regularExpression, .caseInsensitive]
+           ) {
+            return String(text[match])
+        }
+        return nil
+    }
+
+    private static func decodeUserComment(_ data: Data) -> String? {
+        let payload = data.count >= 8 ? data.dropFirst(8) : data[...]
+        return String(data: payload, encoding: .utf8)?
+            .trimmingCharacters(in: .controlCharacters.union(.whitespacesAndNewlines))
+    }
+
+    private static func extractTIFFUserComment(from container: Data) -> String? {
+        let exifMarker = Data("Exif\0\0".utf8)
+        var starts = [0]
+        var searchStart = container.startIndex
+        while searchStart < container.endIndex,
+              let range = container.range(of: exifMarker, in: searchStart..<container.endIndex) {
+            starts.append(range.upperBound)
+            searchStart = range.upperBound
+        }
+
+        for start in starts where start + 8 <= container.count {
+            let marker = Array(container[start..<(start + 2)])
+            guard marker == [0x49, 0x49] || marker == [0x4d, 0x4d] else { continue }
+            let littleEndian = marker[0] == 0x49
+            guard readUInt16(container, at: start + 2, littleEndian: littleEndian) == 42,
+                  let firstIFD = readUInt32(container, at: start + 4, littleEndian: littleEndian) else { continue }
+            var pending = [Int(firstIFD)]
+            var visited = Set<Int>()
+            while let relativeOffset = pending.popLast() {
+                guard visited.insert(relativeOffset).inserted else { continue }
+                let ifd = start + relativeOffset
+                guard let count = readUInt16(container, at: ifd, littleEndian: littleEndian), count <= 4096 else { continue }
+                for index in 0..<Int(count) {
+                    let entry = ifd + 2 + index * 12
+                    guard let tag = readUInt16(container, at: entry, littleEndian: littleEndian),
+                          let type = readUInt16(container, at: entry + 2, littleEndian: littleEndian),
+                          let valueCount = readUInt32(container, at: entry + 4, littleEndian: littleEndian),
+                          let valueOffset = readUInt32(container, at: entry + 8, littleEndian: littleEndian) else { break }
+                    if tag == 0x8769 || tag == 0x8825 {
+                        pending.append(Int(valueOffset))
+                    } else if tag == 0x9286, type == 7 {
+                        let length = Int(valueCount)
+                        let valueStart = length <= 4 ? entry + 8 : start + Int(valueOffset)
+                        guard valueStart >= 0, valueStart + length <= container.count else { continue }
+                        let bytes = container.subdata(in: valueStart..<(valueStart + length))
+                        if let value = decodeUserComment(bytes), !value.isEmpty {
+                            return value
+                        }
+                    }
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func readUInt16(_ data: Data, at offset: Int, littleEndian: Bool) -> UInt16? {
+        guard offset >= 0, offset + 2 <= data.count else { return nil }
+        let first = UInt16(data[offset])
+        let second = UInt16(data[offset + 1])
+        return littleEndian ? first | second << 8 : first << 8 | second
+    }
+
+    private static func readUInt32(_ data: Data, at offset: Int, littleEndian: Bool) -> UInt32? {
+        guard offset >= 0, offset + 4 <= data.count else { return nil }
+        let values = (0..<4).map { UInt32(data[offset + $0]) }
+        return littleEndian
+            ? values[0] | values[1] << 8 | values[2] << 16 | values[3] << 24
+            : values[0] << 24 | values[1] << 16 | values[2] << 8 | values[3]
+    }
+
+    private static func collectInputFiles(
+        _ inputs: [URL],
+        excluding outputDirectory: URL?,
+        fileManager: FileManager
+    ) throws -> [URL] {
+        let excluded = outputDirectory?.standardizedFileURL.path
+        var collected: [String: URL] = [:]
+        for input in inputs {
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: input.path, isDirectory: &isDirectory) else {
+                throw XDRemuxError.inputNotFound(input)
+            }
+            if !isDirectory.boolValue {
+                if supportedExtensions.contains(input.pathExtension.lowercased()) {
+                    collected[input.standardizedFileURL.path] = input
+                }
+                continue
+            }
+            guard let enumerator = fileManager.enumerator(
+                at: input,
+                includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            ) else { throw XDRemuxError.unableToRead(input) }
+            for case let url as URL in enumerator {
+                let path = url.standardizedFileURL.path
+                let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+                if let excluded, path == excluded || path.hasPrefix(excluded + "/") {
+                    if isDirectory { enumerator.skipDescendants() }
+                    continue
+                }
+                if outputDirectory == nil, isDirectory,
+                   captureModeFolderNames.contains(url.lastPathComponent) {
+                    enumerator.skipDescendants()
+                    continue
+                }
+                let values = try url.resourceValues(forKeys: [.isRegularFileKey])
+                guard values.isRegularFile == true,
+                      supportedExtensions.contains(url.pathExtension.lowercased()) else { continue }
+                collected[path] = url
+            }
+        }
+        return collected.values.sorted { $0.standardizedFileURL.path < $1.standardizedFileURL.path }
+    }
+
+    private static func destinationURL(directory: URL, sourceName: String, sequence: Int) -> URL {
+        guard sequence > 1 else { return directory.appendingPathComponent(sourceName) }
+        let source = URL(fileURLWithPath: sourceName)
+        let ext = source.pathExtension
+        let stem = source.deletingPathExtension().lastPathComponent
+        let name = ext.isEmpty ? "\(stem) (\(sequence))" : "\(stem) (\(sequence)).\(ext)"
+        return directory.appendingPathComponent(name)
+    }
+
+    private static func filesMatch(_ left: URL, _ right: URL) throws -> Bool {
+        let leftSize = try left.resourceValues(forKeys: [.fileSizeKey]).fileSize
+        let rightSize = try right.resourceValues(forKeys: [.fileSizeKey]).fileSize
+        guard leftSize == rightSize else { return false }
+        return try sha256Hex(left) == sha256Hex(right)
+    }
+
+    private static func sha256Hex(_ url: URL) throws -> String {
+        let data = try Data(contentsOf: url, options: [.mappedIfSafe])
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func copyAtomically(_ source: URL, to destination: URL, fileManager: FileManager) throws {
+        let parent = destination.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+        let temporary = parent.appendingPathComponent(".xdremux-categorize-\(UUID().uuidString).tmp")
+        defer { try? fileManager.removeItem(at: temporary) }
+        try fileManager.copyItem(at: source, to: temporary)
+        try fileManager.moveItem(at: temporary, to: destination)
+    }
+}

--- a/Tests/XDRemuxCLITests/ConversionArgumentParserTests.swift
+++ b/Tests/XDRemuxCLITests/ConversionArgumentParserTests.swift
@@ -31,6 +31,31 @@ final class ConversionArgumentParserTests: XCTestCase {
         XCTAssertNil(command.checkpointURL)
         XCTAssertTrue(command.resume)
         XCTAssertTrue(command.skipExisting)
+        XCTAssertFalse(command.categorizeOutput)
+    }
+
+    func testCategorizeCommandAndBatchSwitch() throws {
+        let categorize = try ConversionArgumentParser.parseCategorize([
+            "--input", "/tmp/a.heic",
+            "--input", "/tmp/photos",
+            "--output-dir", "/tmp/output",
+            "--jobs", "2",
+            "--dry-run",
+        ])
+        XCTAssertEqual(categorize.inputURLs.map(\.path), ["/tmp/a.heic", "/tmp/photos"])
+        XCTAssertEqual(categorize.outputDirURL.path, "/tmp/output")
+        XCTAssertEqual(categorize.jobs, 2)
+        XCTAssertTrue(categorize.dryRun)
+
+        let batch = try ConversionArgumentParser.parseBatch([
+            "--input-dir", "/tmp/input",
+            "--categorize",
+        ])
+        XCTAssertTrue(batch.categorizeOutput)
+        XCTAssertThrowsError(try ConversionArgumentParser.parseConvert([
+            "--input", "/tmp/input.heic",
+            "--categorize",
+        ]))
     }
 
     func testStandardAndOppoModesKeepTheirTailPolicies() throws {

--- a/Tests/XDRemuxCoreTests/CoreContractTests.swift
+++ b/Tests/XDRemuxCoreTests/CoreContractTests.swift
@@ -4,6 +4,111 @@ import XCTest
 @testable import XDRemuxCore
 
 final class CoreContractTests: XCTestCase {
+    func testOppoCaptureModeContractMatrix() throws {
+        struct ContractCase: Decodable {
+            let userComment: String?
+            let mode: String?
+            let folder: String?
+            let status: String
+
+            enum CodingKeys: String, CodingKey {
+                case userComment = "user_comment"
+                case mode, folder, status
+            }
+        }
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("fixtures/oppo_capture_mode_cases.json")
+        let cases = try JSONDecoder().decode([ContractCase].self, from: Data(contentsOf: fixtureURL))
+        for item in cases {
+            let classification = PhotoCategorizationEngine.classify(userComment: item.userComment)
+            XCTAssertEqual(classification.mode?.rawValue, item.mode, "comment: \(item.userComment ?? "nil")")
+            XCTAssertEqual(classification.mode?.folderName, item.folder)
+            XCTAssertEqual(classification.status.rawValue, item.status)
+        }
+    }
+
+    func testPhotoCategorizationPlansFoldersRootAndStableDuplicates() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-categorize-\(UUID().uuidString)", isDirectory: true)
+        let input = root.appendingPathComponent("input", isDirectory: true)
+        let nested = input.appendingPathComponent("nested", isDirectory: true)
+        let output = input.appendingPathComponent("categorized", isDirectory: true)
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let portrait = input.appendingPathComponent("same.heic")
+        let secondPortrait = nested.appendingPathComponent("same.heic")
+        let unclassified = input.appendingPathComponent("plain.jpg")
+        try Data("header-oplus_18-tail".utf8).write(to: portrait)
+        try Data("different-oplus_18-tail".utf8).write(to: secondPortrait)
+        try Data("no user comment".utf8).write(to: unclassified)
+
+        let plan = try PhotoCategorizationEngine.makePlan(inputs: [input], outputDirectory: output)
+        XCTAssertEqual(plan.items.count, 3)
+        XCTAssertEqual(plan.items[0].destinationURL.deletingLastPathComponent().lastPathComponent, "人像")
+        XCTAssertEqual(plan.items[1].destinationURL.lastPathComponent, "plain.jpg")
+        XCTAssertEqual(plan.items[1].destinationURL.deletingLastPathComponent(), output)
+        XCTAssertEqual(plan.items[2].destinationURL.lastPathComponent, "same (2).heic")
+
+        let result = PhotoCategorizationEngine.execute(plan, jobs: 2)
+        XCTAssertEqual(result.copiedCount, 3)
+        let repeated = try PhotoCategorizationEngine.makePlan(inputs: [input], outputDirectory: output)
+        XCTAssertEqual(repeated.items.count, 3)
+        XCTAssertTrue(repeated.items.allSatisfy { $0.disposition == .duplicate })
+    }
+
+    func testPhotoCategorizationReadsTIFFUserCommentBytes() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-categorize-tiff-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("comment.jpg")
+        try makeTIFFUserComment("Oplus_4096").write(to: source)
+
+        let classification = PhotoCategorizationEngine.classify(at: source)
+        XCTAssertEqual(classification.mode, .enhancedText)
+        XCTAssertEqual(classification.status, .categorized)
+    }
+
+    func testCategorizationResultCountsMalformedCommentsAsIssuesAfterCopy() {
+        let source = URL(fileURLWithPath: "/tmp/malformed.jpg")
+        let classification = PhotoCategorizationEngine.classify(userComment: "not-an-oppo-comment")
+        let item = PhotoCategorizationItem(
+            sourceURL: source,
+            destinationURL: URL(fileURLWithPath: "/tmp/output/malformed.jpg"),
+            classification: classification,
+            disposition: .copied
+        )
+        let result = PhotoCategorizationResult(items: [item])
+
+        XCTAssertEqual(result.rootCount, 1)
+        XCTAssertEqual(result.copiedCount, 1)
+        XCTAssertEqual(result.issueCount, 1)
+    }
+
+    func testSourceDirectoryCategorizationExcludesCreatedModeTrees() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-categorize-source-root-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = root.appendingPathComponent("portrait.heic")
+        try Data("oplus_18".utf8).write(to: source)
+
+        let initial = try PhotoCategorizationEngine.makePlan(inputs: [root], outputDirectory: nil)
+        XCTAssertEqual(initial.items.first?.destinationURL.lastPathComponent, "portrait.heic")
+        XCTAssertEqual(
+            initial.items.first?.destinationURL.deletingLastPathComponent().lastPathComponent,
+            "人像"
+        )
+        XCTAssertEqual(PhotoCategorizationEngine.execute(initial).copiedCount, 1)
+
+        let repeated = try PhotoCategorizationEngine.makePlan(inputs: [root], outputDirectory: nil)
+        XCTAssertEqual(repeated.items.count, 1)
+        XCTAssertEqual(repeated.items.first?.disposition, .duplicate)
+        XCTAssertFalse(repeated.items.contains { $0.destinationURL.path.contains("人像/人像") })
+    }
     func testPhotographicStylesResolveUnspecifiedProducerToProductionSolver() {
         XCTAssertEqual(
             AppleStyleDataProducerMode.unspecified.resolvedForPhotographicStyles,
@@ -197,5 +302,24 @@ final class CoreContractTests: XCTestCase {
             XDRemuxError.invalidValue(option: "--jobs", value: "0").description,
             "invalid value for --jobs: 0"
         )
+    }
+
+    private func makeTIFFUserComment(_ comment: String) -> Data {
+        let payload = Data("ASCII\0\0\0\(comment)".utf8)
+        var data = Data([0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00])
+        data.append(contentsOf: [0x01, 0x00])
+        data.append(contentsOf: [0x69, 0x87, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00, 0x1a, 0x00, 0x00, 0x00])
+        data.append(contentsOf: [0x00, 0x00, 0x00, 0x00])
+        data.append(contentsOf: [0x01, 0x00])
+        data.append(contentsOf: [0x86, 0x92, 0x07, 0x00])
+        let count = UInt32(payload.count)
+        data.append(contentsOf: [
+            UInt8(count & 0xff), UInt8((count >> 8) & 0xff),
+            UInt8((count >> 16) & 0xff), UInt8((count >> 24) & 0xff),
+            0x2c, 0x00, 0x00, 0x00,
+        ])
+        data.append(contentsOf: [0x00, 0x00, 0x00, 0x00])
+        data.append(payload)
+        return data
     }
 }

--- a/Tests/fixtures/oppo_capture_mode_cases.json
+++ b/Tests/fixtures/oppo_capture_mode_cases.json
@@ -1,0 +1,23 @@
+[
+  {"name":"normal-zero","user_comment":"oplus_0","mode":"normal","folder":"普通拍照","status":"categorized"},
+  {"name":"normal-local-hdr","user_comment":"Oplus_262144","mode":"normal","folder":"普通拍照","status":"categorized"},
+  {"name":"normal-known-uint64-additional-bit","user_comment":"oplus_4611686018427387904","mode":"normal","folder":"普通拍照","status":"categorized"},
+  {"name":"master-over-professional","user_comment":"oplus_4294967552","mode":"master","folder":"大师模式","status":"categorized"},
+  {"name":"ricoh-gr","user_comment":"oplus_2147483648","mode":"ricoh-gr","folder":"RICOH GR","status":"categorized"},
+  {"name":"professional","user_comment":"oplus_256","mode":"professional","folder":"专业模式","status":"categorized"},
+  {"name":"portrait-over-beauty","user_comment":"oplus_18","mode":"portrait","folder":"人像","status":"categorized"},
+  {"name":"night","user_comment":"oplus_2048","mode":"night","folder":"夜景","status":"categorized"},
+  {"name":"panorama-oppo-prefix","user_comment":"Oppo_4","mode":"panorama","folder":"全景","status":"categorized"},
+  {"name":"time-lapse","user_comment":"oplus_8","mode":"time-lapse","folder":"延时摄影","status":"categorized"},
+  {"name":"ultra-high-resolution","user_comment":"oplus_8192","mode":"ultra-high-resolution","folder":"超清","status":"categorized"},
+  {"name":"id-photo","user_comment":"oplus_16384","mode":"id-photo","folder":"证件照","status":"categorized"},
+  {"name":"sticker","user_comment":"oplus_512","mode":"sticker","folder":"贴纸","status":"categorized"},
+  {"name":"enhanced-text-ascii","user_comment":"ASCIIOplus_4096","mode":"enhanced-text","folder":"超级文本","status":"categorized"},
+  {"name":"group-photo-json","user_comment":"{\"oplustag\":4194304}","mode":"group-photo","folder":"合影","status":"categorized"},
+  {"name":"double-exposure","user_comment":"oplus_32768","mode":"double-exposure","folder":"双重曝光","status":"categorized"},
+  {"name":"beauty","user_comment":"oplus_2","mode":"beauty","folder":"美颜","status":"categorized"},
+  {"name":"missing","user_comment":null,"mode":null,"folder":null,"status":"missing-user-comment"},
+  {"name":"malformed","user_comment":"not-an-oppo-comment","mode":null,"folder":null,"status":"malformed-user-comment"},
+  {"name":"unknown","user_comment":"oplus_17179869184","mode":null,"folder":null,"status":"unknown-flags"},
+  {"name":"unknown-above-int64","user_comment":"oplus_9223372036854775808","mode":null,"folder":null,"status":"unknown-flags"}
+]

--- a/Tests/test_categorization_documentation.py
+++ b/Tests/test_categorization_documentation.py
@@ -1,0 +1,34 @@
+import unittest
+from pathlib import Path
+
+
+class CategorizationDocumentationTests(unittest.TestCase):
+    def test_bilingual_readmes_use_the_same_public_commands(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        for name in ("README.md", "README.en.md"):
+            with self.subTest(name=name):
+                text = (root / name).read_text(encoding="utf-8")
+                self.assertIn("swift run xdremux categorize", text)
+                self.assertIn("python3 xdremux/python/XDRemux.py categorize", text)
+                self.assertIn("--categorize", text)
+                self.assertNotIn("--categorize-output", text)
+                self.assertNotIn("--organize-by-mode", text)
+                self.assertNotIn("xdremux classify", text)
+
+    def test_cli_usage_exposes_only_categorize_naming(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        paths = (
+            root / "Sources/XDRemuxCLI/Commands/XDRemuxCommand.swift",
+            root / "xdremux/python/XDRemux.py",
+            root / "xdremux/README.md",
+        )
+        for path in paths:
+            with self.subTest(path=path.name):
+                text = path.read_text(encoding="utf-8")
+                self.assertIn("categorize", text)
+                self.assertNotIn("--categorize-output", text)
+                self.assertNotIn("--organize-by-mode", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/test_photo_categorization.py
+++ b/Tests/test_photo_categorization.py
@@ -1,0 +1,105 @@
+import json
+import struct
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from io import StringIO
+from pathlib import Path
+
+from xdremux.python import categorize
+from xdremux.python import XDRemux
+
+
+class PhotoCategorizationTests(unittest.TestCase):
+    def test_python_cli_uses_categorize_for_command_and_batch_switch(self) -> None:
+        parser = XDRemux.build_parser()
+        standalone = parser.parse_args([
+            "categorize", "--input", "/tmp/a.heic", "--input", "/tmp/photos",
+            "--output-dir", "/tmp/output", "--jobs", "2", "--dry-run",
+        ])
+        self.assertEqual(standalone.command, "categorize")
+        self.assertEqual(standalone.input, ["/tmp/a.heic", "/tmp/photos"])
+        self.assertEqual(standalone.jobs, 2)
+        self.assertTrue(standalone.dry_run)
+
+        batch = parser.parse_args(["batch", "--input-dir", "/tmp/input", "--categorize"])
+        self.assertTrue(batch.categorize_output)
+        with redirect_stderr(StringIO()), self.assertRaises(SystemExit):
+            parser.parse_args(["convert", "--input", "/tmp/input.heic", "--categorize"])
+
+    def test_shared_contract_matrix(self) -> None:
+        fixture = Path(__file__).parent / "fixtures" / "oppo_capture_mode_cases.json"
+        cases = json.loads(fixture.read_text(encoding="utf-8"))
+        for item in cases:
+            with self.subTest(item=item["name"]):
+                result = categorize.classify_user_comment(item["user_comment"])
+                self.assertEqual(result.mode.key if result.mode else None, item["mode"])
+                self.assertEqual(result.mode.folder_name if result.mode else None, item["folder"])
+                self.assertEqual(result.status, item["status"])
+
+    def test_plan_copies_to_categories_and_root_without_duplicate_reruns(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            nested = source / "nested"
+            output = source / "categorized"
+            nested.mkdir(parents=True)
+            (source / "same.heic").write_bytes(b"head-oplus_18-tail")
+            (nested / "same.heic").write_bytes(b"different-oplus_18-tail")
+            (source / "plain.jpg").write_bytes(b"no comment")
+
+            plan = categorize.make_plan([source], output)
+            self.assertEqual(len(plan), 3)
+            self.assertEqual(plan[0].destination.parent.name, "人像")
+            self.assertEqual(plan[1].destination, output / "plain.jpg")
+            self.assertEqual(plan[2].destination.name, "same (2).heic")
+
+            results = categorize.execute_plan(plan, jobs=2)
+            self.assertTrue(all(item.disposition == "copied" for item in results))
+            repeated = categorize.make_plan([source], output)
+            self.assertTrue(all(item.disposition == "duplicate" for item in repeated))
+
+    def test_dry_run_writes_nothing(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "portrait.heic"
+            output = root / "output"
+            source.write_bytes(b"oplus_18")
+            results = categorize.execute_plan(categorize.make_plan([source], output), dry_run=True)
+            self.assertEqual(results[0].disposition, "dry-run")
+            self.assertFalse(output.exists())
+
+    def test_malformed_comment_is_copied_to_root_and_returns_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "malformed.jpg"
+            output = root / "output"
+            payload = b"ASCII\0\0\0not-an-oppo-comment"
+            header = b"II" + struct.pack("<H", 42) + struct.pack("<I", 8)
+            ifd0 = struct.pack("<H", 1) + struct.pack("<HHII", 0x8769, 4, 1, 26) + struct.pack("<I", 0)
+            exif = struct.pack("<H", 1) + struct.pack("<HHII", 0x9286, 7, len(payload), 44) + struct.pack("<I", 0)
+            source.write_bytes(header + ifd0 + exif + payload)
+
+            result = XDRemux.main([
+                "categorize", "--input", str(source), "--output-dir", str(output),
+            ])
+
+            self.assertEqual(result, 1)
+            self.assertEqual((output / source.name).read_bytes(), source.read_bytes())
+
+    def test_reads_tiff_user_comment_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "comment.jpg"
+            payload = b"ASCII\0\0\0Oplus_4096"
+            header = b"II" + struct.pack("<H", 42) + struct.pack("<I", 8)
+            ifd0 = struct.pack("<H", 1) + struct.pack("<HHII", 0x8769, 4, 1, 26) + struct.pack("<I", 0)
+            exif = struct.pack("<H", 1) + struct.pack("<HHII", 0x9286, 7, len(payload), 44) + struct.pack("<I", 0)
+            source.write_bytes(header + ifd0 + exif + payload)
+
+            result = categorize.classify_path(source)
+            self.assertEqual(result.mode, categorize.CaptureMode.ENHANCED_TEXT)
+            self.assertEqual(result.status, "categorized")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/test_public_documentation.py
+++ b/Tests/test_public_documentation.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROOT_READMES = (ROOT / "README.md", ROOT / "README.en.md")
+PUBLIC_DOCUMENTS = ROOT_READMES + tuple(
+    ROOT / relative
+    for relative in (
+        "docs/cli.md",
+        "docs/cli.en.md",
+        "docs/apple-features.md",
+        "docs/apple-features.en.md",
+        "docs/development.md",
+        "docs/development.en.md",
+        "docs/supported-devices.md",
+        "docs/supported-devices.en.md",
+        "xdremux/README.md",
+    )
+)
+MARKDOWN_LINK = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+
+class PublicDocumentationTests(unittest.TestCase):
+    def test_bilingual_readmes_publish_matching_categorize_workflows(self) -> None:
+        required = (
+            "swift run xdremux categorize",
+            "python3 xdremux/python/XDRemux.py categorize",
+            "--categorize",
+        )
+        forbidden = ("--categorize-output", "--organize-by-mode", "xdremux classify")
+        for readme in ROOT_READMES:
+            text = readme.read_text(encoding="utf-8")
+            for value in required:
+                self.assertIn(value, text, f"{value} missing from {readme.name}")
+            for value in forbidden:
+                self.assertNotIn(value, text, f"legacy naming in {readme.name}: {value}")
+
+    def test_local_links_in_public_documents_resolve_inside_the_repository(self) -> None:
+        for document in PUBLIC_DOCUMENTS:
+            self.assertTrue(document.is_file(), f"missing public document: {document}")
+            for match in MARKDOWN_LINK.finditer(document.read_text(encoding="utf-8")):
+                target = match.group(1).strip().strip("<>")
+                if target.startswith(("https://", "http://", "mailto:", "#")):
+                    continue
+                target = target.split("#", maxsplit=1)[0]
+                if not target:
+                    continue
+                resolved = (document.parent / target).resolve()
+                try:
+                    resolved.relative_to(ROOT)
+                except ValueError:
+                    self.fail(f"{document}: link escapes repository: {target}")
+                self.assertTrue(resolved.exists(), f"{document}: missing link target {target}")
+
+    def test_documentation_workflows_reference_present_test_modules(self) -> None:
+        workflows = (
+            ROOT / ".github" / "workflows" / "docs.yml",
+            ROOT / ".github" / "workflows" / "policy.yml",
+        )
+        for workflow in workflows:
+            text = workflow.read_text(encoding="utf-8")
+            self.assertIn("python3 -m unittest Tests.test_public_documentation", text)
+        self.assertTrue((ROOT / "Tests" / "test_public_documentation.py").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/test_swift_app_architecture.py
+++ b/Tests/test_swift_app_architecture.py
@@ -44,7 +44,9 @@ class SwiftAppArchitectureTests(unittest.TestCase):
 
     def test_ci_runs_architecture_and_app_model_checks(self) -> None:
         self.assertIn("python3 -m unittest Tests.test_swift_app_architecture", CI_WORKFLOW)
+        self.assertIn("-scheme XDRemuxApp", CI_WORKFLOW)
         self.assertIn("-scheme XDRemuxAppModelTests", CI_WORKFLOW)
+        self.assertIn("CODE_SIGNING_ALLOWED=NO", CI_WORKFLOW)
         self.assertIn("XDRemuxAppModelTests\"", CI_WORKFLOW)
         self.assertIn("actions/upload-artifact@v7", CI_WORKFLOW)
 

--- a/Tests/test_swift_app_architecture.py
+++ b/Tests/test_swift_app_architecture.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_SOURCE_ROOT = ROOT / "apps" / "macos" / "XDRemuxApp" / "Sources"
+APP_SOURCES = {
+    path.name: path.read_text(encoding="utf-8")
+    for path in sorted(APP_SOURCE_ROOT.glob("*.swift"))
+}
+BRIDGE = APP_SOURCES["XDRemuxCore.swift"]
+PROJECT = (ROOT / "apps" / "macos" / "XDRemuxApp" / "project.yml").read_text(
+    encoding="utf-8"
+)
+CI_WORKFLOW = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+
+class SwiftAppArchitectureTests(unittest.TestCase):
+    def test_app_uses_shared_modules_without_cli_subprocess_rpc(self) -> None:
+        combined = "\n".join(APP_SOURCES.values())
+        for forbidden in ("import XDRemuxCLI", "CommandLine.arguments", "Process()"):
+            self.assertNotIn(forbidden, combined)
+        self.assertIn("import XDRemuxCore", BRIDGE)
+        self.assertIn("import XDRemuxAppleFeatures", BRIDGE)
+        self.assertIn("ConversionEngine.convert(request)", BRIDGE)
+        self.assertIn("AppleFeatureConversionEngine.convert(request)", BRIDGE)
+
+    def test_categorization_ui_uses_the_shared_core_engine(self) -> None:
+        model = APP_SOURCES["PhotoCategorizationViewModel.swift"]
+        view = APP_SOURCES["PhotoCategorizationView.swift"]
+        queue = APP_SOURCES["XDRemuxViewModel.swift"]
+        for source in (model, view, queue):
+            self.assertIn("import XDRemuxCore", source)
+        self.assertIn("PhotoCategorizationEngine.makePlan", model)
+        self.assertIn("PhotoCategorizationEngine.execute", model)
+        self.assertIn("PhotoCategorizationEngine.classify", queue)
+
+    def test_app_and_model_tools_depend_on_shared_package_products(self) -> None:
+        self.assertIn("product: XDRemuxCore", PROJECT)
+        self.assertIn("product: XDRemuxAppleFeatures", PROJECT)
+        self.assertIn("XDRemuxAppModelTests:", PROJECT)
+        self.assertIn("XDRemuxAppConversionSmoke:", PROJECT)
+        self.assertIn("PhotoCategorizationView.swift", PROJECT)
+
+    def test_ci_runs_architecture_and_app_model_checks(self) -> None:
+        self.assertIn("python3 -m unittest Tests.test_swift_app_architecture", CI_WORKFLOW)
+        self.assertIn("-scheme XDRemuxAppModelTests", CI_WORKFLOW)
+        self.assertIn("XDRemuxAppModelTests\"", CI_WORKFLOW)
+        self.assertIn("actions/upload-artifact@v7", CI_WORKFLOW)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/validation/verify_categorization_cross_implementation.py
+++ b/Tests/validation/verify_categorization_cross_implementation.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Compare Swift and Python categorization against the same real photos."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+RESULT_PATTERN = re.compile(r"^(\S+) \[(.+)] (.+) -> (.+?)(?: error=.*)?$")
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def output_manifest(root: Path) -> dict[str, str]:
+    return {
+        str(path.relative_to(root)): sha256(path)
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def run(
+    command: list[str],
+    cwd: Path,
+    allowed_returncodes: tuple[int, ...] = (0,),
+) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+    if completed.returncode not in allowed_returncodes:
+        raise subprocess.CalledProcessError(
+            completed.returncode,
+            command,
+            output=completed.stdout,
+            stderr=completed.stderr,
+        )
+    return completed
+
+
+def result_manifest(stdout: str, output_root: Path) -> list[tuple[str, str, str]]:
+    results: list[tuple[str, str, str]] = []
+    for line in stdout.splitlines():
+        match = RESULT_PATTERN.match(line)
+        if not match:
+            continue
+        disposition, mode, _, destination = match.groups()
+        relative = str(Path(destination).relative_to(output_root))
+        results.append((disposition, mode, relative))
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", action="append", required=True)
+    parser.add_argument("--swift-executable", default=".build/debug/xdremux")
+    args = parser.parse_args()
+
+    repo = Path(__file__).resolve().parents[2]
+    inputs = [str(Path(value).resolve()) for value in args.input]
+    swift_executable = str((repo / args.swift_executable).resolve())
+    python_cli = str(repo / "xdremux/python/XDRemux.py")
+
+    with tempfile.TemporaryDirectory(prefix="xdremux-categorization-cross-") as temporary:
+        root = Path(temporary)
+        swift_output = root / "swift"
+        python_output = root / "python"
+        common = [part for value in inputs for part in ("--input", value)]
+        swift_dry_output = root / "swift-dry"
+        python_dry_output = root / "python-dry"
+        swift_dry = run(
+            [swift_executable, "categorize", *common, "--output-dir", str(swift_dry_output), "--jobs", "3", "--dry-run"],
+            repo,
+            (0, 1),
+        )
+        python_dry = run(
+            [sys.executable, python_cli, "categorize", *common, "--output-dir", str(python_dry_output), "--jobs", "3", "--dry-run"],
+            repo,
+            (0, 1),
+        )
+        swift_dry_results = result_manifest(swift_dry.stdout, swift_dry_output)
+        python_dry_results = result_manifest(python_dry.stdout, python_dry_output)
+        if not swift_dry_results or swift_dry_results != python_dry_results:
+            raise AssertionError("Swift and Python dry-run plans differ")
+        if any(item[0] != "dry-run" for item in swift_dry_results):
+            raise AssertionError(f"dry-run returned unexpected dispositions: {swift_dry_results}")
+        if swift_dry_output.exists() or python_dry_output.exists():
+            raise AssertionError("dry-run created an output directory")
+
+        malformed = root / "malformed.jpg"
+        payload = b"ASCII\0\0\0not-an-oppo-comment"
+        header = b"II" + struct.pack("<H", 42) + struct.pack("<I", 8)
+        ifd0 = struct.pack("<H", 1) + struct.pack("<HHII", 0x8769, 4, 1, 26) + struct.pack("<I", 0)
+        exif = struct.pack("<H", 1) + struct.pack("<HHII", 0x9286, 7, len(payload), 44) + struct.pack("<I", 0)
+        malformed.write_bytes(header + ifd0 + exif + payload)
+        for label, command, output in (
+            (
+                "Swift",
+                [swift_executable, "categorize", "--input", str(malformed), "--output-dir", str(root / "swift-malformed")],
+                root / "swift-malformed",
+            ),
+            (
+                "Python",
+                [sys.executable, python_cli, "categorize", "--input", str(malformed), "--output-dir", str(root / "python-malformed")],
+                root / "python-malformed",
+            ),
+        ):
+            completed = subprocess.run(command, cwd=repo, text=True, capture_output=True)
+            if completed.returncode == 0:
+                raise AssertionError(f"{label} accepted a malformed UserComment without reporting failure")
+            if (output / malformed.name).read_bytes() != malformed.read_bytes():
+                raise AssertionError(f"{label} did not preserve the malformed photo in the output root")
+
+        swift = run(
+            [swift_executable, "categorize", *common, "--output-dir", str(swift_output), "--jobs", "2"],
+            repo,
+            (0, 1),
+        )
+        python = run(
+            [sys.executable, python_cli, "categorize", *common, "--output-dir", str(python_output), "--jobs", "2"],
+            repo,
+            (0, 1),
+        )
+
+        swift_results = result_manifest(swift.stdout, swift_output)
+        python_results = result_manifest(python.stdout, python_output)
+        if swift_results != python_results:
+            raise AssertionError(f"result mismatch:\nSwift: {swift_results}\nPython: {python_results}")
+        if output_manifest(swift_output) != output_manifest(python_output):
+            raise AssertionError("relative output paths or SHA-256 values differ")
+        if not swift_results:
+            raise AssertionError("no categorized results were reported")
+
+        first_manifest = output_manifest(swift_output)
+        swift_repeat = run(
+            [swift_executable, "categorize", *common, "--output-dir", str(swift_output)],
+            repo,
+            (0, 1),
+        )
+        python_repeat = run(
+            [sys.executable, python_cli, "categorize", *common, "--output-dir", str(python_output)],
+            repo,
+            (0, 1),
+        )
+        for label, completed, output in (
+            ("Swift", swift_repeat, swift_output),
+            ("Python", python_repeat, python_output),
+        ):
+            repeated = result_manifest(completed.stdout, output)
+            if not repeated or any(item[0] != "duplicate" for item in repeated):
+                raise AssertionError(f"{label} repeat was not duplicate-only: {repeated}")
+        if first_manifest != output_manifest(swift_output):
+            raise AssertionError("Swift repeat changed the output tree")
+        if first_manifest != output_manifest(python_output):
+            raise AssertionError("Python repeat changed the output tree")
+
+    print(f"categorization cross-implementation check passed for {len(inputs)} input(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tests/validation/verify_categorized_batch_outputs.py
+++ b/Tests/validation/verify_categorized_batch_outputs.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Run real Swift/Python batches with --categorize and validate their outputs."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def run(command: list[str], cwd: Path) -> None:
+    subprocess.run(command, cwd=cwd, text=True, check=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--swift-executable", default=".build/debug/xdremux")
+    args = parser.parse_args()
+
+    repo = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(repo))
+    from xdremux.python import categorize
+
+    source = Path(args.input).resolve()
+    source_comment = categorize.extract_user_comment(source)
+    classification = categorize.classify_path(source)
+    folder = classification.mode.folder_name if classification.mode else ""
+    swift_executable = str((repo / args.swift_executable).resolve())
+    python_cli = str(repo / "xdremux/python/XDRemux.py")
+
+    with tempfile.TemporaryDirectory(prefix="xdremux-categorized-batch-") as temporary:
+        root = Path(temporary)
+        outputs: list[Path] = []
+        for implementation in ("swift", "python"):
+            input_dir = root / implementation / "input"
+            output_dir = root / implementation / "output"
+            input_dir.mkdir(parents=True)
+            local_input = input_dir / source.name
+            shutil.copy2(source, local_input)
+            if implementation == "swift":
+                run(
+                    [
+                        swift_executable, "batch", "--input-dir", str(input_dir),
+                        "--output-dir", str(output_dir), "--glob", "*.heic",
+                        "--jobs", "1", "--no-resume", "--categorize",
+                    ],
+                    repo,
+                )
+            else:
+                run(
+                    [
+                        sys.executable, python_cli, "batch", "--input-dir", str(input_dir),
+                        "--output-dir", str(output_dir), "--glob", "*.heic", "--categorize",
+                    ],
+                    repo,
+                )
+            output = output_dir / folder / source.name if folder else output_dir / source.name
+            if not output.is_file():
+                raise AssertionError(f"{implementation} categorized output missing: {output}")
+            if categorize.extract_user_comment(output) != source_comment:
+                raise AssertionError(f"{implementation} did not preserve UserComment")
+            try:
+                from pillow_heif import open_heif
+                heif = open_heif(str(output), convert_hdr_to_8bit=False)
+                if len(heif) < 1:
+                    raise AssertionError(f"{implementation} output has no readable image")
+            except ImportError as exc:
+                raise AssertionError("pillow-heif is required for the functional batch check") from exc
+            outputs.append(output)
+
+    print(f"categorized Swift and Python batch outputs passed for {source.name} in {folder or 'root'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/macos/XDRemuxApp/Sources/AppStrings.swift
+++ b/apps/macos/XDRemuxApp/Sources/AppStrings.swift
@@ -129,6 +129,8 @@ enum AppStrings {
     static let oppoCameraTailPreserveNoHDRHelp = "在完整保留其他业务数据的前提下，等长停用 local.uhdr.*、hdr.*、local.hdr.* 和 src.local.hdr.* manifest key。"
     static let skipExisting = "跳过已有有效输出"
     static let skipExistingHelp = "目标文件已经满足当前 ISO gain map 与 OPPO 相机尾部设置时不重复转换。"
+    static let categorizeOutput = "按拍摄模式分类输出"
+    static let categorizeOutputHelp = "根据源照片的 OPPO UserComment，将转换结果写入普通拍照、大师模式、专业模式、人像等子目录；无法可靠识别的文件保留在输出根目录。"
     static let concurrentJobs = "并发任务"
     static let outputFileSuffix = "输出文件后缀"
     static let outputFileSuffixHelp = "未设置输出目录时，在原目录用这个后缀生成新文件。"

--- a/apps/macos/XDRemuxApp/Sources/ContentView.swift
+++ b/apps/macos/XDRemuxApp/Sources/ContentView.swift
@@ -3,68 +3,99 @@ import UniformTypeIdentifiers
 import Observation
 import AppKit
 
+private enum WorkspaceMode: String, CaseIterable, Identifiable {
+    case convert = "转换"
+    case categorize = "按模式分类"
+
+    var id: String { rawValue }
+}
+
 struct ContentView: View {
     @State private var viewModel = XDRemuxViewModel()
+    @State private var categorizationViewModel = PhotoCategorizationViewModel()
+    @State private var workspaceMode = WorkspaceMode.convert
     @State private var isTargeted = false
     @State private var isSettingsPresented = false
     @State private var selectedQueueItemID: UUID?
     @State private var queueFilter = ""
 
     var body: some View {
-        NavigationSplitView {
-            sidebar
-                .navigationSplitViewColumnWidth(min: 300, ideal: 360, max: 440)
-        } detail: {
-            workbench
+        Group {
+            if workspaceMode == .convert {
+                conversionWorkspace
+            } else {
+                PhotoCategorizationView(viewModel: categorizationViewModel)
+            }
         }
         .navigationTitle("XDRemux")
         .frame(minWidth: 1040, minHeight: 680)
-        .searchable(text: $queueFilter, prompt: "搜索队列")
         .toolbar {
-            ToolbarItemGroup(placement: .primaryAction) {
-                Button(action: selectFiles) {
-                    Label(AppStrings.addHEIC, systemImage: "plus")
+            ToolbarItem(placement: .navigation) {
+                Picker("工作模式", selection: $workspaceMode) {
+                    ForEach(WorkspaceMode.allCases) { mode in
+                        Text(mode.rawValue).tag(mode)
+                    }
                 }
-                .disabled(!viewModel.canEditQueue)
-                .help(AppStrings.addHEICHelp)
+                .pickerStyle(.segmented)
+                .frame(width: 220)
+            }
 
-                Button {
-                    viewModel.startConversion()
-                } label: {
-                    Label(AppStrings.startConversion, systemImage: "play.fill")
-                }
-                .buttonStyle(.borderedProminent)
-                .disabled(!viewModel.canStart)
-                .keyboardShortcut(.defaultAction)
+            if workspaceMode == .convert {
+                ToolbarItemGroup(placement: .primaryAction) {
+                    Button(action: selectFiles) {
+                        Label(AppStrings.addHEIC, systemImage: "plus")
+                    }
+                    .disabled(!viewModel.canEditQueue)
+                    .help(AppStrings.addHEICHelp)
 
-                Button {
-                    viewModel.cancelTask()
-                } label: {
-                    Label(AppStrings.cancel, systemImage: "stop.fill")
-                }
-                .disabled(viewModel.state != .processing && viewModel.state != .scanning)
-                .keyboardShortcut(.cancelAction)
+                    Button {
+                        viewModel.startConversion()
+                    } label: {
+                        Label(AppStrings.startConversion, systemImage: "play.fill")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!viewModel.canStart)
+                    .keyboardShortcut(.defaultAction)
 
-                Button {
-                    isSettingsPresented = true
-                } label: {
-                    Image(systemName: "slider.horizontal.3")
-                }
-                .help(AppStrings.conversionSettings)
+                    Button {
+                        viewModel.cancelTask()
+                    } label: {
+                        Label(AppStrings.cancel, systemImage: "stop.fill")
+                    }
+                    .disabled(viewModel.state != .processing && viewModel.state != .scanning)
+                    .keyboardShortcut(.cancelAction)
 
-                Button {
-                    viewModel.clearQueue()
-                } label: {
-                    Image(systemName: "trash")
+                    Button {
+                        isSettingsPresented = true
+                    } label: {
+                        Image(systemName: "slider.horizontal.3")
+                    }
+                    .help(AppStrings.conversionSettings)
+
+                    Button {
+                        viewModel.clearQueue()
+                    } label: {
+                        Image(systemName: "trash")
+                    }
+                    .disabled(!viewModel.canEditQueue || viewModel.queue.isEmpty)
+                    .help(AppStrings.clearQueue)
                 }
-                .disabled(!viewModel.canEditQueue || viewModel.queue.isEmpty)
-                .help(AppStrings.clearQueue)
             }
         }
         .sheet(isPresented: $isSettingsPresented) {
             SettingsView(viewModel: viewModel)
                 .presentationSizing(.fitted)
         }
+    }
+
+    private var conversionWorkspace: some View {
+        NavigationSplitView {
+            sidebar
+                .navigationSplitViewColumnWidth(min: 300, ideal: 360, max: 440)
+        } detail: {
+            workbench
+        }
+        .searchable(text: $queueFilter, prompt: "搜索队列")
         .dropDestination(for: URL.self) { items, _ in
             guard !items.isEmpty else { return false }
             viewModel.addFiles(from: items)
@@ -184,6 +215,8 @@ struct ContentView: View {
             item.inputURL.lastPathComponent.localizedCaseInsensitiveContains(term) ||
             item.inputURL.path.localizedCaseInsensitiveContains(term) ||
             item.outputURL.path.localizedCaseInsensitiveContains(term) ||
+            (item.captureMode?.folderName.localizedCaseInsensitiveContains(term) ?? false) ||
+            item.classificationStatus.appDisplayName.localizedCaseInsensitiveContains(term) ||
             item.status.displayName.localizedCaseInsensitiveContains(term) ||
             item.outputPlanStatus.displayName.localizedCaseInsensitiveContains(term)
         }
@@ -332,6 +365,13 @@ private struct QueueSidebarRow: View {
                 HStack(spacing: 6) {
                     Text(item.status.displayName)
                         .foregroundStyle(item.status.iconColor)
+                    if let mode = item.captureMode {
+                        Text(mode.folderName)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text(item.classificationStatus.appDisplayName)
+                            .foregroundStyle(.secondary)
+                    }
                     if item.outputPlanStatus != .ready {
                         Text(item.outputPlanStatus.displayName)
                             .foregroundStyle(item.outputPlanStatus.iconColor)
@@ -841,6 +881,15 @@ private struct SettingsView: View {
                         viewModel.refreshOutputURLsForPendingItems()
                     }
                 SettingExplanation(AppStrings.skipExistingHelp)
+
+                Toggle(
+                    AppStrings.categorizeOutput,
+                    isOn: $viewModel.config.categorizeOutputByCaptureMode
+                )
+                .onChange(of: viewModel.config.categorizeOutputByCaptureMode) {
+                    viewModel.refreshOutputURLsForPendingItems()
+                }
+                SettingExplanation(AppStrings.categorizeOutputHelp)
 
                 Stepper(value: $viewModel.config.maxConcurrentJobs, in: 1...maxJobs) {
                     LabeledContent(AppStrings.concurrentJobs) {

--- a/apps/macos/XDRemuxApp/Sources/PhotoCategorizationView.swift
+++ b/apps/macos/XDRemuxApp/Sources/PhotoCategorizationView.swift
@@ -1,0 +1,177 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+import XDRemuxCore
+
+struct PhotoCategorizationView: View {
+    let viewModel: PhotoCategorizationViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            controls
+            Divider()
+            if viewModel.items.isEmpty {
+                ContentUnavailableView(
+                    "选择照片并扫描",
+                    systemImage: "square.grid.2x2",
+                    description: Text(statusText)
+                )
+            } else {
+                Table(viewModel.items) {
+                    TableColumn("文件") { item in
+                        Text(item.sourceURL.lastPathComponent)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    TableColumn("拍摄模式") { item in
+                        Text(item.classification.mode?.folderName ?? "根目录")
+                    }
+                    TableColumn("状态") { item in
+                        Text(item.classification.mode == nil
+                            ? item.classification.status.appDisplayName
+                            : item.disposition.displayName)
+                    }
+                    TableColumn("目标") { item in
+                        Text(item.destinationURL.path)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                }
+                .tableStyle(.inset)
+            }
+            Divider()
+            footer
+        }
+        .frame(minWidth: 1040, minHeight: 680)
+        .dropDestination(for: URL.self) { urls, _ in
+            viewModel.addInputs(urls)
+            return !urls.isEmpty
+        }
+    }
+
+    private var controls: some View {
+        HStack(spacing: 10) {
+            Button(action: chooseInputs) {
+                Label("添加照片", systemImage: "plus")
+            }
+            .disabled(viewModel.isBusy)
+
+            Button(action: chooseOutputDirectory) {
+                Label("目标目录", systemImage: "folder")
+            }
+            .disabled(viewModel.isBusy)
+
+            Text(viewModel.outputDirectory?.path ?? "各照片所在目录")
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Spacer()
+
+            Button {
+                viewModel.scan()
+            } label: {
+                Label("扫描", systemImage: "magnifyingglass")
+            }
+            .disabled(!viewModel.canScan)
+
+            Button {
+                viewModel.copyPlannedFiles()
+            } label: {
+                Label("开始分类", systemImage: "play.fill")
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!viewModel.canCopy)
+
+            Button {
+                viewModel.cancel()
+            } label: {
+                Image(systemName: "stop.fill")
+            }
+            .help("取消")
+            .disabled(!viewModel.isBusy)
+
+            Button(action: viewModel.revealResults) {
+                Image(systemName: "folder.badge.magnifyingglass")
+            }
+            .help("在 Finder 中显示结果")
+            .disabled(viewModel.items.allSatisfy {
+                $0.disposition != .copied && $0.disposition != .duplicate
+            })
+
+            Button {
+                viewModel.clear()
+            } label: {
+                Image(systemName: "trash")
+            }
+            .help("清空")
+            .disabled(viewModel.isBusy || (viewModel.inputURLs.isEmpty && viewModel.items.isEmpty))
+        }
+        .padding(14)
+    }
+
+    private var footer: some View {
+        HStack(spacing: 18) {
+            Label("\(viewModel.items.isEmpty ? viewModel.inputURLs.count : viewModel.items.count) 张照片", systemImage: "photo.on.rectangle")
+            Label("\(viewModel.categorizedCount) 已分类", systemImage: "folder.badge.gearshape")
+                .help(viewModel.modeSummary)
+            Label("\(viewModel.rootCount) 根目录", systemImage: "tray")
+            Label("\(viewModel.duplicateCount) 重复", systemImage: "equal.circle")
+            if viewModel.failedCount > 0 {
+                Label("\(viewModel.failedCount) 失败", systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.red)
+            }
+            Spacer()
+            Text(statusText)
+                .foregroundStyle(.secondary)
+                .help(viewModel.modeSummary)
+        }
+        .font(.caption)
+        .padding(.horizontal, 14)
+        .frame(height: 42)
+    }
+
+    private var statusText: String {
+        switch viewModel.state {
+        case .idle: return "等待扫描"
+        case .scanning: return "正在读取 UserComment"
+        case .ready: return "扫描完成"
+        case .copying: return "正在复制 \(viewModel.completedCount)/\(viewModel.items.count)"
+        case .completed: return "分类完成"
+        case .cancelled: return "已取消"
+        case .failed(let message): return message
+        }
+    }
+
+    private func chooseInputs() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = [.heic, .heif, .jpeg]
+        panel.prompt = "添加"
+        if panel.runModal() == .OK { viewModel.addInputs(panel.urls) }
+    }
+
+    private func chooseOutputDirectory() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.prompt = "选择"
+        if panel.runModal() == .OK { viewModel.outputDirectory = panel.url }
+    }
+}
+
+private extension PhotoCategorizationDisposition {
+    var displayName: String {
+        switch self {
+        case .copy: return "待复制"
+        case .duplicate: return "内容相同，跳过"
+        case .copied: return "已复制"
+        case .failed: return "失败"
+        case .dryRun: return "预演"
+        }
+    }
+}

--- a/apps/macos/XDRemuxApp/Sources/PhotoCategorizationViewModel.swift
+++ b/apps/macos/XDRemuxApp/Sources/PhotoCategorizationViewModel.swift
@@ -1,0 +1,149 @@
+import Foundation
+import Observation
+import XDRemuxCore
+import AppKit
+
+enum PhotoCategorizationAppState: Equatable {
+    case idle
+    case scanning
+    case ready
+    case copying
+    case completed
+    case cancelled
+    case failed(String)
+}
+
+private final class CategorizationCancellationToken: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+}
+
+@Observable
+@MainActor
+final class PhotoCategorizationViewModel {
+    var inputURLs: [URL] = []
+    var outputDirectory: URL?
+    var items: [PhotoCategorizationItem] = []
+    var state: PhotoCategorizationAppState = .idle
+    var completedCount = 0
+
+    var canScan: Bool { !inputURLs.isEmpty && !isBusy }
+    var canCopy: Bool { state == .ready && items.contains { $0.disposition == .copy } }
+    var isBusy: Bool { state == .scanning || state == .copying }
+    var categorizedCount: Int { items.count { $0.classification.mode != nil } }
+    var rootCount: Int { items.count { $0.classification.mode == nil } }
+    var duplicateCount: Int { items.count { $0.disposition == .duplicate } }
+    var failedCount: Int { items.count { $0.disposition == .failed } }
+    var modeSummary: String {
+        let counts = Dictionary(grouping: items.compactMap(\.classification.mode), by: { $0 })
+            .mapValues(\.count)
+        return OppoCaptureMode.allCases.compactMap { mode in
+            counts[mode].map { "\(mode.folderName) \($0)" }
+        }.joined(separator: " · ")
+    }
+
+    private var task: Task<Void, Never>?
+    private var cancellationToken: CategorizationCancellationToken?
+
+    func addInputs(_ urls: [URL]) {
+        guard !isBusy else { return }
+        var existing = Set(inputURLs.map { $0.standardizedFileURL.path })
+        for url in urls where existing.insert(url.standardizedFileURL.path).inserted {
+            inputURLs.append(url)
+        }
+        items.removeAll()
+        state = .idle
+    }
+
+    func clear() {
+        guard !isBusy else { return }
+        inputURLs.removeAll()
+        outputDirectory = nil
+        items.removeAll()
+        completedCount = 0
+        state = .idle
+    }
+
+    func scan() {
+        guard canScan else { return }
+        task?.cancel()
+        state = .scanning
+        completedCount = 0
+        let inputs = inputURLs
+        let outputDirectory = outputDirectory
+        task = Task { [weak self] in
+            do {
+                let plan = try await Task.detached(priority: .userInitiated) {
+                    try PhotoCategorizationEngine.makePlan(
+                        inputs: inputs,
+                        outputDirectory: outputDirectory
+                    )
+                }.value
+                guard !Task.isCancelled else { return }
+                self?.items = plan.items
+                self?.state = .ready
+            } catch {
+                self?.state = .failed(String(describing: error))
+            }
+        }
+    }
+
+    func copyPlannedFiles() {
+        guard canCopy else { return }
+        state = .copying
+        completedCount = 0
+        let token = CategorizationCancellationToken()
+        cancellationToken = token
+        let planItems = items
+        let outputDirectory = outputDirectory
+        task = Task { [weak self] in
+            let results = await Task.detached(priority: .userInitiated) {
+                var completed: [PhotoCategorizationItem] = []
+                for item in planItems {
+                    if token.isCancelled { break }
+                    let plan = PhotoCategorizationPlan(outputDirectory: outputDirectory, items: [item])
+                    completed.append(contentsOf: PhotoCategorizationEngine.execute(plan, jobs: 1).items)
+                }
+                return completed
+            }.value
+            guard let self else { return }
+            let completedByID = Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) })
+            items = items.map { completedByID[$0.id] ?? $0 }
+            completedCount = results.count
+            if token.isCancelled {
+                state = .cancelled
+            } else if items.contains(where: { $0.disposition == .failed }) {
+                state = .failed("部分文件复制失败")
+            } else {
+                state = .completed
+            }
+            cancellationToken = nil
+        }
+    }
+
+    func cancel() {
+        cancellationToken?.cancel()
+        task?.cancel()
+        if isBusy { state = .cancelled }
+    }
+
+    func revealResults() {
+        let urls = items
+            .filter { $0.disposition == .copied || $0.disposition == .duplicate }
+            .map(\.destinationURL)
+        guard !urls.isEmpty else { return }
+        NSWorkspace.shared.activateFileViewerSelecting(urls)
+    }
+}

--- a/apps/macos/XDRemuxApp/Sources/XDRemuxViewModel.swift
+++ b/apps/macos/XDRemuxApp/Sources/XDRemuxViewModel.swift
@@ -416,12 +416,16 @@ final class XDRemuxViewModel {
         return markOutputCollisions()
     }
 
-    func effectiveConcurrencyForTesting(fileSizes: [UInt64], physicalMemory: UInt64) -> Int {
+    func effectiveConcurrencyForTesting(
+        fileSizes: [UInt64],
+        physicalMemory: UInt64,
+        processorCount: Int = ProcessInfo.processInfo.activeProcessorCount
+    ) -> Int {
         Self.effectiveConcurrency(
             configuredLimit: config.maxConcurrentJobs,
             fileSizes: fileSizes,
             physicalMemory: physicalMemory,
-            processorCount: ProcessInfo.processInfo.activeProcessorCount
+            processorCount: processorCount
         )
     }
 

--- a/apps/macos/XDRemuxApp/Sources/XDRemuxViewModel.swift
+++ b/apps/macos/XDRemuxApp/Sources/XDRemuxViewModel.swift
@@ -4,6 +4,7 @@ import Observation
 import ImageIO
 import UniformTypeIdentifiers
 import AppKit
+import XDRemuxCore
 
 enum AppState: Equatable {
     case idle
@@ -93,6 +94,8 @@ struct ConversionQueueItem: Identifiable, Sendable, Equatable {
     var errorMessage: String?
     var startedAt: Date?
     var finishedAt: Date?
+    var captureMode: OppoCaptureMode?
+    var classificationStatus: OppoPhotoClassificationStatus
 
     init(
         id: UUID = UUID(),
@@ -102,7 +105,9 @@ struct ConversionQueueItem: Identifiable, Sendable, Equatable {
         outputPlanStatus: OutputPlanStatus = .ready,
         errorMessage: String? = nil,
         startedAt: Date? = nil,
-        finishedAt: Date? = nil
+        finishedAt: Date? = nil,
+        captureMode: OppoCaptureMode? = nil,
+        classificationStatus: OppoPhotoClassificationStatus = .missingUserComment
     ) {
         self.id = id
         self.inputURL = inputURL
@@ -112,6 +117,8 @@ struct ConversionQueueItem: Identifiable, Sendable, Equatable {
         self.errorMessage = errorMessage
         self.startedAt = startedAt
         self.finishedAt = finishedAt
+        self.captureMode = captureMode
+        self.classificationStatus = classificationStatus
     }
 
     var isSuccessful: Bool {
@@ -121,6 +128,18 @@ struct ConversionQueueItem: Identifiable, Sendable, Equatable {
     var duration: TimeInterval? {
         guard let startedAt, let finishedAt else { return nil }
         return finishedAt.timeIntervalSince(startedAt)
+    }
+}
+
+extension OppoPhotoClassificationStatus {
+    var appDisplayName: String {
+        switch self {
+        case .categorized: return "已识别"
+        case .missingUserComment: return "缺少 UserComment"
+        case .malformedUserComment: return "UserComment 格式错误"
+        case .unknownFlags: return "含未知拍摄标记"
+        case .unreadableImage: return "照片读取失败"
+        }
     }
 }
 
@@ -209,8 +228,10 @@ final class XDRemuxViewModel {
         state = .scanning
         currentFileName = "正在扫描 HEIC 文件..."
 
-        let heicURLs = await Task.detached(priority: .userInitiated) {
-            Self.collectHEICURLs(from: urls)
+        let classifiedURLs = await Task.detached(priority: .userInitiated) {
+            Self.collectHEICURLs(from: urls).map { url in
+                (url, PhotoCategorizationEngine.classify(at: url))
+            }
         }.value
 
         if Task.isCancelled {
@@ -220,14 +241,20 @@ final class XDRemuxViewModel {
         }
 
         let existingInputs = Set(queue.map { Self.pathKey($0.inputURL) })
-        let newItems = heicURLs
-            .filter { !existingInputs.contains(Self.pathKey($0)) }
-            .map {
-                let outputURL = Self.makeOutputURL(for: $0, config: config)
+        let newItems = classifiedURLs
+            .filter { !existingInputs.contains(Self.pathKey($0.0)) }
+            .map { inputURL, classification in
+                let outputURL = Self.makeOutputURL(
+                    for: inputURL,
+                    config: config,
+                    captureMode: classification.mode
+                )
                 return ConversionQueueItem(
-                    inputURL: $0,
+                    inputURL: inputURL,
                     outputURL: outputURL,
-                    outputPlanStatus: Self.outputPlanStatus(inputURL: $0, outputURL: outputURL, config: config)
+                    outputPlanStatus: Self.outputPlanStatus(inputURL: inputURL, outputURL: outputURL, config: config),
+                    captureMode: classification.mode,
+                    classificationStatus: classification.status
                 )
             }
 
@@ -292,7 +319,7 @@ final class XDRemuxViewModel {
             queue[index].errorMessage = nil
             queue[index].startedAt = nil
             queue[index].finishedAt = nil
-            queue[index].outputURL = Self.makeOutputURL(for: queue[index].inputURL, config: config)
+            queue[index].outputURL = Self.makeOutputURL(for: queue[index].inputURL, config: config, captureMode: queue[index].captureMode)
             queue[index].outputPlanStatus = Self.outputPlanStatus(inputURL: queue[index].inputURL, outputURL: queue[index].outputURL, config: config)
         }
         refreshOutputURLsAndPlansForEditableItems()
@@ -360,7 +387,7 @@ final class XDRemuxViewModel {
 
     private func refreshOutputURLsAndPlansForEditableItems() {
         for index in queue.indices where queue[index].status == .pending || queue[index].status == .failed || queue[index].status == .cancelled {
-            queue[index].outputURL = Self.makeOutputURL(for: queue[index].inputURL, config: config)
+            queue[index].outputURL = Self.makeOutputURL(for: queue[index].inputURL, config: config, captureMode: queue[index].captureMode)
             queue[index].outputPlanStatus = Self.outputPlanStatus(
                 inputURL: queue[index].inputURL,
                 outputURL: queue[index].outputURL,
@@ -519,7 +546,7 @@ final class XDRemuxViewModel {
             queue[index].errorMessage = nil
             queue[index].startedAt = nil
             queue[index].finishedAt = nil
-            queue[index].outputURL = Self.makeOutputURL(for: queue[index].inputURL, config: config)
+            queue[index].outputURL = Self.makeOutputURL(for: queue[index].inputURL, config: config, captureMode: queue[index].captureMode)
             queue[index].outputPlanStatus = Self.outputPlanStatus(inputURL: queue[index].inputURL, outputURL: queue[index].outputURL, config: config)
         }
         refreshOutputURLsAndPlansForEditableItems()
@@ -595,14 +622,25 @@ final class XDRemuxViewModel {
         return heicURLs.sorted { $0.path < $1.path }
     }
 
-    nonisolated private static func makeOutputURL(for inputURL: URL, config: ConversionConfig) -> URL {
+    nonisolated private static func makeOutputURL(
+        for inputURL: URL,
+        config: ConversionConfig,
+        captureMode: OppoCaptureMode?
+    ) -> URL {
+        let category = config.categorizeOutputByCaptureMode ? captureMode?.folderName : nil
         if let outputDirectory = config.outputDirectory {
-            return outputDirectory.appendingPathComponent(inputURL.lastPathComponent)
+            let directory = category.map {
+                outputDirectory.appendingPathComponent($0, isDirectory: true)
+            } ?? outputDirectory
+            return directory.appendingPathComponent(inputURL.lastPathComponent)
         }
 
         let suffix = config.fileNameSuffix.isEmpty ? "_iso" : config.fileNameSuffix
         let stem = inputURL.deletingPathExtension().lastPathComponent
-        return inputURL.deletingLastPathComponent().appendingPathComponent("\(stem)\(suffix).heic")
+        let parent = category.map {
+            inputURL.deletingLastPathComponent().appendingPathComponent($0, isDirectory: true)
+        } ?? inputURL.deletingLastPathComponent()
+        return parent.appendingPathComponent("\(stem)\(suffix).heic")
     }
 
     nonisolated private static func pathKey(_ url: URL) -> String {

--- a/apps/macos/XDRemuxApp/Tests/XDRemuxAppModelTests.swift
+++ b/apps/macos/XDRemuxApp/Tests/XDRemuxAppModelTests.swift
@@ -312,13 +312,22 @@ struct XDRemuxAppModelTests {
 
         let small = viewModel.effectiveConcurrencyForTesting(
             fileSizes: [10 * 1024 * 1024, 12 * 1024 * 1024],
-            physicalMemory: 64 * 1024 * 1024 * 1024
+            physicalMemory: 64 * 1024 * 1024 * 1024,
+            processorCount: 8
         )
         try expect(small == 4, "small files should keep the configured concurrency")
 
+        let cpuCapped = viewModel.effectiveConcurrencyForTesting(
+            fileSizes: [10 * 1024 * 1024],
+            physicalMemory: 64 * 1024 * 1024 * 1024,
+            processorCount: 2
+        )
+        try expect(cpuCapped == 2, "concurrency should respect the available processor count")
+
         let large = viewModel.effectiveConcurrencyForTesting(
             fileSizes: [20 * 1024 * 1024 * 1024],
-            physicalMemory: 16 * 1024 * 1024 * 1024
+            physicalMemory: 16 * 1024 * 1024 * 1024,
+            processorCount: 8
         )
         try expect(large == 1, "oversized inputs should drop concurrency to one")
     }

--- a/apps/macos/XDRemuxApp/Tests/XDRemuxAppModelTests.swift
+++ b/apps/macos/XDRemuxApp/Tests/XDRemuxAppModelTests.swift
@@ -37,6 +37,10 @@ struct XDRemuxAppModelTests {
     @MainActor
     static func main() async throws {
         try await testImportDiscoversHEICFilesAndDeduplicates()
+        try await testConversionCategorizationMapsModeAndRootDirectories()
+        try await testCategorizationPreviewCopyAndDuplicateRerun()
+        try await testCategorizationDefaultsToEachSourceDirectory()
+        try await testCategorizationCancellationKeepsCancelledState()
         try await testImportedRowsStartWithEmptyThumbnailState()
         try await testOutputCollisionsAreMarkedBeforeConversion()
         try await testOutputPlanFlagsInvalidExistingOutputAsOverwriteRisk()
@@ -51,6 +55,114 @@ struct XDRemuxAppModelTests {
         try testSimplifiedProductSwitches()
         try testIndependentAppleFeatureConfiguration()
         print("XDRemuxAppModelTests passed")
+    }
+
+    @MainActor
+    private static func waitForCategorization(
+        _ viewModel: PhotoCategorizationViewModel,
+        timeout: Duration = .seconds(5)
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while viewModel.isBusy, clock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        try expect(!viewModel.isBusy, "categorization operation timed out")
+    }
+
+    @MainActor
+    private static func testConversionCategorizationMapsModeAndRootDirectories() async throws {
+        let root = try makeTempDirectory("conversion-categorize")
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+        let output = root.appendingPathComponent("output", isDirectory: true)
+        let portrait = root.appendingPathComponent("portrait.heic")
+        let unknown = root.appendingPathComponent("unknown.heic")
+        try Data("header-oplus_18-tail".utf8).write(to: portrait)
+        try Data("header-oplus_17179869184-tail".utf8).write(to: unknown)
+
+        let viewModel = XDRemuxViewModel()
+        viewModel.config.outputDirectory = output
+        viewModel.config.categorizeOutputByCaptureMode = true
+        _ = await viewModel.importFiles(from: [portrait, unknown])
+
+        let byName = Dictionary(uniqueKeysWithValues: viewModel.queue.map { ($0.inputURL.lastPathComponent, $0) })
+        try expect(byName["portrait.heic"]?.captureMode == .portrait, "conversion queue should expose the parsed capture mode")
+        try expect(byName["portrait.heic"]?.outputURL == output.appendingPathComponent("人像/portrait.heic"), "categorized conversion should use the mode directory")
+        try expect(byName["unknown.heic"]?.classificationStatus == .unknownFlags, "unknown flags should remain visible in the queue")
+        try expect(byName["unknown.heic"]?.outputURL == output.appendingPathComponent("unknown.heic"), "unclassified conversion should stay at the output root")
+    }
+
+    @MainActor
+    private static func testCategorizationPreviewCopyAndDuplicateRerun() async throws {
+        let root = try makeTempDirectory("standalone-categorize")
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+        let input = root.appendingPathComponent("input", isDirectory: true)
+        let output = input.appendingPathComponent("output", isDirectory: true)
+        try FileManager.default.createDirectory(at: input, withIntermediateDirectories: true)
+        try Data("header-oplus_18-tail".utf8).write(to: input.appendingPathComponent("portrait.heic"))
+        try Data("no user comment".utf8).write(to: input.appendingPathComponent("plain.jpg"))
+
+        let viewModel = PhotoCategorizationViewModel()
+        viewModel.addInputs([input])
+        viewModel.outputDirectory = output
+        viewModel.scan()
+        try await waitForCategorization(viewModel)
+
+        try expect(viewModel.state == .ready, "scan should produce a ready preview")
+        try expect(viewModel.items.count == 2, "preview should include both supported files")
+        try expect(viewModel.categorizedCount == 1 && viewModel.rootCount == 1, "preview counts should separate categorized and root items")
+        try expect(viewModel.modeSummary.contains("人像 1"), "preview should summarize counts by capture mode")
+        try expect(viewModel.items.contains { $0.destinationURL == output.appendingPathComponent("人像/portrait.heic") }, "preview should show the mode destination")
+        try expect(viewModel.items.contains { $0.destinationURL == output.appendingPathComponent("plain.jpg") }, "preview should show the root destination")
+
+        viewModel.copyPlannedFiles()
+        try await waitForCategorization(viewModel)
+        try expect(viewModel.state == .completed, "copy should complete")
+        try expect(FileManager.default.fileExists(atPath: output.appendingPathComponent("人像/portrait.heic").path), "copy should create the categorized file")
+        try expect(FileManager.default.fileExists(atPath: output.appendingPathComponent("plain.jpg").path), "copy should create the root file")
+
+        viewModel.scan()
+        try await waitForCategorization(viewModel)
+        try expect(viewModel.duplicateCount == 2, "a repeated scan should plan both files as duplicates")
+    }
+
+    @MainActor
+    private static func testCategorizationCancellationKeepsCancelledState() async throws {
+        let root = try makeTempDirectory("categorize-cancel")
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+        let input = root.appendingPathComponent("source.heic")
+        try Data("oplus_18".utf8).write(to: input)
+
+        let viewModel = PhotoCategorizationViewModel()
+        viewModel.addInputs([input])
+        viewModel.outputDirectory = root.appendingPathComponent("output", isDirectory: true)
+        viewModel.scan()
+        viewModel.cancel()
+        try await Task.sleep(for: .milliseconds(50))
+        try expect(viewModel.state == .cancelled, "cancel should leave scanning in the cancelled state")
+    }
+
+    @MainActor
+    private static func testCategorizationDefaultsToEachSourceDirectory() async throws {
+        let root = try makeTempDirectory("categorize-source-roots")
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+        let firstDirectory = root.appendingPathComponent("first", isDirectory: true)
+        let secondDirectory = root.appendingPathComponent("second", isDirectory: true)
+        try FileManager.default.createDirectory(at: firstDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: secondDirectory, withIntermediateDirectories: true)
+        let first = firstDirectory.appendingPathComponent("a.heic")
+        let second = secondDirectory.appendingPathComponent("b.heic")
+        try Data("oplus_18".utf8).write(to: first)
+        try Data("oplus_256".utf8).write(to: second)
+
+        let viewModel = PhotoCategorizationViewModel()
+        viewModel.addInputs([first, second])
+        viewModel.scan()
+        try await waitForCategorization(viewModel)
+
+        let destinations = Set(viewModel.items.map(\.destinationURL))
+        try expect(destinations.contains(firstDirectory.appendingPathComponent("人像/a.heic")), "first input should use its own parent as the classification root")
+        try expect(destinations.contains(secondDirectory.appendingPathComponent("专业模式/b.heic")), "second input should use its own parent as the classification root")
     }
 
     @MainActor

--- a/apps/macos/XDRemuxApp/XDRemuxApp.xcodeproj/project.pbxproj
+++ b/apps/macos/XDRemuxApp/XDRemuxApp.xcodeproj/project.pbxproj
@@ -7,27 +7,47 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		05412BD804CEF55569CAE7EF /* XDRemuxCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6145D033286A8F0E09BD373D /* XDRemuxCore.swift */; };
+		0F43851D4B592404CEAC2195 /* XDRemuxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02861545396D149E80797322 /* XDRemuxViewModel.swift */; };
+		31A8AD6AA40C358D2256BAE5 /* XDRemuxAppleFeatures in Frameworks */ = {isa = PBXBuildFile; productRef = 6161D9D9DDB6EF3D09CB1565 /* XDRemuxAppleFeatures */; };
 		4647AC898D992E985AED2E10 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78B033306E4AE0A568C34EBB /* VisualEffectView.swift */; };
 		64707094865385A92093E856 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B735B3E26375EEF954008A /* ContentView.swift */; };
+		6CFF6C897EE95ADA2AD61994 /* XDRemuxCore in Frameworks */ = {isa = PBXBuildFile; productRef = 55A425FEE6F8B9E96D90D2BC /* XDRemuxCore */; };
 		6FB05CECE182A7A46CEB0EAB /* XDRemuxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02861545396D149E80797322 /* XDRemuxViewModel.swift */; };
 		730715CA1E3ED4981267A175 /* XDRemuxApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F286B32FD9F916FBCC95124 /* XDRemuxApp.swift */; };
+		7D5AF2A3C8D8CD5B3E4C16ED /* PhotoCategorizationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD897E1D2BE4F3EDFDA6F539 /* PhotoCategorizationView.swift */; };
+		91B25CCEC94C36E1AD7C7ADF /* XDRemuxAppleFeatures in Frameworks */ = {isa = PBXBuildFile; productRef = 5387D4A93C45E1A2DD45B6EC /* XDRemuxAppleFeatures */; };
+		941FF8D05D7878AE38937FE3 /* XDRemuxCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6145D033286A8F0E09BD373D /* XDRemuxCore.swift */; };
+		A5D5F7315B5BAB773495946F /* XDRemuxAppConversionSmoke.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1F041FB2225C19F92B5072 /* XDRemuxAppConversionSmoke.swift */; };
+		A93949EEDCA56F8FE29266E3 /* XDRemuxCore in Frameworks */ = {isa = PBXBuildFile; productRef = 5A1D61EF06B4A13105FB0521 /* XDRemuxCore */; };
 		AA8B69637B6501859D143F53 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C71CCE0438700ED958A717D9 /* Assets.xcassets */; };
 		B66A0608AE01B0872E60A8B5 /* XDRemuxCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6145D033286A8F0E09BD373D /* XDRemuxCore.swift */; };
+		BAF5DCC3B6AB918C96092168 /* PhotoCategorizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84352F34EF49AA75EBBD028F /* PhotoCategorizationViewModel.swift */; };
+		C135C4E6E7337935172B1AAC /* PhotoCategorizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84352F34EF49AA75EBBD028F /* PhotoCategorizationViewModel.swift */; };
 		D9CEF12592FDD344F3F41A43 /* XDRemuxAppleFeatures in Frameworks */ = {isa = PBXBuildFile; productRef = F48590AC451F7304EEB000A2 /* XDRemuxAppleFeatures */; };
+		E099FE876A4F0E60B9D321F9 /* XDRemuxAppModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D38BBBE639FE49CE3858D2 /* XDRemuxAppModelTests.swift */; };
 		E1116493F99381D29CD7E8D7 /* AppStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C894071433802A3CCD2584E /* AppStrings.swift */; };
 		F5F31309C8B9E1444AFC858E /* XDRemuxCore in Frameworks */ = {isa = PBXBuildFile; productRef = 3F104D52F84F7132F954DC08 /* XDRemuxCore */; };
+		FA8D86BD040C149938C2778B /* AppStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C894071433802A3CCD2584E /* AppStrings.swift */; };
+		FBAE381A260B401C292D7ABC /* AppStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C894071433802A3CCD2584E /* AppStrings.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		02861545396D149E80797322 /* XDRemuxViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XDRemuxViewModel.swift; sourceTree = "<group>"; };
+		24D38BBBE639FE49CE3858D2 /* XDRemuxAppModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XDRemuxAppModelTests.swift; sourceTree = "<group>"; };
 		33E42AF90B0C23E087B64A36 /* XDRemuxApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = XDRemuxApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		385EDD63795756F2E8F07D00 /* proxdrtest */ = {isa = PBXFileReference; lastKnownFileType = folder; name = proxdrtest; path = ../../..; sourceTree = SOURCE_ROOT; };
+		4C1F041FB2225C19F92B5072 /* XDRemuxAppConversionSmoke.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XDRemuxAppConversionSmoke.swift; sourceTree = "<group>"; };
 		4C894071433802A3CCD2584E /* AppStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStrings.swift; sourceTree = "<group>"; };
 		6145D033286A8F0E09BD373D /* XDRemuxCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XDRemuxCore.swift; sourceTree = "<group>"; };
 		67B735B3E26375EEF954008A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		78B033306E4AE0A568C34EBB /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
+		84352F34EF49AA75EBBD028F /* PhotoCategorizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCategorizationViewModel.swift; sourceTree = "<group>"; };
+		8E527F1F8D6D31E4D93147BD /* XDRemuxAppModelTests */ = {isa = PBXFileReference; includeInIndex = 0; path = XDRemuxAppModelTests; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F286B32FD9F916FBCC95124 /* XDRemuxApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XDRemuxApp.swift; sourceTree = "<group>"; };
 		C71CCE0438700ED958A717D9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		D91FEFE1496703DB6B56AFC8 /* XDRemuxAppConversionSmoke */ = {isa = PBXFileReference; includeInIndex = 0; path = XDRemuxAppConversionSmoke; sourceTree = BUILT_PRODUCTS_DIR; };
+		FD897E1D2BE4F3EDFDA6F539 /* PhotoCategorizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCategorizationView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -40,13 +60,42 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		730CDBE8CE4E43B9FCB15ACE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A93949EEDCA56F8FE29266E3 /* XDRemuxCore in Frameworks */,
+				91B25CCEC94C36E1AD7C7ADF /* XDRemuxAppleFeatures in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7D64FFF3FA8351B5E9B98B9E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6CFF6C897EE95ADA2AD61994 /* XDRemuxCore in Frameworks */,
+				31A8AD6AA40C358D2256BAE5 /* XDRemuxAppleFeatures in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1DF0B83CD6A4294749BA3C29 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				4C1F041FB2225C19F92B5072 /* XDRemuxAppConversionSmoke.swift */,
+				24D38BBBE639FE49CE3858D2 /* XDRemuxAppModelTests.swift */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
 		47AC7D1C26659BEDC0B30E28 /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				33E42AF90B0C23E087B64A36 /* XDRemuxApp.app */,
+				D91FEFE1496703DB6B56AFC8 /* XDRemuxAppConversionSmoke */,
+				8E527F1F8D6D31E4D93147BD /* XDRemuxAppModelTests */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -57,6 +106,7 @@
 				C71CCE0438700ED958A717D9 /* Assets.xcassets */,
 				B7A0A209B126F278B11B4134 /* Packages */,
 				E7A4CA36C47CDA7399DC9F7B /* Sources */,
+				1DF0B83CD6A4294749BA3C29 /* Tests */,
 				47AC7D1C26659BEDC0B30E28 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -74,6 +124,8 @@
 			children = (
 				4C894071433802A3CCD2584E /* AppStrings.swift */,
 				67B735B3E26375EEF954008A /* ContentView.swift */,
+				FD897E1D2BE4F3EDFDA6F539 /* PhotoCategorizationView.swift */,
+				84352F34EF49AA75EBBD028F /* PhotoCategorizationViewModel.swift */,
 				78B033306E4AE0A568C34EBB /* VisualEffectView.swift */,
 				8F286B32FD9F916FBCC95124 /* XDRemuxApp.swift */,
 				6145D033286A8F0E09BD373D /* XDRemuxCore.swift */,
@@ -85,6 +137,26 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		50AFEF514F42441C1F5CA065 /* XDRemuxAppModelTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9E7AA06415D18C7009F3CBDF /* Build configuration list for PBXNativeTarget "XDRemuxAppModelTests" */;
+			buildPhases = (
+				C920CDAC59EE4DB9E6637158 /* Sources */,
+				7D64FFF3FA8351B5E9B98B9E /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = XDRemuxAppModelTests;
+			packageProductDependencies = (
+				55A425FEE6F8B9E96D90D2BC /* XDRemuxCore */,
+				6161D9D9DDB6EF3D09CB1565 /* XDRemuxAppleFeatures */,
+			);
+			productName = XDRemuxAppModelTests;
+			productReference = 8E527F1F8D6D31E4D93147BD /* XDRemuxAppModelTests */;
+			productType = "com.apple.product-type.tool";
+		};
 		AF3D641BAED6AD7AF7BA4842 /* XDRemuxApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 85CB44165E48F2F8587BA77E /* Build configuration list for PBXNativeTarget "XDRemuxApp" */;
@@ -105,6 +177,26 @@
 			productName = XDRemuxApp;
 			productReference = 33E42AF90B0C23E087B64A36 /* XDRemuxApp.app */;
 			productType = "com.apple.product-type.application";
+		};
+		EDD9D32390AF7FF03419EF01 /* XDRemuxAppConversionSmoke */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C4EF20FFDEA8D4E0811426AE /* Build configuration list for PBXNativeTarget "XDRemuxAppConversionSmoke" */;
+			buildPhases = (
+				D36C54929D96C4B67FEEED6D /* Sources */,
+				730CDBE8CE4E43B9FCB15ACE /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = XDRemuxAppConversionSmoke;
+			packageProductDependencies = (
+				5A1D61EF06B4A13105FB0521 /* XDRemuxCore */,
+				5387D4A93C45E1A2DD45B6EC /* XDRemuxAppleFeatures */,
+			);
+			productName = XDRemuxAppConversionSmoke;
+			productReference = D91FEFE1496703DB6B56AFC8 /* XDRemuxAppConversionSmoke */;
+			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */
 
@@ -138,6 +230,8 @@
 			projectRoot = "";
 			targets = (
 				AF3D641BAED6AD7AF7BA4842 /* XDRemuxApp */,
+				EDD9D32390AF7FF03419EF01 /* XDRemuxAppConversionSmoke */,
+				50AFEF514F42441C1F5CA065 /* XDRemuxAppModelTests */,
 			);
 		};
 /* End PBXProject section */
@@ -160,10 +254,34 @@
 			files = (
 				E1116493F99381D29CD7E8D7 /* AppStrings.swift in Sources */,
 				64707094865385A92093E856 /* ContentView.swift in Sources */,
+				7D5AF2A3C8D8CD5B3E4C16ED /* PhotoCategorizationView.swift in Sources */,
+				BAF5DCC3B6AB918C96092168 /* PhotoCategorizationViewModel.swift in Sources */,
 				4647AC898D992E985AED2E10 /* VisualEffectView.swift in Sources */,
 				730715CA1E3ED4981267A175 /* XDRemuxApp.swift in Sources */,
 				B66A0608AE01B0872E60A8B5 /* XDRemuxCore.swift in Sources */,
 				6FB05CECE182A7A46CEB0EAB /* XDRemuxViewModel.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C920CDAC59EE4DB9E6637158 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FBAE381A260B401C292D7ABC /* AppStrings.swift in Sources */,
+				C135C4E6E7337935172B1AAC /* PhotoCategorizationViewModel.swift in Sources */,
+				E099FE876A4F0E60B9D321F9 /* XDRemuxAppModelTests.swift in Sources */,
+				05412BD804CEF55569CAE7EF /* XDRemuxCore.swift in Sources */,
+				0F43851D4B592404CEAC2195 /* XDRemuxViewModel.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D36C54929D96C4B67FEEED6D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA8D86BD040C149938C2778B /* AppStrings.swift in Sources */,
+				A5D5F7315B5BAB773495946F /* XDRemuxAppConversionSmoke.swift in Sources */,
+				941FF8D05D7878AE38937FE3 /* XDRemuxCore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -187,6 +305,21 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.proxdr.XDRemuxApp;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		25519BD28AB27D8EDD9F3B68 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.proxdr.XDRemuxAppModelTests;
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -274,6 +407,21 @@
 			};
 			name = Debug;
 		};
+		31FAB81F83E9413C6AF6C056 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.proxdr.XDRemuxAppModelTests;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
 		5052B9F40473E2D5C1607B4F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -329,6 +477,36 @@
 			};
 			name = Release;
 		};
+		70CAD3FF2F9EA351ABCAECB0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.proxdr.XDRemuxAppConversionSmoke;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		BDE0A282D57E3D8FDCB623CA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.proxdr.XDRemuxAppConversionSmoke;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -350,6 +528,24 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
+		9E7AA06415D18C7009F3CBDF /* Build configuration list for PBXNativeTarget "XDRemuxAppModelTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				25519BD28AB27D8EDD9F3B68 /* Debug */,
+				31FAB81F83E9413C6AF6C056 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		C4EF20FFDEA8D4E0811426AE /* Build configuration list for PBXNativeTarget "XDRemuxAppConversionSmoke" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				70CAD3FF2F9EA351ABCAECB0 /* Debug */,
+				BDE0A282D57E3D8FDCB623CA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
@@ -363,6 +559,22 @@
 		3F104D52F84F7132F954DC08 /* XDRemuxCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = XDRemuxCore;
+		};
+		5387D4A93C45E1A2DD45B6EC /* XDRemuxAppleFeatures */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = XDRemuxAppleFeatures;
+		};
+		55A425FEE6F8B9E96D90D2BC /* XDRemuxCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = XDRemuxCore;
+		};
+		5A1D61EF06B4A13105FB0521 /* XDRemuxCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = XDRemuxCore;
+		};
+		6161D9D9DDB6EF3D09CB1565 /* XDRemuxAppleFeatures */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = XDRemuxAppleFeatures;
 		};
 		F48590AC451F7304EEB000A2 /* XDRemuxAppleFeatures */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/apps/macos/XDRemuxApp/project.yml
+++ b/apps/macos/XDRemuxApp/project.yml
@@ -25,3 +25,43 @@ targets:
       INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.utilities
       INFOPLIST_KEY_NSPrincipalClass: NSApplication
       GENERATE_INFOPLIST_FILE: YES
+  XDRemuxAppModelTests:
+    type: tool
+    platform: macOS
+    deploymentTarget: 15.0
+    sources:
+      - path: Sources
+        excludes:
+          - ContentView.swift
+          - PhotoCategorizationView.swift
+          - VisualEffectView.swift
+          - XDRemuxApp.swift
+      - path: Tests/XDRemuxAppModelTests.swift
+    dependencies:
+      - package: XDRemux
+        product: XDRemuxCore
+      - package: XDRemux
+        product: XDRemuxAppleFeatures
+    settings:
+      CODE_SIGN_IDENTITY: "-"
+  XDRemuxAppConversionSmoke:
+    type: tool
+    platform: macOS
+    deploymentTarget: 15.0
+    sources:
+      - path: Sources
+        excludes:
+          - ContentView.swift
+          - PhotoCategorizationView.swift
+          - PhotoCategorizationViewModel.swift
+          - VisualEffectView.swift
+          - XDRemuxApp.swift
+          - XDRemuxViewModel.swift
+      - path: Tests/XDRemuxAppConversionSmoke.swift
+    dependencies:
+      - package: XDRemux
+        product: XDRemuxCore
+      - package: XDRemux
+        product: XDRemuxAppleFeatures
+    settings:
+      CODE_SIGN_IDENTITY: "-"

--- a/xdremux/README.md
+++ b/xdremux/README.md
@@ -8,5 +8,10 @@ This directory contains compatibility and non-SwiftPM converter entry points.
   the root package executable.
 - `python/` is the cross-platform Python CLI path.
 
+Both current CLIs support standalone shooting-mode categorization with
+`categorize --input ... --output-dir ...`. Their `batch` commands use the
+`--categorize` switch to write converted files under the same Chinese mode
+directories. Single-file `convert` does not accept that switch.
+
 Reusable Swift implementation lives under `Sources/`. Graphical app shells are
 intentionally kept outside this directory under `apps/`.

--- a/xdremux/python/XDRemux.py
+++ b/xdremux/python/XDRemux.py
@@ -6,11 +6,13 @@ with pillow-heif + Pillow + numpy.
 
 Usage:
     xdremux.py convert --input <file.heic> [--output <out.heic>] [--debug-dir <dir>] [--oppo-compatible]
-    xdremux.py batch --input-dir <dir> [--output-dir <dir>] [--glob <pattern>] [--oppo-compatible]
+    xdremux.py batch --input-dir <dir> [--output-dir <dir>] [--glob <pattern>] [--oppo-compatible] [--categorize]
+    xdremux.py categorize --input <file-or-dir> [--input <file-or-dir> ...] --output-dir <dir> [--jobs <n>] [--dry-run]
 """
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -18,7 +20,7 @@ if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
     __package__ = "xdremux.python"
 
-from . import container, edr, iso21496
+from . import categorize, container, edr, iso21496
 
 
 def cmd_convert(args: argparse.Namespace) -> int:
@@ -157,9 +159,14 @@ def cmd_batch(args: argparse.Namespace) -> int:
 
     glob_pattern = args.glob or "*.heic"
     files = sorted(input_dir.glob(glob_pattern))
+    categorized_outputs = (
+        categorize.batch_destinations(files, output_dir)
+        if getattr(args, "categorize_output", False)
+        else {}
+    )
     converted, failed = 0, 0
     for f in files:
-        out = output_dir / f.name
+        out = categorized_outputs.get(f, output_dir / f.name)
         args2 = argparse.Namespace(input=str(f), output=str(out),
                                     debug_dir=args.debug_dir,
                                     oppo_compat=args.oppo_compat,
@@ -172,6 +179,39 @@ def cmd_batch(args: argparse.Namespace) -> int:
             failed += 1
 
     print(f"batch complete: {converted} converted, {failed} failed")
+    return 0 if failed == 0 else 1
+
+
+def cmd_categorize(args: argparse.Namespace) -> int:
+    """Copy photos into shooting-mode directories without modifying sources."""
+    try:
+        plan = categorize.make_plan([Path(value) for value in args.input], Path(args.output_dir))
+    except (OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    results = categorize.execute_plan(plan, jobs=args.jobs, dry_run=args.dry_run)
+    for item in results:
+        mode = (
+            item.classification.mode.folder_name
+            if item.classification.mode
+            else f"根目录 ({item.classification.status})"
+        )
+        detail = f" error={item.error}" if item.error else ""
+        print(f"{item.disposition} [{mode}] {item.source} -> {item.destination}{detail}")
+    copied = sum(item.disposition == "copied" for item in results)
+    dry_run = sum(item.disposition == "dry-run" for item in results)
+    duplicate = sum(item.disposition == "duplicate" for item in results)
+    categorized = sum(item.classification.mode is not None for item in results)
+    root = len(results) - categorized
+    failed = sum(
+        item.disposition == "failed"
+        or item.classification.status in {"malformed-user-comment", "unreadable-image"}
+        for item in results
+    )
+    print(
+        f"categorize complete: {categorized} categorized, {root} kept at root, "
+        f"{copied} copied, {dry_run} dry-run, {duplicate} duplicate, {failed} failed"
+    )
     return 0 if failed == 0 else 1
 
 
@@ -209,6 +249,15 @@ def build_parser() -> argparse.ArgumentParser:
                    help=argparse.SUPPRESS)
     b.add_argument("--reencode", action="store_true", dest="reencode",
                    help="Decode and re-encode the base image instead of preserving source HEVC")
+    b.add_argument("--categorize", action="store_true", dest="categorize_output",
+                   help="Write outputs under Chinese shooting-mode directories")
+
+    category = sub.add_parser("categorize")
+    category.add_argument("--input", action="append", required=True,
+                          help="Input photo or directory; may be repeated")
+    category.add_argument("--output-dir", required=True)
+    category.add_argument("--jobs", type=int, default=min(os.cpu_count() or 1, 4))
+    category.add_argument("--dry-run", action="store_true")
     return parser
 
 
@@ -219,6 +268,10 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_convert(args)
     elif args.command == "batch":
         return cmd_batch(args)
+    elif args.command == "categorize":
+        if args.jobs < 1:
+            parser.error("--jobs must be greater than zero")
+        return cmd_categorize(args)
     else:
         parser.print_help()
         return 1

--- a/xdremux/python/categorize.py
+++ b/xdremux/python/categorize.py
@@ -1,0 +1,312 @@
+"""OPPO UserComment shooting-mode categorization shared by the Python CLI."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import struct
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, replace
+from enum import Enum
+from pathlib import Path
+from typing import Iterable
+
+
+class CaptureMode(Enum):
+    MASTER = ("master", "大师模式", 0x100000000)
+    RICOH_GR = ("ricoh-gr", "RICOH GR", 0x80000000)
+    PROFESSIONAL = ("professional", "专业模式", 0x100)
+    PORTRAIT = ("portrait", "人像", 0x10)
+    NIGHT = ("night", "夜景", 0x800)
+    PANORAMA = ("panorama", "全景", 0x4)
+    TIME_LAPSE = ("time-lapse", "延时摄影", 0x8)
+    ULTRA_HIGH_RESOLUTION = ("ultra-high-resolution", "超清", 0x2000)
+    ID_PHOTO = ("id-photo", "证件照", 0x4000)
+    STICKER = ("sticker", "贴纸", 0x200)
+    ENHANCED_TEXT = ("enhanced-text", "超级文本", 0x1000)
+    GROUP_PHOTO = ("group-photo", "合影", 0x400000)
+    DOUBLE_EXPOSURE = ("double-exposure", "双重曝光", 0x8000)
+    BEAUTY = ("beauty", "美颜", 0x2)
+    NORMAL = ("normal", "普通拍照", 0)
+
+    def __init__(self, key: str, folder_name: str, bit: int) -> None:
+        self.key = key
+        self.folder_name = folder_name
+        self.bit = bit
+
+
+MODE_PRIORITY = tuple(mode for mode in CaptureMode if mode is not CaptureMode.NORMAL)
+KNOWN_FLAGS_MASK = 0
+for _bit in (
+    0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
+    0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000, 0x8000,
+    0x10000, 0x20000, 0x40000, 0x80000, 0x100000, 0x200000,
+    0x400000, 0x800000, 0x1000000, 0x2000000, 0x4000000,
+    0x8000000, 0x10000000, 0x20000000, 0x40000000, 0x80000000,
+    0x100000000, 0x200000000, 0x4000000000000000,
+):
+    KNOWN_FLAGS_MASK |= _bit
+
+SUPPORTED_EXTENSIONS = {".heic", ".heif", ".jpg", ".jpeg"}
+COMMENT_PATTERN = re.compile(rb"(?:Oplus|Oppo)_[0-9]+", re.IGNORECASE)
+JSON_TAG_PATTERN = re.compile(rb'"oplustag"\s*:\s*"?([0-9]+)"?', re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class Classification:
+    raw_user_comment: str | None
+    tag_flags: int | None
+    unknown_flags: int
+    mode: CaptureMode | None
+    status: str
+
+
+@dataclass(frozen=True)
+class CategorizationItem:
+    source: Path
+    destination: Path
+    classification: Classification
+    disposition: str
+    error: str | None = None
+
+
+def classify_user_comment(raw: str | None) -> Classification:
+    if raw is None or not raw.strip():
+        return Classification(raw, None, 0, None, "missing-user-comment")
+    normalized = raw.strip()
+    flags = _parse_flags(normalized)
+    if flags is None:
+        return Classification(normalized, None, 0, None, "malformed-user-comment")
+    unknown = flags & ~KNOWN_FLAGS_MASK
+    mode = next((candidate for candidate in MODE_PRIORITY if flags & candidate.bit), None)
+    if mode is None and unknown:
+        return Classification(normalized, flags, unknown, None, "unknown-flags")
+    return Classification(normalized, flags, unknown, mode or CaptureMode.NORMAL, "categorized")
+
+
+def classify_path(path: Path) -> Classification:
+    try:
+        raw = extract_user_comment(path)
+    except OSError:
+        return Classification(None, None, 0, None, "unreadable-image")
+    return classify_user_comment(raw)
+
+
+def extract_user_comment(path: Path) -> str | None:
+    exif_bytes: bytes | None = None
+    suffix = path.suffix.lower()
+    try:
+        if suffix in {".heic", ".heif"}:
+            from pillow_heif import open_heif
+            heif = open_heif(str(path), convert_hdr_to_8bit=False)
+            primary = heif[0] if hasattr(heif, "__getitem__") else heif
+            exif_bytes = primary.info.get("exif")
+        else:
+            from PIL import Image
+            with Image.open(path) as image:
+                exif_bytes = image.info.get("exif")
+                if exif_bytes is None:
+                    exif = image.getexif()
+                    try:
+                        value = exif.get_ifd(0x8769).get(0x9286)
+                    except (KeyError, TypeError):
+                        value = None
+                    decoded = _decode_user_comment_value(value)
+                    if decoded:
+                        return decoded
+    except Exception:
+        exif_bytes = None
+
+    if exif_bytes:
+        decoded = _extract_tiff_user_comment(exif_bytes)
+        if decoded:
+            return decoded
+
+    data = path.read_bytes()
+    decoded = _extract_tiff_user_comment(data)
+    if decoded:
+        return decoded
+    match = COMMENT_PATTERN.search(data)
+    if match:
+        return match.group(0).decode("ascii")
+    json_match = JSON_TAG_PATTERN.search(data)
+    if json_match:
+        return '{"oplustag":"' + json_match.group(1).decode("ascii") + '"}'
+    return None
+
+
+def collect_inputs(inputs: Iterable[Path], output_dir: Path) -> list[Path]:
+    excluded = output_dir.resolve(strict=False)
+    collected: dict[str, Path] = {}
+    for source in inputs:
+        if not source.exists():
+            raise FileNotFoundError(f"input not found: {source}")
+        candidates = [source] if source.is_file() else source.rglob("*")
+        for candidate in candidates:
+            resolved = candidate.resolve(strict=False)
+            if resolved == excluded or excluded in resolved.parents:
+                continue
+            if candidate.is_file() and candidate.suffix.lower() in SUPPORTED_EXTENSIONS:
+                collected[str(resolved)] = candidate
+    return [collected[key] for key in sorted(collected)]
+
+
+def make_plan(inputs: Iterable[Path], output_dir: Path) -> list[CategorizationItem]:
+    reserved: dict[Path, tuple[Path, str]] = {}
+    items: list[CategorizationItem] = []
+    for source in collect_inputs(inputs, output_dir):
+        classification = classify_path(source)
+        directory = output_dir / classification.mode.folder_name if classification.mode else output_dir
+        source_digest = _sha256(source)
+        sequence = 1
+        while True:
+            destination = _sequenced_destination(directory, source.name, sequence)
+            prior = reserved.get(destination)
+            if prior:
+                if prior[1] == source_digest:
+                    items.append(CategorizationItem(source, prior[0], classification, "duplicate"))
+                    break
+                sequence += 1
+                continue
+            if destination.exists():
+                if _files_match(source, destination):
+                    reserved[destination] = (destination, source_digest)
+                    items.append(CategorizationItem(source, destination, classification, "duplicate"))
+                    break
+                sequence += 1
+                continue
+            reserved[destination] = (destination, source_digest)
+            items.append(CategorizationItem(source, destination, classification, "copy"))
+            break
+    return items
+
+
+def execute_plan(items: list[CategorizationItem], jobs: int = 4, dry_run: bool = False) -> list[CategorizationItem]:
+    def execute(item: CategorizationItem) -> CategorizationItem:
+        if item.disposition == "duplicate":
+            return item
+        if dry_run:
+            return replace(item, disposition="dry-run")
+        try:
+            _copy_atomically(item.source, item.destination)
+            return replace(item, disposition="copied")
+        except OSError as exc:
+            return replace(item, disposition="failed", error=str(exc))
+
+    with ThreadPoolExecutor(max_workers=max(1, jobs)) as pool:
+        return list(pool.map(execute, items))
+
+
+def batch_destinations(files: list[Path], output_dir: Path) -> dict[Path, Path]:
+    reserved: set[Path] = set()
+    result: dict[Path, Path] = {}
+    for source in sorted(files, key=lambda item: str(item.resolve(strict=False))):
+        classification = classify_path(source)
+        directory = output_dir / classification.mode.folder_name if classification.mode else output_dir
+        sequence = 1
+        while True:
+            destination = _sequenced_destination(directory, source.with_suffix(".heic").name, sequence)
+            if destination not in reserved:
+                reserved.add(destination)
+                result[source] = destination
+                break
+            sequence += 1
+    return result
+
+
+def _parse_flags(raw: str) -> int | None:
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, dict):
+            value = next((value for key, value in parsed.items() if key.lower() == "oplustag"), None)
+            if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                return value
+            if isinstance(value, str) and value.strip().isdigit():
+                return int(value.strip())
+    except (ValueError, TypeError):
+        pass
+    normalized = raw.replace("\x00", "")
+    match = re.search(r"(?:oplus|oppo)_([0-9]+)", normalized, re.IGNORECASE)
+    return int(match.group(1)) if match else None
+
+
+def _decode_user_comment_value(value: object) -> str | None:
+    if isinstance(value, str):
+        return value.strip("\x00")
+    if isinstance(value, bytes):
+        payload = value[8:] if len(value) >= 8 else value
+        return payload.decode("utf-8", errors="replace").strip("\x00")
+    return None
+
+
+def _extract_tiff_user_comment(exif_bytes: bytes) -> str | None:
+    data = exif_bytes
+    if len(data) >= 10 and data[:4] == b"\x00\x00\x00\x06" and data[4:10] == b"Exif\x00\x00":
+        data = data[10:]
+    elif data.startswith(b"Exif\x00\x00"):
+        data = data[6:]
+    if len(data) < 8 or data[:2] not in {b"II", b"MM"}:
+        return None
+    endian = "<" if data[:2] == b"II" else ">"
+    if struct.unpack_from(endian + "H", data, 2)[0] != 42:
+        return None
+    pending = [struct.unpack_from(endian + "I", data, 4)[0]]
+    visited: set[int] = set()
+    while pending:
+        offset = pending.pop()
+        if offset in visited or offset + 2 > len(data):
+            continue
+        visited.add(offset)
+        count = struct.unpack_from(endian + "H", data, offset)[0]
+        if count > 4096:
+            return None
+        for index in range(count):
+            entry = offset + 2 + index * 12
+            if entry + 12 > len(data):
+                return None
+            tag, field_type = struct.unpack_from(endian + "HH", data, entry)
+            value_count = struct.unpack_from(endian + "I", data, entry + 4)[0]
+            value_offset = struct.unpack_from(endian + "I", data, entry + 8)[0]
+            if tag in {0x8769, 0x8825}:
+                pending.append(value_offset)
+            if tag == 0x9286 and field_type == 7:
+                start = entry + 8 if value_count <= 4 else value_offset
+                end = start + value_count
+                if end <= len(data):
+                    return _decode_user_comment_value(data[start:end])
+    return None
+
+
+def _sequenced_destination(directory: Path, name: str, sequence: int) -> Path:
+    if sequence == 1:
+        return directory / name
+    source = Path(name)
+    return directory / f"{source.stem} ({sequence}){source.suffix}"
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _files_match(left: Path, right: Path) -> bool:
+    return left.stat().st_size == right.stat().st_size and _sha256(left) == _sha256(right)
+
+
+def _copy_atomically(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=".xdremux-categorize-", dir=destination.parent)
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        shutil.copy2(source, temporary)
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

- add shared Swift shooting-mode categorization for OPPO/OnePlus UserComment metadata
- add matching Python `categorize` support and `batch --categorize` output routing
- add a macOS App categorization workspace plus categorized conversion output
- document the Swift, Python, batch, and App workflows in Chinese and English
- restore the public documentation and Swift App architecture contract tests referenced by CI
- build the public macOS App scheme directly in CI without code signing

## Behavior

Standalone categorization recursively scans HEIC, HEIF, and JPEG inputs and copies them into fixed Chinese shooting-mode directories. Missing or unrecognized primary modes remain at the output root. Same-name duplicates use SHA-256 comparison and stable numbered destinations, and copies land atomically.

Swift and Python consume the same contract matrix for all supported primary modes, precedence rules, supplemental flags, parsing forms, malformed input, unknown flags, and 64-bit values. Batch conversion uses the concise `--categorize` switch; single-file `convert` rejects it.

This feature classifies local EXIF/UserComment data only and does not claim OPPO Gallery device recognition.

## Validation

- repository completion gate passed for commit `eab1047cae0e5200cdcfe59170de64001ec4218d`
- Swift package regression suite: 49 tests, 1 pre-existing private-fixture skip, 0 failures
- Python categorization and bilingual documentation regression tests
- macOS App build, categorization model integration tests, and real conversion smoke
- Swift/Python cross-implementation comparison over five real photos, including relative paths, statuses, copied SHA-256 values, dry-run behavior, and idempotent reruns
- real Swift and Python production batch conversions with `--categorize`, preserving UserComment and producing readable HEIC output
