### PR TITLE
Harden container parsing, failure paths, and public repo contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,6 @@ on:
       - "Tests/validation/test_agent_completion_gate.py"
       - ".github/workflows/**"
 
-env:
-  XDREMUX_LANGUAGE: en
-
 jobs:
   macos:
     runs-on: macos-latest
@@ -101,25 +98,24 @@ jobs:
             echo "APPLE_PORTRAIT_RESULT=Not configured" >> "$GITHUB_ENV"
             exit 0
           fi
-          export XDREMUX_HELPER_DIRECTORY="$PWD/.build/debug"
-          echo "::group::Fixture conversions (JSONL)"
-          .build/debug/xdremux convert --language en --format jsonl \
+          echo "::group::Fixture conversions"
+          .build/debug/xdremux convert \
             --input "$FIXTURE_ROOT/standard.heic" --output artifacts/fixtures/standard.heic \
-            > artifacts/fixtures/standard.jsonl 2> artifacts/fixtures/standard.stderr
+            > artifacts/fixtures/standard.log 2> artifacts/fixtures/standard.stderr
           echo "STANDARD_FIXTURE_RESULT=Passed" >> "$GITHUB_ENV"
-          .build/debug/xdremux convert --language en --format jsonl --oppo-compatible \
+          .build/debug/xdremux convert --oppo-compatible \
             --input "$FIXTURE_ROOT/oppo.heic" --output artifacts/fixtures/oppo.heic \
-            > artifacts/fixtures/oppo.jsonl 2> artifacts/fixtures/oppo.stderr
+            > artifacts/fixtures/oppo.log 2> artifacts/fixtures/oppo.stderr
           echo "OPPO_FIXTURE_RESULT=Passed" >> "$GITHUB_ENV"
-          .build/debug/xdremux-dev convert --language en --format jsonl --apple-photographic-styles \
-            --diagnostics-dir artifacts/diagnostics/apple-styles \
+          .build/debug/xdremux convert --apple-photographic-styles \
+            --debug-dir artifacts/diagnostics/apple-styles \
             --input "$FIXTURE_ROOT/apple-styles.heic" --output artifacts/fixtures/apple-styles.heic \
-            > artifacts/fixtures/apple-styles.jsonl 2> artifacts/fixtures/apple-styles.stderr
+            > artifacts/fixtures/apple-styles.log 2> artifacts/fixtures/apple-styles.stderr
           echo "APPLE_STYLES_RESULT=Passed" >> "$GITHUB_ENV"
-          .build/debug/xdremux-dev convert --language en --format jsonl --apple-portrait \
-            --diagnostics-dir artifacts/diagnostics/apple-portrait \
+          .build/debug/xdremux convert --apple-portrait \
+            --debug-dir artifacts/diagnostics/apple-portrait \
             --input "$FIXTURE_ROOT/apple-portrait.heic" --output artifacts/fixtures/apple-portrait.heic \
-            > artifacts/fixtures/apple-portrait.jsonl 2> artifacts/fixtures/apple-portrait.stderr
+            > artifacts/fixtures/apple-portrait.log 2> artifacts/fixtures/apple-portrait.stderr
           echo "APPLE_PORTRAIT_RESULT=Passed" >> "$GITHUB_ENV"
           echo "::endgroup::"
 
@@ -130,15 +126,14 @@ jobs:
             echo "CONTAINER_VALIDATION_RESULT=Not configured" >> "$GITHUB_ENV"
             exit 0
           fi
-          export XDREMUX_HELPER_DIRECTORY="$PWD/.build/debug"
           echo "::group::Container validation"
           python3 Tests/validation/verify_swift_cli_sample.py \
             --validate-only --input artifacts/fixtures/standard.heic --expected-pixel-format 444f
           python3 Tests/validation/verify_swift_cli_sample.py \
             --validate-only --input artifacts/fixtures/oppo.heic --expected-pixel-format 420f
-          .build/debug/xdremux-dev validate-apple --input artifacts/fixtures/apple-styles.heic \
+          .build/debug/xdremux validate-apple --input artifacts/fixtures/apple-styles.heic \
             > artifacts/fixtures/apple-styles-validation.json
-          .build/debug/xdremux-dev validate-portrait --input artifacts/fixtures/apple-portrait.heic \
+          .build/debug/xdremux validate-portrait --input artifacts/fixtures/apple-portrait.heic \
             > artifacts/fixtures/apple-portrait-validation.json
           echo "::endgroup::"
           echo "CONTAINER_VALIDATION_RESULT=Passed" >> "$GITHUB_ENV"

--- a/.gitignore
+++ b/.gitignore
@@ -27,12 +27,8 @@ xdremux_py/
 CLAUDE.md
 HANDOFF.md
 Makefile
-docs/
 skills/
 **/MIGRATION_PLAN.md
-scripts/agent_completion_gate.py
-Tests/validation/test_agent_completion_gate.py
-Tests/validation/verify_swift_cli_sample.py
 apk_analysis_results/
 evals/
 handoff_package/

--- a/Sources/XDRemuxAppleFeatures/PhotographicStyles/ApplePhotographicStylesPipeline.swift
+++ b/Sources/XDRemuxAppleFeatures/PhotographicStyles/ApplePhotographicStylesPipeline.swift
@@ -297,7 +297,7 @@ package enum ApplePhotographicStylesPipeline {
             ?? preview.dngOrientation
         guard (1...8).contains(orientation) else {
             throw CLIError.invalidContainer(
-                "RAW embedded PreviewImage has unsupported EXIF orientation (orientation)"
+                "RAW embedded PreviewImage has unsupported EXIF orientation \(orientation)"
             )
         }
         let sourceWidth = (properties[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue
@@ -310,7 +310,7 @@ package enum ApplePhotographicStylesPipeline {
               sourceHeight == gainStorageHeight * 2 else {
             throw CLIError.invalidContainer(
                 "RAW embedded ISO Gain Map is not half-resolution in primary storage geometry: "
-                    + "primary=(sourceWidth)x(sourceHeight) gain=(gainStorageWidth)x(gainStorageHeight)"
+                    + "primary=\(sourceWidth)x\(sourceHeight) gain=\(gainStorageWidth)x\(gainStorageHeight)"
             )
         }
 
@@ -324,7 +324,8 @@ package enum ApplePhotographicStylesPipeline {
         guard [gainWidth, gainHeight] == expectedPresentationSize else {
             throw CLIError.invalidContainer(
                 "RAW embedded ISO Gain Map orientation produced unexpected geometry: "
-                    + "got=(gainWidth)x(gainHeight) expected=(expectedPresentationSize[0])x(expectedPresentationSize[1])"
+                    + "got=\(gainWidth)x\(gainHeight) "
+                    + "expected=\(expectedPresentationSize[0])x\(expectedPresentationSize[1])"
             )
         }
 
@@ -3199,14 +3200,14 @@ package enum ApplePhotographicStylesPipeline {
                 throw CLIError.invalidContainer("\(owner) semantic merge item graph is incomplete")
             }
             let refs = parseISOBMFFIRefs(data, iref)
-            let ipma = parseISOBMFFIPMA(data, ipmaBox)
+            let ipma = try parseISOBMFFIPMA(data, ipmaBox)
             return ParsedFile(
                 data: data,
                 top: top,
                 meta: meta,
                 mdat: mdat,
                 children: children,
-                primaryID: parseISOBMFFPITM(data, pitm),
+                primaryID: try parseISOBMFFPITM(data, pitm),
                 toneMapID: toneMapID,
                 items: itemInfo.items,
                 iinfVersion: itemInfo.version,
@@ -3555,7 +3556,7 @@ package enum ApplePhotographicStylesPipeline {
         let iprp = try required("iprp")
         let sourceIDAT = children.first(where: { $0.type == "idat" })
         let sourceIREF = children.first(where: { $0.type == "iref" })
-        let primaryID = parseISOBMFFPITM(source, pitm)
+        let primaryID = try parseISOBMFFPITM(source, pitm)
         let itemInfo = parseISOBMFFItemInfos(source, iinf)
         let ilocEntries = try parseISOBMFFILoc(source, iloc)
         let refsInfo = parseISOBMFFIRefs(source, sourceIREF)
@@ -3576,7 +3577,7 @@ package enum ApplePhotographicStylesPipeline {
         ).first(where: { $0.type == "ipma" }) else {
             throw CLIError.invalidContainer("Photographic Styles writer requires ipma")
         }
-        let sourceIPMA = parseISOBMFFIPMA(source, ipmaBox)
+        let sourceIPMA = try parseISOBMFFIPMA(source, ipmaBox)
         let properties = try parseISOBMFFIPCOPropertyInfos(source, iprp)
         let propertyByIndex = Dictionary(uniqueKeysWithValues: properties.map { ($0.index, $0) })
         let primaryColorIndex = sourceIPMA.entries.first(where: { $0.itemID == primaryID })?
@@ -3920,7 +3921,7 @@ package enum ApplePhotographicStylesPipeline {
                 if !portraitWritten {
                     portraitUnavailableReason = "required OPPO portrait depth bundle is unavailable"
                 }
-            } catch {
+            } catch let error as CLIError {
                 let sourceExtension = inputURL.pathExtension.lowercased()
                 if sourceExtension == "jpg" || sourceExtension == "jpeg" {
                     // JPEG enters this product path only through the validated
@@ -3928,7 +3929,11 @@ package enum ApplePhotographicStylesPipeline {
                     // HEIC converter after that bridge fails.
                     throw error
                 }
-                portraitUnavailableReason = String(describing: error)
+                // Degrading to styles-only is correct only when the input is not
+                // a portrait at all. Any other portrait failure is a real defect
+                // and must not be laundered into an "unavailable" note.
+                guard case .portraitPrerequisitesMissing(let reason) = error else { throw error }
+                portraitUnavailableReason = reason
             }
         }
 
@@ -4037,9 +4042,20 @@ package enum ApplePhotographicStylesPipeline {
             evidenceContainer = FileManager.default.temporaryDirectory
                 .appendingPathComponent("xdremux-photographic-styles-\(runToken)", isDirectory: true)
         }
+        // Scratch evidence is disposable only when the run succeeds. On failure it
+        // is the sole record of what the pipeline produced, so keep it and say
+        // where it is instead of deleting the one artifact worth inspecting.
+        var succeeded = false
         defer {
-            if !persistEvidence {
+            if persistEvidence {
+                // Caller asked for a durable --debug-dir; nothing to clean up.
+            } else if succeeded {
                 try? FileManager.default.removeItem(at: evidenceContainer)
+            } else if FileManager.default.fileExists(atPath: evidenceContainer.path) {
+                FileHandle.standardError.write(Data(
+                    ("note: Photographic Styles evidence retained for diagnosis at "
+                        + "\(evidenceContainer.path)\n").utf8
+                ))
             }
         }
         let evidenceDirectory = evidenceContainer
@@ -4451,6 +4467,7 @@ package enum ApplePhotographicStylesPipeline {
                 options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
             ).write(to: evidenceContainer.appendingPathComponent("latest.json"), options: .atomic)
         }
+        succeeded = true
     }
 
     private struct StylesValidationResult {
@@ -4476,7 +4493,7 @@ package enum ApplePhotographicStylesPipeline {
             throw CLIError.invalidContainer("Styles validation: required item graph boxes are missing")
         }
         let idat = children.first(where: { $0.type == "idat" })
-        let primaryID = parseISOBMFFPITM(data, pitm)
+        let primaryID = try parseISOBMFFPITM(data, pitm)
         let items = parseISOBMFFItemInfos(data, iinf).items
         let locations = try parseISOBMFFILoc(data, iloc)
         let locationByID = Dictionary(uniqueKeysWithValues: locations.map { ($0.itemID, $0) })

--- a/Sources/XDRemuxAppleFeatures/Portrait/PortraitConversionPipeline.swift
+++ b/Sources/XDRemuxAppleFeatures/Portrait/PortraitConversionPipeline.swift
@@ -643,7 +643,7 @@ package enum PortraitConversionPipeline {
         do {
             blocks = try LHDRExtractor.portraitBlocks(from: inputData)
         } catch {
-            throw CLIError.invalidContainer(
+            throw CLIError.portraitPrerequisitesMissing(
                 "--apple-portrait requires an OPPO private tail containing rear.depth"
             )
         }
@@ -651,7 +651,7 @@ package enum PortraitConversionPipeline {
               let srcImage = blocks["src.image"],
               let rearDepthConfig = blocks["rear.depth.config"],
               let compressedDepth = blocks["rear.depth"] else {
-            throw CLIError.invalidContainer(
+            throw CLIError.portraitPrerequisitesMissing(
                 "--apple-portrait requires OPPO portrait UserComment, src.image, and rear.depth"
             )
         }
@@ -1059,29 +1059,54 @@ package enum PortraitConversionPipeline {
         return value & 65_536 != 0
     }
 
+    private static let zstdTimeout: TimeInterval = 120
+
+    /// A GUI launch inherits a minimal PATH that omits both Homebrew prefixes,
+    /// so the well-known install locations are probed before PATH itself.
+    private static func locateZstd() -> URL? {
+        let fileManager = FileManager.default
+        let wellKnown = ["/usr/bin/zstd", "/opt/homebrew/bin/zstd", "/usr/local/bin/zstd"]
+        for candidate in wellKnown where fileManager.isExecutableFile(atPath: candidate) {
+            return URL(fileURLWithPath: candidate)
+        }
+        let path = ProcessInfo.processInfo.environment["PATH"] ?? ""
+        for directory in path.split(separator: ":") where !directory.isEmpty {
+            let candidate = URL(fileURLWithPath: String(directory), isDirectory: true)
+                .appendingPathComponent("zstd")
+            if fileManager.isExecutableFile(atPath: candidate.path) { return candidate }
+        }
+        return nil
+    }
+
     private static func decompressZstd(_ data: Data) throws -> Data {
+        guard let zstd = locateZstd() else {
+            throw CLIError.invalidContainer(
+                "--apple-portrait requires the zstd command-line tool; install it with "
+                    + "`brew install zstd`"
+            )
+        }
         let directory = FileManager.default.temporaryDirectory
         let input = directory.appendingPathComponent("xdremux-depth-\(UUID().uuidString).zst")
         defer { try? FileManager.default.removeItem(at: input) }
         try data.write(to: input, options: .atomic)
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = ["zstd", "-d", "-q", "-c", input.path]
-        let output = Pipe()
-        let errors = Pipe()
-        process.standardOutput = output
-        process.standardError = errors
-        do { try process.run() } catch {
-            throw CLIError.invalidContainer("--apple-portrait requires the zstd command-line tool")
+        let result = try AppleNativeToolchain.run(
+            zstd,
+            arguments: ["-d", "-q", "-c", input.path],
+            timeout: zstdTimeout
+        )
+        guard !result.timedOut else {
+            throw CLIError.invalidContainer(
+                "zstd depth decompression timed out after \(Int(zstdTimeout))s"
+            )
         }
-        let decoded = output.fileHandleForReading.readDataToEndOfFile()
-        let errorData = errors.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else {
-            let message = String(data: errorData, encoding: .utf8) ?? "zstd failed"
-            throw CLIError.invalidContainer(message.trimmingCharacters(in: .whitespacesAndNewlines))
+        guard result.status == 0 else {
+            let message = String(data: result.stderr, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            throw CLIError.invalidContainer(
+                message.isEmpty ? "zstd depth decompression failed (exit \(result.status))" : message
+            )
         }
-        return decoded
+        return result.stdout
     }
 
     private static func registerMetadataNamespace(
@@ -3560,7 +3585,7 @@ package func transplantPortraitBaseAndGainPayloads(
               let iprp = children.first(where: { $0.type == "iprp" }) else {
             throw CLIError.invalidContainer("\(owner) item graph is incomplete")
         }
-        let primary = parseISOBMFFPITM(data, pitm)
+        let primary = try parseISOBMFFPITM(data, pitm)
         let infos = parseISOBMFFItemInfos(data, iinf).items
         guard let tmap = infos.first(where: { $0.type == "tmap" })?.itemID else {
             throw CLIError.invalidContainer("\(owner) has no tmap")
@@ -3584,7 +3609,7 @@ package func transplantPortraitBaseAndGainPayloads(
         guard let ipmaBox = isobmffBoxes(in: data, start: iprp.dataStart, end: iprp.dataEnd).first(where: { $0.type == "ipma" }) else {
             throw CLIError.invalidContainer("\(owner) has no ipma")
         }
-        let ipma = parseISOBMFFIPMA(data, ipmaBox)
+        let ipma = try parseISOBMFFIPMA(data, ipmaBox)
         var hvcCPropertyByItem: [Int: ISOBMFFPropertyInfo] = [:]
         for entry in ipma.entries {
             for association in entry.associations {

--- a/Sources/XDRemuxAppleFeatures/SemanticScene/AppleNativeToolchain.swift
+++ b/Sources/XDRemuxAppleFeatures/SemanticScene/AppleNativeToolchain.swift
@@ -11,6 +11,7 @@ package enum AppleNativeToolchain {
     }
 
     private static let compileLock = NSLock()
+    private static let compileTimeout: TimeInterval = 300
 
     static func semanticExecutable() throws -> URL {
         let source = try resourceURL(
@@ -215,16 +216,37 @@ package enum AppleNativeToolchain {
             return executable
         }
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        // `compileLock` only serializes this process. The cache directory is
+        // shared across every XDRemux process on the machine, so compile to a
+        // private staging path and publish it with an atomic rename — otherwise
+        // a concurrent run can exec a half-written binary.
+        let staging = directory.appendingPathComponent("\(executableName).\(UUID().uuidString)")
+        var published = false
+        defer {
+            if !published { try? FileManager.default.removeItem(at: staging) }
+        }
         let result = try run(
             URL(fileURLWithPath: "/usr/bin/xcrun"),
-            arguments: arguments + ["-o", executable.path]
+            arguments: arguments + ["-o", staging.path],
+            timeout: compileTimeout
         )
-        guard result.status == 0, FileManager.default.isExecutableFile(atPath: executable.path) else {
+        guard !result.timedOut else {
+            throw CLIError.invalidContainer(
+                "cannot build \(executableName): compiler exceeded \(Int(compileTimeout)) seconds"
+            )
+        }
+        guard result.status == 0, FileManager.default.isExecutableFile(atPath: staging.path) else {
             let diagnostic = String(data: result.stderr, encoding: .utf8) ?? "unknown compiler error"
             throw CLIError.invalidContainer(
                 "cannot build \(executableName): \(diagnostic.trimmingCharacters(in: .whitespacesAndNewlines))"
             )
         }
+        guard rename(staging.path, executable.path) == 0 else {
+            throw CLIError.invalidContainer(
+                "cannot publish \(executableName) into the tool cache: \(String(cString: strerror(errno)))"
+            )
+        }
+        published = true
         return executable
     }
 }

--- a/Sources/XDRemuxAppleFeatures/SemanticScene/AppleSemanticSceneAnalyzer.swift
+++ b/Sources/XDRemuxAppleFeatures/SemanticScene/AppleSemanticSceneAnalyzer.swift
@@ -2,6 +2,8 @@ import Foundation
 import XDRemuxCore
 
 package enum AppleSemanticSceneAnalyzer {
+    private static let semanticHelperTimeout: TimeInterval = 300
+
     static func copyEvidence(from sourceDirectory: URL, to outputDirectory: URL) throws {
         let fileManager = FileManager.default
         guard fileManager.fileExists(atPath: sourceDirectory.path) else {
@@ -56,12 +58,23 @@ package enum AppleSemanticSceneAnalyzer {
         if !writePNGEvidence {
             arguments.append("--raw-only")
         }
-        let result = try AppleNativeToolchain.run(executable, arguments: arguments)
-        guard result.status == 0 else {
+        // Every other native helper is bounded; a hung Vision request must not
+        // wedge a batch run forever. Full-resolution matte generation is the
+        // heaviest of them, hence the wider budget.
+        let result = try AppleNativeToolchain.run(
+            executable,
+            arguments: arguments,
+            timeout: semanticHelperTimeout
+        )
+        guard !result.timedOut, result.status == 0 else {
             let stderr = String(data: result.stderr, encoding: .utf8) ?? ""
             let stdout = String(data: result.stdout, encoding: .utf8) ?? ""
+            let timeout = result.timedOut
+                ? "helper exceeded \(Int(semanticHelperTimeout)) seconds; "
+                : ""
             throw CLIError.invalidContainer(
-                "Apple semantic capability unavailable: \([stderr, stdout].filter { !$0.isEmpty }.joined(separator: " "))"
+                "Apple semantic capability unavailable: \(timeout)"
+                    + [stderr, stdout].filter { !$0.isEmpty }.joined(separator: " ")
             )
         }
         try result.stdout.write(

--- a/Sources/XDRemuxCLI/Commands/XDRemuxCommand.swift
+++ b/Sources/XDRemuxCLI/Commands/XDRemuxCommand.swift
@@ -221,7 +221,12 @@ enum XDRemuxCommand {
 
     private static func runBatch(_ cmd: BatchCommand) throws {
         try ensureDirectory(cmd.outputDirURL, fileManager: fileManager)
-        let discovered = try enumerateInputs(root: cmd.inputDirURL, glob: cmd.glob)
+        let discovered = try enumerateInputs(
+            root: cmd.inputDirURL,
+            glob: cmd.glob,
+            excluding: cmd.outputDirURL,
+            categorized: cmd.categorizeOutput
+        )
         let matched = discovered
         guard !matched.isEmpty else {
             throw CLIError.noFilesMatched(cmd.inputDirURL, cmd.glob)
@@ -722,7 +727,12 @@ enum XDRemuxCommand {
         }
     }
 
-    private static func enumerateInputs(root: URL, glob: String) throws -> [URL] {
+    static func enumerateInputs(
+        root: URL,
+        glob: String,
+        excluding outputDirectory: URL?,
+        categorized: Bool
+    ) throws -> [URL] {
         guard fileManager.fileExists(atPath: root.path) else {
             throw CLIError.inputNotFound(root)
         }
@@ -730,15 +740,43 @@ enum XDRemuxCommand {
         let regex = try globToRegex(glob)
         guard let enumerator = fileManager.enumerator(
             at: root,
-            includingPropertiesForKeys: [.isRegularFileKey],
+            includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey],
             options: [.skipsHiddenFiles]
         ) else {
             throw CLIError.inputNotFound(root)
         }
 
+        let rootPath = root.standardizedFileURL.path
+        let outputPath = outputDirectory?.standardizedFileURL.path
+        // Only skip the output tree when it is nested *inside* the scanned root.
+        // When it is the root itself (in-place batch) skipping it would discard
+        // every input.
+        let excludedTree = outputPath.flatMap {
+            $0 != rootPath && $0.hasPrefix(rootPath + "/") ? $0 : nil
+        }
+        // A categorized run files its results under per-capture-mode folders of
+        // the output directory. Those folders only ever hold XDRemux output, so
+        // skipping them keeps a repeated batch over the same directory
+        // idempotent instead of re-converting yesterday's results.
+        let categorizedParent = categorized ? (outputPath ?? rootPath) : nil
+        let captureModeFolders = Set(OppoCaptureMode.allCases.map(\.folderName))
+
         var matched: [URL] = []
         for case let fileURL as URL in enumerator {
-            let values = try fileURL.resourceValues(forKeys: [.isRegularFileKey])
+            let path = fileURL.standardizedFileURL.path
+            let values = try fileURL.resourceValues(forKeys: [.isRegularFileKey, .isDirectoryKey])
+            let isDirectory = values.isDirectory == true
+
+            if let excludedTree, path == excludedTree || path.hasPrefix(excludedTree + "/") {
+                if isDirectory { enumerator.skipDescendants() }
+                continue
+            }
+            if isDirectory, let categorizedParent,
+               fileURL.deletingLastPathComponent().standardizedFileURL.path == categorizedParent,
+               captureModeFolders.contains(fileURL.lastPathComponent) {
+                enumerator.skipDescendants()
+                continue
+            }
             guard values.isRegularFile == true else { continue }
 
             let relative = fileURL.path.replacingOccurrences(of: root.path + "/", with: "")

--- a/Sources/XDRemuxCore/Conversion/ConversionEngine.swift
+++ b/Sources/XDRemuxCore/Conversion/ConversionEngine.swift
@@ -589,6 +589,10 @@ func writeImageIOPreservedGainMapPassthrough(
         patchedUserComment: patchedUserComment,
         preserveTmapColor: oppoCompatibility.wantsOppoCompat,
         strictISO21496Tmap: strictISO21496,
-        fallbackXMPPayload: makeHdrgmXMP(infoFloats: productInput.extracted.metaFloats)
+        // makeHdrgmXMP expects the 20-float UHDR info layout; for LHDR inputs
+        // extracted.metaFloats is the 36-float local.hdr.meta.data block
+        // (f[0] = version, f[17] = histogram accumulator, ...), which would
+        // serialize garbage hdrgm values into the fallback XMP.
+        fallbackXMPPayload: makeHdrgmXMP(infoFloats: privateGainMapInfoFloats(for: productInput))
     )
 }

--- a/Sources/XDRemuxCore/Conversion/Models.swift
+++ b/Sources/XDRemuxCore/Conversion/Models.swift
@@ -40,6 +40,11 @@ public enum XDRemuxError: Error, CustomStringConvertible {
     case outputVerificationFailed(URL)
     case gainMapPixelFormatMismatch(URL, expected: UInt32, actual: UInt32?)
     case invalidContainer(String)
+    /// The input simply is not an OPPO portrait: the private tail lacks the
+    /// depth bundle Apple Portrait needs. Distinct from `invalidContainer` so a
+    /// combined Styles+Portrait run can degrade to styles-only for this case
+    /// alone and still surface every genuine portrait failure.
+    case portraitPrerequisitesMissing(String)
     case appleFeatureRuntimeUnavailable(String)
     case appleFeatureConversionFailed(status: Int32, log: String)
 
@@ -102,6 +107,8 @@ public enum XDRemuxError: Error, CustomStringConvertible {
         case .gainMapPixelFormatMismatch(let url, let expected, let actual):
             return "gain map pixel format mismatch in \(url.path): expected \(fourCCString(expected)), got \(fourCCString(actual))"
         case .invalidContainer(let message):
+            return "invalid HEIC container: \(message)"
+        case .portraitPrerequisitesMissing(let message):
             return "invalid HEIC container: \(message)"
         case .appleFeatureRuntimeUnavailable(let message):
             return "Apple feature runtime unavailable: \(message)"

--- a/Sources/XDRemuxCore/HDR/HDRPipeline.swift
+++ b/Sources/XDRemuxCore/HDR/HDRPipeline.swift
@@ -519,8 +519,12 @@ package enum LHDRExtractor {
 
             var metaFloats = (try? unpackFloatArrayLE(metaBytes, count: 20)) ?? Array(repeating: 0.0, count: 20)
 
-            // Check for valid Identity or Swapped manifest
-            if metaFloats.allSatisfy({ $0 == 0.0 }) || abs(metaFloats[0] - 1.0) > 0.1 {
+            // Check for valid Identity or Swapped manifest. Non-finite floats
+            // must fall back too: NaN passes the abs() comparison below and
+            // would later trap in Int32 rational serialization.
+            if metaFloats.allSatisfy({ $0 == 0.0 })
+                || metaFloats.contains(where: { !$0.isFinite })
+                || abs(metaFloats[0] - 1.0) > 0.1 {
                 metaFloats = [
                     1.0, 1.0, 1.0,             // ratioMin
                     1.0,                       // padding
@@ -531,7 +535,6 @@ package enum LHDRExtractor {
                     1.0,                       // displayRatioSdr
                     4.926,                     // displayRatioHdr
                     4.926,                     // scale
-                    0.0,                       // baseImageType
                     0.0                        // type
                 ]
                 var repacked = Data()
@@ -1174,7 +1177,9 @@ package enum EDRScaleResolver {
         let f24 = f[24]
         let f29 = max(f[29], 1.0)
         let f32 = f[32]
-        let cfg = Int(f[34]) == 1
+        // Equivalent to Int(f[34]) == 1 for all finite values, but NaN/Inf
+        // metadata cannot trap the integer conversion.
+        let cfg = f[34] >= 1.0 && f[34] < 2.0
 
         // Branch: f23 <= 0.99 || f0 < 3.0 → SIGMOID PATH
         if f23 <= 0.99 || f[0] < 3.0 {
@@ -1303,7 +1308,7 @@ package enum EDRScaleResolver {
         let preCorrectionEDR = scale.edrScale
         let finalEDR = scale.edrScale
         let faceCorrectionApplied = f.count > 24 ? f[24] > 0.0 : false
-        let sqrtCorrectionApplied = f.count > 34 ? (Int(f[34]) == 1 || (f[24] > 0.0)) : false
+        let sqrtCorrectionApplied = f.count > 34 ? ((f[34] >= 1.0 && f[34] < 2.0) || (f[24] > 0.0)) : false
 
         return CalibrationTrace(
             familyDetected: familyDetected.rawValue,

--- a/Sources/XDRemuxCore/HEIF/ISOBMFF.swift
+++ b/Sources/XDRemuxCore/HEIF/ISOBMFF.swift
@@ -37,9 +37,26 @@ package func appendInt32BE(_ value: Int32, to data: inout Data) {
 package func makeBox(_ type: String, payload: Data) -> Data {
     var out = Data()
     appendUInt32BE(payload.count + 8, to: &out)
-    out.append(type.data(using: .ascii)!)
+    // Box types are decoded from source bytes as ISO Latin-1 (see
+    // isobmffBoxes); encoding back as ASCII would force-unwrap nil for any
+    // preserved vendor 4CC with a byte >= 0x80. Latin-1 round-trips exactly.
+    out.append(type.data(using: .isoLatin1) ?? Data("????".utf8))
     out.append(payload)
     return out
+}
+
+/// Throws when fewer than `count` bytes remain before `end` — the shared
+/// guard for parsers that walk file-supplied structures. Field counts inside
+/// iloc/ipma/iinf come from the input file; without this, a truncated or
+/// malicious box drives Data subscripts past the end and crashes the process
+/// instead of failing with `invalidContainer`.
+@inline(__always)
+package func requireBytes(_ pos: Int, _ count: Int, end: Int, in boxType: String) throws {
+    guard pos >= 0, count >= 0, pos <= end, end - pos >= count else {
+        throw CLIError.invalidContainer(
+            "truncated \(boxType) box: need \(count) bytes at offset \(pos), box ends at \(end)"
+        )
+    }
 }
 
 package func isobmffBoxes(in data: Data, start: Int, end: Int) -> [ISOBMFFBox] {
@@ -52,7 +69,10 @@ package func isobmffBoxes(in data: Data, start: Int, end: Int) -> [ISOBMFFBox] {
         var header = 8
         if size == 1 {
             if pos + 16 > end { break }
-            size = Int(UInt64(readUInt32BEUnchecked(data, at: pos + 8)) << 32 | UInt64(readUInt32BEUnchecked(data, at: pos + 12)))
+            let large = UInt64(readUInt32BEUnchecked(data, at: pos + 8)) << 32
+                | UInt64(readUInt32BEUnchecked(data, at: pos + 12))
+            guard let converted = Int(exactly: large) else { break }
+            size = converted
             header = 16
         } else if size == 0 {
             size = end - pos
@@ -65,6 +85,8 @@ package func isobmffBoxes(in data: Data, start: Int, end: Int) -> [ISOBMFFBox] {
 }
 
 package func parseISOBMFFILoc(_ data: Data, _ box: ISOBMFFBox) throws -> [ISOBMFFILocEntry] {
+    let end = box.dataEnd
+    try requireBytes(box.dataStart, 6, end: end, in: "iloc")
     let version = data[box.dataStart]
     var pos = box.dataStart + 4
     let sizes0 = data[pos]; pos += 1
@@ -75,69 +97,91 @@ package func parseISOBMFFILoc(_ data: Data, _ box: ISOBMFFBox) throws -> [ISOBMF
     let indexSize = version == 1 || version == 2 ? Int(sizes1 & 0x0f) : 0
     let count: Int
     if version >= 2 {
+        try requireBytes(pos, 4, end: end, in: "iloc")
         count = readUInt32BEUnchecked(data, at: pos); pos += 4
     } else {
+        try requireBytes(pos, 2, end: end, in: "iloc")
         count = readUInt16BEUnchecked(data, at: pos); pos += 2
     }
 
-    func read(_ size: Int, _ pos: inout Int) -> Int {
-        var value = 0
+    func read(_ size: Int, _ pos: inout Int) throws -> Int {
+        try requireBytes(pos, size, end: end, in: "iloc")
+        var value: UInt64 = 0
         for _ in 0..<size {
-            value = (value << 8) | Int(data[pos])
+            value = (value << 8) | UInt64(data[pos])
             pos += 1
         }
-        return value
+        guard let converted = Int(exactly: value) else {
+            throw CLIError.invalidContainer("iloc field value \(value) exceeds supported range")
+        }
+        return converted
     }
 
     var entries: [ISOBMFFILocEntry] = []
     for _ in 0..<count {
         let itemID: Int
         if version >= 2 {
+            try requireBytes(pos, 4, end: end, in: "iloc")
             itemID = readUInt32BEUnchecked(data, at: pos); pos += 4
         } else {
+            try requireBytes(pos, 2, end: end, in: "iloc")
             itemID = readUInt16BEUnchecked(data, at: pos); pos += 2
         }
         var constructionMethod = 0
         if version == 1 || version == 2 {
+            try requireBytes(pos, 2, end: end, in: "iloc")
             constructionMethod = readUInt16BEUnchecked(data, at: pos) & 0x0f
             pos += 2
         }
+        try requireBytes(pos, 2, end: end, in: "iloc")
         let dataReferenceIndex = readUInt16BEUnchecked(data, at: pos); pos += 2
-        let baseOffset = read(baseOffsetSize, &pos)
+        let baseOffset = try read(baseOffsetSize, &pos)
+        try requireBytes(pos, 2, end: end, in: "iloc")
         let extentCount = readUInt16BEUnchecked(data, at: pos); pos += 2
         var extents: [(offset: Int, length: Int)] = []
         for _ in 0..<extentCount {
-            if indexSize > 0 { _ = read(indexSize, &pos) }
-            let offset = read(offsetSize, &pos)
-            let length = read(lengthSize, &pos)
-            extents.append((baseOffset + offset, length))
+            if indexSize > 0 { _ = try read(indexSize, &pos) }
+            let offset = try read(offsetSize, &pos)
+            let length = try read(lengthSize, &pos)
+            let (absolute, overflow) = baseOffset.addingReportingOverflow(offset)
+            guard !overflow else {
+                throw CLIError.invalidContainer("iloc extent offset overflows for item \(itemID)")
+            }
+            extents.append((absolute, length))
         }
         entries.append(ISOBMFFILocEntry(itemID: itemID, constructionMethod: constructionMethod, dataReferenceIndex: dataReferenceIndex, extents: extents))
     }
     return entries
 }
 
-package func parseISOBMFFIInf(_ data: Data, _ box: ISOBMFFBox) -> (version: UInt8, entries: [Int: String], rawInfe: [Int: Data]) {
+package func parseISOBMFFIInf(_ data: Data, _ box: ISOBMFFBox) throws -> (version: UInt8, entries: [Int: String], rawInfe: [Int: Data]) {
+    let end = box.dataEnd
+    try requireBytes(box.dataStart, 6, end: end, in: "iinf")
     let version = data[box.dataStart]
     var pos = box.dataStart + 4
     if version >= 1 {
+        try requireBytes(pos, 4, end: end, in: "iinf")
         pos += 4
     } else {
         pos += 2
     }
     var entries: [Int: String] = [:]
     var raw: [Int: Data] = [:]
-    for child in isobmffBoxes(in: data, start: pos, end: box.dataEnd) where child.type == "infe" {
+    for child in isobmffBoxes(in: data, start: pos, end: end) where child.type == "infe" {
+        try requireBytes(child.dataStart, 4, end: child.dataEnd, in: "infe")
         let v = data[child.dataStart]
         var p = child.dataStart + 4
         if v >= 2 {
             let itemID: Int
             if v >= 3 {
+                try requireBytes(p, 4, end: child.dataEnd, in: "infe")
                 itemID = readUInt32BEUnchecked(data, at: p); p += 4
             } else {
+                try requireBytes(p, 2, end: child.dataEnd, in: "infe")
                 itemID = readUInt16BEUnchecked(data, at: p); p += 2
             }
             p += 2
+            try requireBytes(p, 4, end: child.dataEnd, in: "infe")
             let type = String(data: data.subdata(in: p..<p + 4), encoding: .isoLatin1) ?? "????"
             entries[itemID] = type
             raw[itemID] = data.subdata(in: child.boxStart..<child.boxStart + child.size)
@@ -146,16 +190,24 @@ package func parseISOBMFFIInf(_ data: Data, _ box: ISOBMFFBox) -> (version: UInt
     return (version, entries, raw)
 }
 
-package func parseISOBMFFPITM(_ data: Data, _ box: ISOBMFFBox) -> Int {
+package func parseISOBMFFPITM(_ data: Data, _ box: ISOBMFFBox) throws -> Int {
+    try requireBytes(box.dataStart, 4, end: box.dataEnd, in: "pitm")
     let version = data[box.dataStart]
     let pos = box.dataStart + 4
-    return version == 0 ? readUInt16BEUnchecked(data, at: pos) : readUInt32BEUnchecked(data, at: pos)
+    if version == 0 {
+        try requireBytes(pos, 2, end: box.dataEnd, in: "pitm")
+        return readUInt16BEUnchecked(data, at: pos)
+    }
+    try requireBytes(pos, 4, end: box.dataEnd, in: "pitm")
+    return readUInt32BEUnchecked(data, at: pos)
 }
 
 package func parseISOBMFFIPMA(
     _ data: Data,
     _ box: ISOBMFFBox
-) -> (version: UInt8, flags: Int, entries: [ISOBMFFIPMAEntry]) {
+) throws -> (version: UInt8, flags: Int, entries: [ISOBMFFIPMAEntry]) {
+    let end = box.dataEnd
+    try requireBytes(box.dataStart, 8, end: end, in: "ipma")
     let version = data[box.dataStart]
     let flags = (Int(data[box.dataStart + 1]) << 16) | (Int(data[box.dataStart + 2]) << 8) | Int(data[box.dataStart + 3])
     var pos = box.dataStart + 4
@@ -164,16 +216,21 @@ package func parseISOBMFFIPMA(
     for _ in 0..<count {
         let itemID: Int
         if version >= 1 {
+            try requireBytes(pos, 4, end: end, in: "ipma")
             itemID = readUInt32BEUnchecked(data, at: pos); pos += 4
         } else {
+            try requireBytes(pos, 2, end: end, in: "ipma")
             itemID = readUInt16BEUnchecked(data, at: pos); pos += 2
         }
+        try requireBytes(pos, 1, end: end, in: "ipma")
         let associationCount = Int(data[pos]); pos += 1
         var associations: [Int] = []
         for _ in 0..<associationCount {
             if flags & 1 != 0 {
+                try requireBytes(pos, 2, end: end, in: "ipma")
                 associations.append(readUInt16BEUnchecked(data, at: pos)); pos += 2
             } else {
+                try requireBytes(pos, 1, end: end, in: "ipma")
                 associations.append(Int(data[pos])); pos += 1
             }
         }
@@ -639,15 +696,24 @@ package func makeAppleTmapPayload(infoFloats f: [Double]) -> Data {
         // compact Apple tmap form with a 22-bit fixed-point denominator. The
         // numeric value alone is insufficient: ImageIO rejects an otherwise
         // equivalent 100000-based representation when reading ISO Gain Maps.
+        guard value.isFinite else {
+            // Extraction sanitizes metadata, so this is a second line of
+            // defense: Int32(NaN) would trap the whole process.
+            appendInt32BE(0, to: &data)
+            appendInt32BE(1, to: &data)
+            return
+        }
         let rounded = value.rounded()
-        if abs(value - rounded) < 1e-12 {
-            appendInt32BE(Int32(rounded), to: &data)
+        if abs(value - rounded) < 1e-12, let exact = Int32(exactly: rounded) {
+            appendInt32BE(exact, to: &data)
             appendInt32BE(1, to: &data)
             return
         }
         let denominator: Int32 = 1 << 22
         let imageIOValue = (value * 100_000.0).rounded() / 100_000.0
-        appendInt32BE(Int32((imageIOValue * Double(denominator)).rounded()), to: &data)
+        let numerator = (imageIOValue * Double(denominator)).rounded()
+        let clamped = min(max(numerator, Double(Int32.min)), Double(Int32.max))
+        appendInt32BE(Int32(clamped), to: &data)
         appendInt32BE(denominator, to: &data)
     }
     let values: [Double] = [
@@ -744,16 +810,16 @@ package func writeHybridPrimaryPassthrough(
     let sourceIprp = try sourceChild("iprp")
     let sourceIDAT = sourceMetaChildren.first(where: { $0.type == "idat" })
     let sourceIref = sourceMetaChildren.first(where: { $0.type == "iref" })
-    let sourcePrimaryID = parseISOBMFFPITM(source, sourcePitm)
+    let sourcePrimaryID = try parseISOBMFFPITM(source, sourcePitm)
     let sourceItemInfo = parseISOBMFFItemInfos(source, sourceIinf)
     let sourceIlocEntries = try parseISOBMFFILoc(source, sourceIloc)
     let sourceRefsInfo = parseISOBMFFIRefs(source, sourceIref)
     let sourceProps = try parseISOBMFFIPCOPropertyInfos(source, sourceIprp)
-    let sourcePropsByIndex = Dictionary(uniqueKeysWithValues: sourceProps.map { ($0.index, $0) })
+    let sourcePropsByIndex = Dictionary(sourceProps.map { ($0.index, $0) }, uniquingKeysWith: { first, _ in first })
     guard let sourceIPMABox = isobmffBoxes(in: source, start: sourceIprp.dataStart, end: sourceIprp.dataEnd).first(where: { $0.type == "ipma" }) else {
         throw CLIError.invalidContainer("source ipma missing")
     }
-    let sourceIPMA = parseISOBMFFIPMA(source, sourceIPMABox)
+    let sourceIPMA = try parseISOBMFFIPMA(source, sourceIPMABox)
 
     let preservedIinf = try preservedChild("iinf")
     let preservedIloc = try preservedChild("iloc")
@@ -761,23 +827,24 @@ package func writeHybridPrimaryPassthrough(
     let preservedIprp = try preservedChild("iprp")
     let preservedIDAT = preservedMetaChildren.first(where: { $0.type == "idat" })
     let preservedIref = preservedMetaChildren.first(where: { $0.type == "iref" })
-    let preservedPrimaryID = parseISOBMFFPITM(preserved, preservedPitm)
+    let preservedPrimaryID = try parseISOBMFFPITM(preserved, preservedPitm)
     let preservedItemInfo = parseISOBMFFItemInfos(preserved, preservedIinf)
-    let preservedItemsByID = Dictionary(uniqueKeysWithValues: preservedItemInfo.items.map { ($0.itemID, $0) })
+    let preservedItemsByID = Dictionary(preservedItemInfo.items.map { ($0.itemID, $0) }, uniquingKeysWith: { first, _ in first })
     let preservedIlocEntries = try parseISOBMFFILoc(preserved, preservedIloc)
-    let preservedIlocByID = Dictionary(uniqueKeysWithValues: preservedIlocEntries.map { ($0.itemID, $0) })
+    let preservedIlocByID = Dictionary(preservedIlocEntries.map { ($0.itemID, $0) }, uniquingKeysWith: { first, _ in first })
     let preservedRefsInfo = parseISOBMFFIRefs(preserved, preservedIref)
     let preservedProps = try parseISOBMFFIPCOPropertyInfos(preserved, preservedIprp)
-    let preservedPropsByIndex = Dictionary(uniqueKeysWithValues: preservedProps.map { ($0.index, $0) })
+    let preservedPropsByIndex = Dictionary(preservedProps.map { ($0.index, $0) }, uniquingKeysWith: { first, _ in first })
     guard let preservedIPMABox = isobmffBoxes(in: preserved, start: preservedIprp.dataStart, end: preservedIprp.dataEnd).first(where: { $0.type == "ipma" }) else {
         throw CLIError.invalidContainer("preserve ipma missing")
     }
-    let preservedIPMA = parseISOBMFFIPMA(preserved, preservedIPMABox)
+    let preservedIPMA = try parseISOBMFFIPMA(preserved, preservedIPMABox)
 
     let preservedDimgRefs = Dictionary(
-        uniqueKeysWithValues: preservedRefsInfo.refs
+        preservedRefsInfo.refs
             .filter { $0.type == "dimg" }
-            .map { ($0.from, $0.to) }
+            .map { ($0.from, $0.to) },
+        uniquingKeysWith: { first, _ in first }
     )
     guard let preservedTmapID = preservedItemInfo.items.first(where: { $0.type == "tmap" })?.itemID,
           let tmapTargets = preservedDimgRefs[preservedTmapID] else {
@@ -935,8 +1002,8 @@ package func writeHybridPrimaryPassthrough(
         props[assoc.0]?.type
     }
 
-    let sourceIPMAByID = Dictionary(uniqueKeysWithValues: sourceIPMA.entries.map { ($0.itemID, $0) })
-    let preservedIPMAByID = Dictionary(uniqueKeysWithValues: preservedIPMA.entries.map { ($0.itemID, $0) })
+    let sourceIPMAByID = Dictionary(sourceIPMA.entries.map { ($0.itemID, $0) }, uniquingKeysWith: { first, _ in first })
+    let preservedIPMAByID = Dictionary(preservedIPMA.entries.map { ($0.itemID, $0) }, uniquingKeysWith: { first, _ in first })
     let sourcePrimaryColorAssoc = assocPairs(sourceIPMAByID[sourcePrimaryID]?.associations ?? [], flags: sourceIPMA.flags)
         .first { propertyType($0, in: sourcePropsByIndex) == "colr" }
     var primaryAssocs = assocPairs(sourceIPMAByID[sourcePrimaryID]?.associations ?? [], flags: sourceIPMA.flags)
@@ -1271,14 +1338,14 @@ package func writePrivateJPEGPassthroughOutput(
     let iprp = try child("iprp")
     let idat = try child("idat")
     let iref = metaChildren.first(where: { $0.type == "iref" })
-    let primaryID = parseISOBMFFPITM(src, pitm)
-    let iinfData = parseISOBMFFIInf(src, iinf)
+    let primaryID = try parseISOBMFFPITM(src, pitm)
+    let iinfData = try parseISOBMFFIInf(src, iinf)
     let ilocEntries = try parseISOBMFFILoc(src, iloc)
     let ipco = try parseISOBMFFIPCOProps(src, iprp)
     guard let ipmaBox = isobmffBoxes(in: src, start: iprp.dataStart, end: iprp.dataEnd).first(where: { $0.type == "ipma" }) else {
         throw CLIError.invalidContainer("ipma missing")
     }
-    let ipma = parseISOBMFFIPMA(src, ipmaBox)
+    let ipma = try parseISOBMFFIPMA(src, ipmaBox)
     let propMask = ipma.flags & 1 != 0 ? 0x7fff : 0x7f
     let primaryAssocs = ipma.entries.first(where: { $0.itemID == primaryID })?.associations ?? []
     let primaryPropIndices = primaryAssocs.map { $0 & propMask }
@@ -1326,6 +1393,14 @@ package func writePrivateJPEGPassthroughOutput(
         userCommentPatch = patch
     } else {
         userCommentPatch = nil
+    }
+
+    var preservedGroupPayload = Data()
+    var sourceGroupIDs: [Int] = []
+    for groupBox in metaChildren where groupBox.type == "grpl" {
+        let preserved = preservedEntityGroupChildren(in: src, grpl: groupBox, dropping: [])
+        preservedGroupPayload.append(preserved.payload)
+        sourceGroupIDs.append(contentsOf: preserved.groupIDs)
     }
 
     var metaParts: [Data] = []
@@ -1427,6 +1502,11 @@ package func writePrivateJPEGPassthroughOutput(
             payload.append(tmapPayload)
             payload.append(xmpPayload)
             metaParts.append(makeBox("idat", payload: payload))
+        case "grpl":
+            // Source entity groups are merged into the single grpl emitted
+            // below; copying the box here as well would produce a duplicate
+            // GroupsListBox (ISO 14496-12 allows at most one per meta).
+            continue
         default:
             metaParts.append(src.subdata(in: part.boxStart..<part.boxStart + part.size))
         }
@@ -1440,9 +1520,9 @@ package func writePrivateJPEGPassthroughOutput(
         metaParts.append(makeBox("iref", payload: payload))
     }
 
-    var grplPayload = Data()
+    var grplPayload = preservedGroupPayload
     var altrPayload = Data([0, 0, 0, 0])
-    appendUInt32BE(max(tmapID, xmpID) + 1, to: &altrPayload)
+    appendUInt32BE(max(max(tmapID, xmpID), sourceGroupIDs.max() ?? 0) + 1, to: &altrPayload)
     appendUInt32BE(2, to: &altrPayload)
     appendUInt32BE(tmapID, to: &altrPayload)
     appendUInt32BE(primaryID, to: &altrPayload)
@@ -1590,9 +1670,9 @@ package func replacePrivateJPEGGainMapWithHEVCTiles(
     let iprp = try child("iprp")
     let idat = try child("idat")
     let iref = try child("iref")
-    let primaryID = parseISOBMFFPITM(source, pitm)
+    let primaryID = try parseISOBMFFPITM(source, pitm)
     let itemInfo = parseISOBMFFItemInfos(source, iinf)
-    let itemByID = Dictionary(uniqueKeysWithValues: itemInfo.items.map { ($0.itemID, $0) })
+    let itemByID = Dictionary(itemInfo.items.map { ($0.itemID, $0) }, uniquingKeysWith: { first, _ in first })
     let refsInfo = parseISOBMFFIRefs(source, iref)
     guard let tmapID = itemInfo.items.first(where: { item in
         item.type == "tmap" && refsInfo.refs.contains(where: {
@@ -1608,7 +1688,7 @@ package func replacePrivateJPEGGainMapWithHEVCTiles(
     }
 
     let ilocEntries = try parseISOBMFFILoc(source, iloc)
-    let ilocByID = Dictionary(uniqueKeysWithValues: ilocEntries.map { ($0.itemID, $0) })
+    let ilocByID = Dictionary(ilocEntries.map { ($0.itemID, $0) }, uniquingKeysWith: { first, _ in first })
     guard let jpegEntry = ilocByID[gainMapID],
           jpegEntry.constructionMethod == 0,
           jpegEntry.extents.count == 1 else {
@@ -1625,7 +1705,7 @@ package func replacePrivateJPEGGainMapWithHEVCTiles(
         .first(where: { $0.type == "ipma" }) else {
         throw CLIError.invalidContainer("private JPEG Gain Map source ipco/ipma missing")
     }
-    let ipma = parseISOBMFFIPMA(source, ipmaBox)
+    let ipma = try parseISOBMFFIPMA(source, ipmaBox)
 
     let appendedGraphIDs = Set([gainMapID, tmapID] + itemInfo.items.compactMap { item in
         guard item.type == "mime",
@@ -1649,7 +1729,7 @@ package func replacePrivateJPEGGainMapWithHEVCTiles(
     }
     let remappedItemIDs = [gainMapID: outputGainMapID, tmapID: outputTmapID]
     func outputItemID(_ itemID: Int) -> Int { remappedItemIDs[itemID] ?? itemID }
-    let propertyByIndex = Dictionary(uniqueKeysWithValues: properties.map { ($0.index, $0) })
+    let propertyByIndex = Dictionary(properties.map { ($0.index, $0) }, uniquingKeysWith: { first, _ in first })
     var uniqueTileSizes: [(width: Int, height: Int)] = []
     for size in tileSizes where !uniqueTileSizes.contains(where: {
         $0.width == size.width && $0.height == size.height

--- a/Sources/XDRemuxCore/HEIF/OutputValidation.swift
+++ b/Sources/XDRemuxCore/HEIF/OutputValidation.swift
@@ -160,12 +160,16 @@ package func appendCompleteSourceTail(
             throw CLIError.invalidContainer("OPPO manifest is outside preserved tail")
         }
         for entry in manifestInfo.entries where shouldNeutralizeOppoCameraTailEntry(entry.name, mode: mode) {
-            let nameBytes = Data(entry.name.utf8)
+            // Match the quoted JSON token, not bare name bytes: entry names
+            // nest ("local.hdr.linear.mask" is a substring of
+            // "src.local.hdr.linear.mask"), so an unquoted search can patch a
+            // byte inside the wrong entry and then fail on the real one.
+            let nameBytes = Data("\"\(entry.name)\"".utf8)
             guard let range = tail.range(of: nameBytes, options: [], in: jsonStart..<jsonEnd),
-                  !range.isEmpty else {
+                  range.count > 2 else {
                 throw CLIError.invalidContainer("unable to neutralize OPPO tail entry \(entry.name)")
             }
-            tail[range.lowerBound] = UInt8(ascii: "x")
+            tail[range.lowerBound + 1] = UInt8(ascii: "x")
         }
     }
 

--- a/Tests/XDRemuxCLITests/BatchInputEnumerationTests.swift
+++ b/Tests/XDRemuxCLITests/BatchInputEnumerationTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import XCTest
+import XDRemuxCore
+@testable import XDRemuxCLI
+
+/// `batch` must never re-enumerate its own results. Before these contracts a
+/// second `--categorize` run over the same directory picked up the converted
+/// files from the first run and failed every one of them.
+final class BatchInputEnumerationTests: XCTestCase {
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("xdremux-enumerate-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    private func touch(_ relativePath: String) throws -> URL {
+        let url = root.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        XCTAssertTrue(FileManager.default.createFile(atPath: url.path, contents: Data([0, 1, 2, 3])))
+        return url
+    }
+
+    /// Paths are reported relative to the fixture root. The absolute prefix is
+    /// unstable — the temporary directory is reached through the /var symlink
+    /// and Foundation spells it inconsistently — so anchor on the unique root
+    /// directory name instead.
+    private func names(_ urls: [URL]) -> [String] {
+        let marker = "/\(root.lastPathComponent)/"
+        return urls.map { url -> String in
+            guard let range = url.path.range(of: marker) else { return url.path }
+            return String(url.path[range.upperBound...])
+        }.sorted()
+    }
+
+    func testCategorizedRunSkipsCaptureModeOutputFolders() throws {
+        _ = try touch("a.heic")
+        _ = try touch("b.heic")
+        _ = try touch("人像/a.heic")
+        _ = try touch("普通拍照/b.heic")
+
+        let matched = try XDRemuxCommand.enumerateInputs(
+            root: root,
+            glob: "*.heic",
+            excluding: root,
+            categorized: true
+        )
+
+        XCTAssertEqual(names(matched), ["a.heic", "b.heic"])
+    }
+
+    func testUncategorizedRunStillSeesShootingModeNamedFolders() throws {
+        _ = try touch("a.heic")
+        _ = try touch("人像/keep.heic")
+
+        let matched = try XDRemuxCommand.enumerateInputs(
+            root: root,
+            glob: "*.heic",
+            excluding: root,
+            categorized: false
+        )
+
+        XCTAssertEqual(names(matched), ["a.heic", "人像/keep.heic"])
+    }
+
+    func testNestedOutputDirectoryIsExcludedFromInputs() throws {
+        _ = try touch("a.heic")
+        _ = try touch("out/a.heic")
+        _ = try touch("out/人像/a.heic")
+
+        let matched = try XDRemuxCommand.enumerateInputs(
+            root: root,
+            glob: "*.heic",
+            excluding: root.appendingPathComponent("out", isDirectory: true),
+            categorized: true
+        )
+
+        XCTAssertEqual(names(matched), ["a.heic"])
+    }
+
+    func testOutputDirectoryOutsideRootExcludesNothing() throws {
+        _ = try touch("a.heic")
+        _ = try touch("nested/b.heic")
+
+        let matched = try XDRemuxCommand.enumerateInputs(
+            root: root,
+            glob: "*.heic",
+            excluding: URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+                .appendingPathComponent("xdremux-elsewhere-\(UUID().uuidString)", isDirectory: true),
+            categorized: true
+        )
+
+        XCTAssertEqual(names(matched), ["a.heic", "nested/b.heic"])
+    }
+}

--- a/Tests/XDRemuxCoreTests/ISOBMFFHardeningTests.swift
+++ b/Tests/XDRemuxCoreTests/ISOBMFFHardeningTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import XCTest
+@testable import XDRemuxCore
+
+/// Every field count inside `iloc`, `iinf`, `ipma`, and `pitm` comes from the
+/// file being read. These contracts pin the behaviour on inputs that lie about
+/// those counts: the parsers must report `invalidContainer`, never index past
+/// the box and trap the process.
+final class ISOBMFFHardeningTests: XCTestCase {
+    private func box(_ type: String, payload: Data) -> (Data, ISOBMFFBox) {
+        let data = makeBox(type, payload: payload)
+        return (data, ISOBMFFBox(
+            type: type,
+            dataStart: 8,
+            dataEnd: data.count,
+            boxStart: 0,
+            size: data.count
+        ))
+    }
+
+    private func assertInvalidContainer(
+        _ expression: @autoclosure () throws -> some Any,
+        _ message: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(try expression(), message, file: file, line: line) { error in
+            guard case XDRemuxError.invalidContainer = error else {
+                return XCTFail("expected invalidContainer, got \(error)", file: file, line: line)
+            }
+        }
+    }
+
+    func testTruncatedILocIsRejected() {
+        // version 0, offset/length/base sizes 4, item_count 1, then nothing.
+        var payload = Data([0, 0, 0, 0])
+        payload.append(contentsOf: [0x44, 0x40])
+        payload.append(contentsOf: [0x00, 0x01])
+        let (data, iloc) = box("iloc", payload: payload)
+
+        assertInvalidContainer(
+            try parseISOBMFFILoc(data, iloc),
+            "an iloc promising one entry but carrying none must be rejected"
+        )
+    }
+
+    func testILocEntryCountLargerThanTheBoxIsRejected() {
+        var payload = Data([0, 0, 0, 0])
+        payload.append(contentsOf: [0x44, 0x40])
+        payload.append(contentsOf: [0xff, 0xff])
+        let (data, iloc) = box("iloc", payload: payload)
+
+        assertInvalidContainer(
+            try parseISOBMFFILoc(data, iloc),
+            "an iloc claiming 65535 entries must not read past the box"
+        )
+    }
+
+    func testTruncatedInfeChildIsRejected() {
+        // iinf version 0, entry_count 1, followed by an infe that declares
+        // version 3 (32-bit item_ID) but ends before the item_ID.
+        var payload = Data([0, 0, 0, 0])
+        payload.append(contentsOf: [0x00, 0x01])
+        payload.append(makeBox("infe", payload: Data([3, 0, 0, 0])))
+        let (data, iinf) = box("iinf", payload: payload)
+
+        assertInvalidContainer(
+            try parseISOBMFFIInf(data, iinf),
+            "an infe that ends before its item_ID must be rejected"
+        )
+    }
+
+    func testTruncatedIPMAIsRejected() {
+        // version 0, flags 0, entry_count 2, no association records follow.
+        var payload = Data([0, 0, 0, 0])
+        payload.append(contentsOf: [0x00, 0x00, 0x00, 0x02])
+        let (data, ipma) = box("ipma", payload: payload)
+
+        assertInvalidContainer(
+            try parseISOBMFFIPMA(data, ipma),
+            "an ipma promising two entries but carrying none must be rejected"
+        )
+    }
+
+    func testTruncatedPITMIsRejected() {
+        let (data, pitm) = box("pitm", payload: Data([0, 0, 0, 0]))
+
+        assertInvalidContainer(
+            try parseISOBMFFPITM(data, pitm),
+            "a pitm with no item_ID must be rejected"
+        )
+    }
+
+    func testZeroLargesizeStopsTheBoxWalkInsteadOfLooping() {
+        var data = Data()
+        appendUInt32BE(1, to: &data)
+        data.append(Data("free".utf8))
+        appendUInt32BE(0, to: &data)
+        appendUInt32BE(0, to: &data)
+
+        XCTAssertTrue(
+            isobmffBoxes(in: data, start: 0, end: data.count).isEmpty,
+            "a largesize of zero cannot advance the cursor and must end the walk"
+        )
+    }
+
+    func testVendorBoxTypesWithHighBytesRoundTrip() {
+        // Box types are read as ISO Latin-1; re-encoding as ASCII used to
+        // force-unwrap nil and trap on any preserved vendor 4CC >= 0x80.
+        let raw = Data([0xa9, 0x54, 0x4f, 0x4f])
+        let type = String(data: raw, encoding: .isoLatin1)!
+
+        let emitted = makeBox(type, payload: Data([1, 2, 3]))
+
+        XCTAssertEqual(emitted.subdata(in: 4..<8), raw)
+        XCTAssertEqual(emitted.count, 11)
+    }
+}

--- a/Tests/test_python_conversion_safety.py
+++ b/Tests/test_python_conversion_safety.py
@@ -1,0 +1,96 @@
+"""Regression contracts for the Python converter's failure handling.
+
+Each case here reproduces a defect that reached main: a crash on a valid photo,
+a truncated file left behind by a failed write, and an unbounded parser loop on
+a malformed container.
+"""
+
+import os
+import struct
+import tempfile
+import unittest
+from unittest import mock
+
+import numpy as np
+
+from xdremux.python import gainmap, heif_io, isobmff_patch
+
+
+class GainMapEdgeCaseTests(unittest.TestCase):
+    def test_unit_edr_scale_yields_a_zero_gain_map(self) -> None:
+        # edr_scale == 1.0 is a legitimate early-LHDR photo carrying no HDR
+        # gain. It used to divide by zero and abort the conversion.
+        mask = np.full((8, 8), 128, dtype=np.uint8)
+        result = gainmap.reconstruct(mask, 1.0, 2.0)
+
+        self.assertEqual(result.shape, mask.shape)
+        self.assertEqual(result.dtype, np.uint8)
+        self.assertTrue(np.all(result == 0))
+
+    def test_ordinary_edr_scale_still_produces_gain(self) -> None:
+        mask = np.full((8, 8), 200, dtype=np.uint8)
+        result = gainmap.reconstruct(mask, 2.5, 2.0)
+
+        self.assertEqual(result.shape, mask.shape)
+        self.assertTrue(np.any(result != 0))
+
+
+class AtomicWriteTests(unittest.TestCase):
+    def test_successful_write_replaces_the_previous_content(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "photo.heic")
+            with open(path, "wb") as handle:
+                handle.write(b"original")
+
+            heif_io.atomic_write_bytes(path, b"converted payload")
+
+            with open(path, "rb") as handle:
+                self.assertEqual(handle.read(), b"converted payload")
+            self.assertEqual(os.listdir(directory), ["photo.heic"])
+
+    def test_failed_write_leaves_the_original_intact(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "photo.heic")
+            with open(path, "wb") as handle:
+                handle.write(b"original")
+
+            def explode(*_args: object, **_kwargs: object) -> None:
+                raise OSError("simulated disk failure")
+
+            with mock.patch.object(heif_io.os, "replace", explode):
+                with self.assertRaises(OSError):
+                    heif_io.atomic_write_bytes(path, b"converted payload")
+
+            with open(path, "rb") as handle:
+                self.assertEqual(handle.read(), b"original")
+            # The staging file must not survive a failed write.
+            self.assertEqual(os.listdir(directory), ["photo.heic"])
+
+
+class BoxWalkerTests(unittest.TestCase):
+    def test_zero_largesize_is_rejected_instead_of_looping(self) -> None:
+        # size==1 selects the 64-bit largesize; a largesize of 0 cannot advance
+        # the cursor and used to spin forever.
+        data = struct.pack(">I", 1) + b"free" + struct.pack(">Q", 0)
+
+        with self.assertRaises(ValueError):
+            list(isobmff_patch._boxes(data, 0, len(data)))
+
+    def test_truncated_largesize_header_is_rejected(self) -> None:
+        data = struct.pack(">I", 1) + b"free" + b"\x00\x00\x00"
+
+        with self.assertRaises(ValueError):
+            list(isobmff_patch._boxes(data, 0, len(data)))
+
+    def test_well_formed_boxes_are_walked(self) -> None:
+        payload = b"\x01\x02\x03\x04"
+        data = struct.pack(">I", 8 + len(payload)) + b"mdat" + payload
+
+        boxes = list(isobmff_patch._boxes(data, 0, len(data)))
+
+        self.assertEqual([box[0] for box in boxes], ["mdat"])
+        self.assertEqual(data[boxes[0][1]:boxes[0][2]], payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/test_swift_artifact_lifecycle.py
+++ b/Tests/test_swift_artifact_lifecycle.py
@@ -21,8 +21,11 @@ class SwiftArtifactLifecycleTests(unittest.TestCase):
         self.assertIn("let persistEvidence = debugRootURL != nil", function)
         self.assertIn("FileManager.default.temporaryDirectory", function)
         self.assertIn("defer {", function)
-        self.assertIn("if !persistEvidence", function)
+        # Scratch evidence is discarded on success and kept on failure, where it
+        # is the only record of what the pipeline produced.
+        self.assertIn("} else if succeeded {", function)
         self.assertIn("try? FileManager.default.removeItem(at: evidenceContainer)", function)
+        self.assertIn("succeeded = true", function)
         self.assertNotIn('appendingPathExtension("xdremux")', function)
         self.assertIn("if persistEvidence {", function)
         self.assertIn('evidenceContainer.appendingPathComponent("latest.json")', function)

--- a/Tests/validation/verify_batch_categorize_idempotence.sh
+++ b/Tests/validation/verify_batch_categorize_idempotence.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# `batch --categorize` must be idempotent: re-running it over a directory it
+# already filed must skip the existing outputs, not re-enumerate the
+# capture-mode folders it wrote and fail every file in them.
+#
+# usage: verify_batch_categorize_idempotence.sh <sample.heic> [<sample.heic> ...]
+
+set -euo pipefail
+
+if (($# == 0)); then
+  echo "usage: $0 <sample.heic> [<sample.heic> ...]" >&2
+  exit 2
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CLI="$ROOT_DIR/.build/debug/xdremux"
+
+if [[ ! -x "$CLI" ]]; then
+  echo "Swift CLI not built: $CLI (run swift build first)" >&2
+  exit 2
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/xdremux-idempotence-XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+for sample in "$@"; do
+  if [[ ! -f "$sample" ]]; then
+    echo "sample not found: $sample" >&2
+    exit 2
+  fi
+  cp "$sample" "$WORK/"
+done
+
+EXPECTED="$#"
+
+echo "== run 1 =="
+FIRST="$("$CLI" batch --input-dir "$WORK" --output-dir "$WORK" --categorize 2>&1)"
+echo "$FIRST"
+if ! grep -q "converted $EXPECTED files, skipped-existing 0 files, failed 0 files" <<<"$FIRST"; then
+  echo "run 1 did not convert all $EXPECTED inputs cleanly" >&2
+  exit 1
+fi
+
+echo "== run 2 =="
+set +e
+SECOND="$("$CLI" batch --input-dir "$WORK" --output-dir "$WORK" --categorize 2>&1)"
+SECOND_STATUS=$?
+set -e
+echo "$SECOND"
+
+if ((SECOND_STATUS != 0)); then
+  echo "run 2 exited $SECOND_STATUS; a repeated categorized batch must succeed" >&2
+  exit 1
+fi
+if ! grep -q "converted 0 files, skipped-existing $EXPECTED files, failed 0 files" <<<"$SECOND"; then
+  echo "run 2 must skip the $EXPECTED existing outputs and fail nothing" >&2
+  exit 1
+fi
+if grep -q "failed to locate plausible 144-byte" <<<"$SECOND"; then
+  echo "run 2 re-enumerated its own categorized output" >&2
+  exit 1
+fi
+
+echo "batch --categorize is idempotent over $EXPECTED inputs"

--- a/Tests/validation/verify_macos_app_model_tests.sh
+++ b/Tests/validation/verify_macos_app_model_tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Builds and runs the macOS app's model test bundle, the same way ci.yml does.
+# Covers XDRemuxViewModel behavior that the SwiftPM test suite cannot reach.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DERIVED_DATA="${XDREMUX_APP_MODEL_DERIVED_DATA:-$(mktemp -d "${TMPDIR:-/tmp}/xdremux-app-model-XXXXXX")}"
+
+cd "$ROOT_DIR"
+
+xcodebuild \
+  -quiet \
+  -project apps/macos/XDRemuxApp/XDRemuxApp.xcodeproj \
+  -scheme XDRemuxAppModelTests \
+  -configuration Debug \
+  -derivedDataPath "$DERIVED_DATA" \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+
+"$DERIVED_DATA/Build/Products/Debug/XDRemuxAppModelTests"

--- a/Tests/validation/verify_swift_cli_sample.py
+++ b/Tests/validation/verify_swift_cli_sample.py
@@ -82,7 +82,33 @@ def parse_arguments() -> argparse.Namespace:
         help="assert ordinary conversion kept the source Base payload byte-identical",
     )
     parser.add_argument("--in-place", action="store_true", help="convert a temporary copy in place")
-    return parser.parse_args()
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="inspect --input as an already-converted output instead of converting it",
+    )
+    arguments = parser.parse_args()
+    if arguments.validate_only:
+        incompatible = [
+            name
+            for name, enabled in (
+                ("--in-place", arguments.in_place),
+                ("--oppo-compatible", arguments.oppo_compatible),
+                ("--apple-portrait", arguments.apple_portrait),
+                ("--expect-direct-gain", arguments.expect_direct_gain),
+                (
+                    "--require-compressed-primary-preserved",
+                    arguments.require_compressed_primary_preserved,
+                ),
+            )
+            if enabled
+        ]
+        if incompatible:
+            parser.error(
+                "--validate-only performs no conversion and cannot be combined with "
+                + ", ".join(incompatible)
+            )
+    return arguments
 
 
 def main() -> int:
@@ -93,7 +119,23 @@ def main() -> int:
     if not input_path.is_file():
         print(f"input sample not found: {input_path}", file=sys.stderr)
         return 2
-    if not cli_path.is_file():
+
+    if arguments.validate_only:
+        # The sample is already a conversion output; only assert its gain-map
+        # pixel format. No CLI is needed, so none is resolved or compiled.
+        run(
+            [
+                "swift",
+                "-e",
+                PIXEL_FORMAT_INSPECTOR,
+                str(input_path),
+                arguments.expected_pixel_format,
+            ],
+            cwd=repo,
+        )
+        return 0
+
+    if not arguments.binary and not cli_path.is_file():
         print(f"Swift CLI not found: {cli_path}", file=sys.stderr)
         return 2
 

--- a/Tests/validation/verify_validate_only_harness.sh
+++ b/Tests/validation/verify_validate_only_harness.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# ci.yml validates already-produced fixture outputs with
+# `verify_swift_cli_sample.py --validate-only`. That mode must assert the
+# gain-map pixel format of an existing file without converting it, and it must
+# actually fail on a mismatch — a validator that always passes is worse than
+# none.
+#
+# usage: verify_validate_only_harness.sh <sample.heic>
+
+set -euo pipefail
+
+if (($# != 1)); then
+  echo "usage: $0 <sample.heic>" >&2
+  exit 2
+fi
+
+SAMPLE="$1"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CLI="$ROOT_DIR/.build/debug/xdremux"
+HARNESS="$ROOT_DIR/Tests/validation/verify_swift_cli_sample.py"
+
+if [[ ! -f "$SAMPLE" ]]; then
+  echo "sample not found: $SAMPLE" >&2
+  exit 2
+fi
+if [[ ! -x "$CLI" ]]; then
+  echo "Swift CLI not built: $CLI (run swift build first)" >&2
+  exit 2
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/xdremux-validate-only-XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+OUTPUT="$WORK/converted.heic"
+"$CLI" convert --input "$SAMPLE" --output "$OUTPUT" >/dev/null
+
+cd "$ROOT_DIR"
+
+echo "== matching pixel format must pass =="
+python3 "$HARNESS" --validate-only --input "$OUTPUT" --expected-pixel-format L008
+
+echo "== mismatching pixel format must fail =="
+set +e
+python3 "$HARNESS" --validate-only --input "$OUTPUT" --expected-pixel-format 420v >/dev/null 2>&1
+MISMATCH_STATUS=$?
+set -e
+if ((MISMATCH_STATUS == 0)); then
+  echo "--validate-only accepted the wrong pixel format" >&2
+  exit 1
+fi
+
+echo "== --validate-only must reject conversion-only flags =="
+set +e
+python3 "$HARNESS" --validate-only --in-place --input "$OUTPUT" \
+  --expected-pixel-format L008 >/dev/null 2>&1
+COMBINED_STATUS=$?
+set -e
+if ((COMBINED_STATUS == 0)); then
+  echo "--validate-only accepted --in-place, which performs a conversion" >&2
+  exit 1
+fi
+
+echo "--validate-only behaves correctly on pass, mismatch, and misuse"

--- a/apps/macos/XDRemuxApp/Sources/XDRemuxViewModel.swift
+++ b/apps/macos/XDRemuxApp/Sources/XDRemuxViewModel.swift
@@ -62,7 +62,9 @@ enum OutputPlanStatus: String, Sendable, Equatable {
 enum OutputPreparationDisposition: String, Sendable, Equatable {
     case ready
     case skippedExistingValidOutput
-    case removedExistingInvalidOutput
+    /// An unusable output is already at the destination. It is replaced only
+    /// once a fresh conversion has succeeded, never deleted up front.
+    case replacesExistingInvalidOutput
 }
 
 enum ThumbnailStatus: Equatable {
@@ -213,6 +215,9 @@ final class XDRemuxViewModel {
 
     private var processTask: Task<Void, Never>?
     private var importTask: Task<Void, Never>?
+    /// Bumped by every import. A scan that resumes after being superseded uses
+    /// it to detect that the state it would publish is no longer the truth.
+    private var importGeneration = 0
 
     func addFiles(from urls: [URL]) {
         guard canEditQueue else { return }
@@ -225,6 +230,8 @@ final class XDRemuxViewModel {
     @discardableResult
     func importFiles(from urls: [URL]) async -> Int {
         guard canEditQueue else { return 0 }
+        importGeneration &+= 1
+        let generation = importGeneration
         state = .scanning
         currentFileName = "正在扫描 HEIC 文件..."
 
@@ -233,6 +240,10 @@ final class XDRemuxViewModel {
                 (url, PhotoCategorizationEngine.classify(at: url))
             }
         }.value
+
+        // A newer import already owns the UI; publishing this one's queue items
+        // or terminal state here would clobber the scan the user is watching.
+        guard generation == importGeneration else { return 0 }
 
         if Task.isCancelled {
             state = queue.isEmpty ? .idle : .cancelled
@@ -587,7 +598,15 @@ final class XDRemuxViewModel {
                 if disposition == .skippedExistingValidOutput {
                     return QueueWorkResult(id: item.id, status: .skippedExisting, errorMessage: nil, finishedAt: Date())
                 }
-                try AppConversionEngine.convert(inputURL: item.inputURL, outputURL: item.outputURL, config: config)
+                if disposition == .replacesExistingInvalidOutput {
+                    try convertReplacingExistingOutput(
+                        inputURL: item.inputURL,
+                        outputURL: item.outputURL,
+                        config: config
+                    )
+                } else {
+                    try AppConversionEngine.convert(inputURL: item.inputURL, outputURL: item.outputURL, config: config)
+                }
                 return QueueWorkResult(id: item.id, status: .converted, errorMessage: nil, finishedAt: Date())
             } catch {
                 return QueueWorkResult(
@@ -705,8 +724,22 @@ final class XDRemuxViewModel {
         if config.skipExisting, AppConversionEngine.isValidOutput(outputURL, config: config) {
             return .skippedExistingValidOutput
         }
-        try fileManager.removeItem(at: outputURL)
-        return .removedExistingInvalidOutput
+        return .replacesExistingInvalidOutput
+    }
+
+    /// Converts into a sibling staging file and publishes it only on success, so
+    /// a failed run leaves whatever was already at `outputURL` untouched.
+    nonisolated private static func convertReplacingExistingOutput(
+        inputURL: URL,
+        outputURL: URL,
+        config: ConversionConfig
+    ) throws {
+        let staging = outputURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(".xdremux-\(UUID().uuidString).heic")
+        defer { try? FileManager.default.removeItem(at: staging) }
+        try AppConversionEngine.convert(inputURL: inputURL, outputURL: staging, config: config)
+        _ = try FileManager.default.replaceItemAt(outputURL, withItemAt: staging)
     }
 
     private func applyThumbnailData(id: UUID, inputURL: URL, data: Data) {

--- a/apps/macos/XDRemuxApp/Tests/XDRemuxAppModelTests.swift
+++ b/apps/macos/XDRemuxApp/Tests/XDRemuxAppModelTests.swift
@@ -45,7 +45,7 @@ struct XDRemuxAppModelTests {
         try await testOutputCollisionsAreMarkedBeforeConversion()
         try await testOutputPlanFlagsInvalidExistingOutputAsOverwriteRisk()
         try await testOutputParentFileBlocksConversionBeforeWorkStarts()
-        try testPreparingOutputRemovesInvalidExistingFileBeforeConversion()
+        try testPreparingOutputKeepsInvalidExistingFileUntilConversionSucceeds()
         try testThumbnailRendererProducesBoundedPNGData()
         try testEffectiveConcurrencyRespectsMemoryAndUserLimit()
         try testClearCompletedAndRetryFailedKeepQueuePredictable()
@@ -277,7 +277,7 @@ struct XDRemuxAppModelTests {
     }
 
     @MainActor
-    private static func testPreparingOutputRemovesInvalidExistingFileBeforeConversion() throws {
+    private static func testPreparingOutputKeepsInvalidExistingFileUntilConversionSucceeds() throws {
         let root = try makeTempDirectory("prepare-output")
         defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
 
@@ -292,8 +292,14 @@ struct XDRemuxAppModelTests {
             skipExisting: true
         )
 
-        try expect(disposition == .removedExistingInvalidOutput, "invalid existing output should be removed before conversion")
-        try expect(!FileManager.default.fileExists(atPath: output.path), "invalid existing output file should be gone")
+        try expect(
+            disposition == .replacesExistingInvalidOutput,
+            "invalid existing output should be scheduled for replacement"
+        )
+        try expect(
+            FileManager.default.fileExists(atPath: output.path),
+            "invalid existing output must survive preparation so a failed conversion cannot destroy it"
+        )
     }
 
     @MainActor

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -1,6 +1,6 @@
 # XDRemux Documentation
 
-English | [简体中文](README.md)
+English | [简体中文](../README.md)
 
 ## User documentation
 

--- a/docs/xdremux/README.md
+++ b/docs/xdremux/README.md
@@ -1,13 +1,18 @@
-# XDRemux 文档
+简体中文 | [English](README.en.md)
 
-用途: 聚合 XDRemux 转换器、ISO/HEIF 合规、Apple ImageIO 兼容和 passthrough 相关文档。
+# XDRemux 技术实现索引
 
-## 当前优先读取
-1. [ISO compliance report v2](iso-compliance-report-v2-20260514.md): 最新完整审计。v2 修正了 v1 中 passthrough base `colr`/`irot` 误报，当前无 SHALL 失败。
-2. [ISO conformance audit 2026-05-11](iso-conformance-audit-20260511.md): 早期审计和 Apple 62B tmap 兼容策略说明。
-3. [ISOBMFF patcher progress](isobmff-patcher-progress-20260507.md): Python patcher 让 CoreImage Headroom 可识别的闭环记录。
-4. [Passthrough plan](passthrough-plan.md): Python passthrough 设计背景。
+本目录收录 HDR、HEIF 与 ISO 容器行为的公开且相对稳定的文档。日常使用请先看[项目 README](../../README.md)或 [CLI 参考](../cli.md)。
 
-## 过期或低优先级
-- `docs/archive/xdremux/iso-compliance-report-v1-20260513.md` 已被 v2 覆盖，只保留用于对比修复前后的误报。
-- `iso-conformance-audit-20260511.md` 中的待办项已部分被 v2 和 eval 覆盖；不要直接拿它判断当前状态。
+## 当前公开文档
+
+- [ISO 合规审计](iso-conformance-audit-20260511.md)：ISO 21496-1、HEIF item 与引用关系、tmap 行为，以及 Apple ImageIO 兼容性。
+- [验证指南](../validation/README.md)：结构性、渲染器、回归与真机证据之间的边界。
+- [Apple 功能](../apple-features.md)：Styles 与 Portrait 的用户能力、输入要求和验收范围。
+- [开发指南](../development.md)：模块边界、helper、Swift Package API 与构建流程。
+
+## 文档边界
+
+公开技术文档描述当前的实现约束和可重复的验证方式。带日期的单样本实验、固件字段、逆向工作、未定假设和临时 UI 验收记录属于 `docs/research/` 或 `docs/experiments/`，不构成产品承诺。
+
+研究结论稳定为产品行为后，先落到代码和回归测试里，再把面向用户或面向开发者的结论写进对应文档。不要把原始研究日志直接追加到 README。

--- a/scripts/agent_completion_gate.py
+++ b/scripts/agent_completion_gate.py
@@ -18,6 +18,7 @@ SCHEMA_VERSION = 1
 CHECK_KINDS = {"static", "regression", "functional", "integration", "device"}
 FUNCTIONAL_KINDS = {"functional", "integration", "device"}
 PRODUCTION_PREFIXES = (
+    "Sources/",
     "xdremux/",
     "apps/macos/XDRemuxApp/Sources/",
 )
@@ -76,7 +77,9 @@ def changed_files(repo: Path, base_commit: str, head_commit: str) -> list[str]:
         repo,
         "diff",
         "--name-only",
-        "--diff-filter=ACMRTUXB",
+        # Deletions are production changes too: removing a source file needs the
+        # same functional evidence as editing one.
+        "--diff-filter=ACDMRTUXB",
         f"{merge_base}...{head_commit}",
     )
     return [line for line in output.splitlines() if line]

--- a/scripts/build_and_run.sh
+++ b/scripts/build_and_run.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# Build and run the XDRemux macOS App.
+#
+# Only an explicit debug build uses the Debug configuration. Everything else —
+# including the plain `run` workflow — builds Release, because the Photographic
+# Styles solver is dominated by floating-point work that a debug build slows by
+# roughly an order of magnitude. Attach a debugger with `debug` when you need
+# symbols more than speed.
+#
+# usage: scripts/build_and_run.sh [run|build|debug|logs|telemetry|verify|clean] [--verbose]
+
+set -euo pipefail
+
+APP_NAME="XDRemuxApp"
+SCHEME="XDRemuxApp"
+PROJECT_PATH="apps/macos/XDRemuxApp/XDRemuxApp.xcodeproj"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DERIVED_DATA="${XDREMUX_DERIVED_DATA:-$ROOT_DIR/.build/xcode}"
+LOG_DIRECTORY="$DERIVED_DATA/Logs/XDRemux"
+BUILD_LOG="$LOG_DIRECTORY/build.log"
+
+COMMAND="run"
+VERBOSE=0
+
+while (($# > 0)); do
+  case "$1" in
+    run|build|debug|logs|telemetry|verify|clean|--debug|--logs|--telemetry|--verify)
+      COMMAND="$1"
+      ;;
+    --verbose)
+      VERBOSE=1
+      ;;
+    -h|--help|help)
+      sed -n '2,11p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      echo "usage: $0 [run|build|debug|logs|telemetry|verify|clean] [--verbose]" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+case "$COMMAND" in
+  --debug|debug)
+    CONFIGURATION="Debug"
+    ;;
+  run|--logs|logs|--telemetry|telemetry|--verify|verify)
+    CONFIGURATION="Release"
+    ;;
+  *)
+    CONFIGURATION="Release"
+    ;;
+esac
+
+APP_BUNDLE="$DERIVED_DATA/Build/Products/$CONFIGURATION/$APP_NAME.app"
+APP_EXECUTABLE="$APP_BUNDLE/Contents/MacOS/$APP_NAME"
+
+cd "$ROOT_DIR"
+
+if [[ "$COMMAND" == "clean" ]]; then
+  rm -rf "$DERIVED_DATA"
+  echo "removed $DERIVED_DATA"
+  exit 0
+fi
+
+if [[ "$COMMAND" == "--logs" || "$COMMAND" == "logs" ]]; then
+  if [[ ! -f "$BUILD_LOG" ]]; then
+    echo "no build log yet at $BUILD_LOG" >&2
+    exit 1
+  fi
+  tail -200 "$BUILD_LOG"
+  exit 0
+fi
+
+build_app() {
+  mkdir -p "$LOG_DIRECTORY"
+  local status=0
+  set +e
+  xcodebuild \
+    -project "$PROJECT_PATH" \
+    -scheme "$SCHEME" \
+    -configuration "$CONFIGURATION" \
+    -derivedDataPath "$DERIVED_DATA" \
+    CODE_SIGNING_ALLOWED=NO \
+    build >"$BUILD_LOG" 2>&1
+  status=$?
+  set -e
+  if ((status != 0)); then
+    echo "build failed ($CONFIGURATION); last 80 log lines:" >&2
+    tail -80 "$BUILD_LOG" >&2
+    echo "full log: $BUILD_LOG" >&2
+    return "$status"
+  fi
+  if ((VERBOSE == 1)); then
+    cat "$BUILD_LOG"
+  fi
+  echo "built $CONFIGURATION -> $APP_BUNDLE"
+}
+
+build_app
+
+case "$COMMAND" in
+  build)
+    ;;
+  --verify|verify)
+    swift build
+    swift test
+    python3 -m unittest discover -s Tests -p "test_*.py"
+    ;;
+  --telemetry|telemetry)
+    log show --predicate 'subsystem == "com.proxdr.XDRemuxApp"' --last 15m --info || true
+    ;;
+  *)
+    if [[ ! -x "$APP_EXECUTABLE" ]]; then
+      echo "app executable missing: $APP_EXECUTABLE" >&2
+      exit 1
+    fi
+    open "$APP_BUNDLE"
+    ;;
+esac

--- a/xdremux/python/XDRemux.py
+++ b/xdremux/python/XDRemux.py
@@ -14,6 +14,10 @@ import argparse
 import json
 import os
 import sys
+
+if sys.version_info < (3, 11):
+    sys.exit("error: XDRemux requires Python 3.11 or newer")
+
 from pathlib import Path
 
 if __package__ in (None, ""):
@@ -42,12 +46,16 @@ def cmd_convert(args: argparse.Namespace) -> int:
         print(f"error: {e}", file=sys.stderr)
         return 1
 
-    if lhdr.mode == "uhdr":
-        iso_meta = iso21496.build_iso21496_metadata_from_uhdr(lhdr.meta_floats)
-        edr_scale = iso_meta.get("scale", 1.0)
-    else:
-        edr_scale = edr.edr_scale_calculator(list(lhdr.meta_floats))
-        iso_meta = iso21496.build_iso21496_metadata(edr_scale)
+    try:
+        if lhdr.mode == "uhdr":
+            iso_meta = iso21496.build_iso21496_metadata_from_uhdr(lhdr.meta_floats)
+            edr_scale = iso_meta.get("scale", 1.0)
+        else:
+            edr_scale = edr.edr_scale_calculator(list(lhdr.meta_floats))
+            iso_meta = iso21496.build_iso21496_metadata(edr_scale)
+    except (ValueError, OverflowError) as e:
+        print(f"error: invalid HDR metadata in {input_path.name}: {e}", file=sys.stderr)
+        return 1
 
     print(f"  mode: {lhdr.mode}")
     print(f"  edr_scale: {edr_scale:.4f}")
@@ -92,12 +100,15 @@ def cmd_convert(args: argparse.Namespace) -> int:
                     gm_img = Image.open(io.BytesIO(gm_data))
                 except Exception:
                     pass
+            if gm_img is None:
+                print("error: UHDR gain map JPEG is missing or undecodable", file=sys.stderr)
+                return 1
         else:
             mask_data = lhdr.mask_data
             if mask_data is None:
                 print("error: no mask data found", file=sys.stderr)
                 return 1
-            mask_np = np.array(Image.open(io.BytesIO(mask_data)))
+            mask_np = np.array(Image.open(io.BytesIO(mask_data)).convert("L"))
             gm_img = gainmap.reconstruct(mask_np, edr_scale, lhdr.meta_floats[0])
 
         if passthrough:
@@ -132,13 +143,18 @@ def cmd_convert(args: argparse.Namespace) -> int:
             }
             (debug_dir / "meta.json").write_text(json.dumps(debug, indent=2))
 
-    except ImportError:
-        print("Metadata extraction only (install pillow-heif + Pillow + numpy for full conversion)")
+    except ImportError as e:
         print(json.dumps({
             "mode": lhdr.mode,
             "edr_scale": edr_scale,
             "gainMapMax": iso_meta["gainMapMax"][0],
         }, indent=2))
+        print(
+            f"error: conversion requires pillow-heif + Pillow + numpy ({e}); "
+            "no output was written",
+            file=sys.stderr,
+        )
+        return 1
 
     verb = "overwritten" if output_path == input_path else f"-> {output_path}"
     print(f"converted {input_path.name} {verb}")

--- a/xdremux/python/container.py
+++ b/xdremux/python/container.py
@@ -201,7 +201,8 @@ def _find_jpeg_in_data(data: bytes, target_length: int | None = None) -> bytes |
 
 def extract_lhdr(path: str) -> ExtractedLHDR:
     """Extract LHDR or UHDR metadata and mask/gainmap from a HEIC file."""
-    data = open(path, "rb").read()
+    with open(path, "rb") as handle:
+        data = handle.read()
 
     # Try QTI marker first
     try:
@@ -247,7 +248,13 @@ def extract_lhdr(path: str) -> ExtractedLHDR:
             json_start = manifest[1]
             info_start = json_start - info_entry["offset"]
             info_bytes = ext[info_start:info_start + info_entry["length"]]
-            info_floats = struct.unpack("<20f", info_bytes)
+            if info_start < 0 or len(info_bytes) < 80:
+                raise ValueError(
+                    "UHDR manifest entry local.uhdr.gainmap.info points outside "
+                    f"the extension region (offset={info_entry['offset']}, "
+                    f"length={info_entry['length']})"
+                )
+            info_floats = struct.unpack("<20f", info_bytes[:80])
 
             data_start = json_start - data_entry["offset"]
             gainmap_bytes = ext[data_start:data_start + data_entry["length"]]

--- a/xdremux/python/gainmap.py
+++ b/xdremux/python/gainmap.py
@@ -29,7 +29,12 @@ def _get_knee_point(edr: float) -> float:
     div1 = _f32(1.0 / p1)
     x_norm = _f32(_f32(_f32(0.9800000190734863) - t) / k)
     p2 = _f32(math.pow(x_norm, inv_gamma))
-    y = _f32(_f32(_f32(p2 * _f32(1.003937005996704)) - div1) / _f32(1.0 - div1))
+    try:
+        y = _f32(_f32(_f32(p2 * _f32(1.003937005996704)) - div1) / _f32(1.0 - div1))
+    except ZeroDivisionError:
+        # scale == 1.0 makes div1 == 1.0; C float math yields ±inf here and
+        # falls into the non-finite branch below. Match that behavior.
+        return float("nan")
     if not math.isfinite(y) or y <= 0.0:
         return float("nan")
 
@@ -75,6 +80,11 @@ def reconstruct(mask: np.ndarray, edr_scale: float,
         knee = 0.0
     else:
         knee = _get_knee_point(edr_scale)
+    if not math.isfinite(knee):
+        # No usable knee point (edr_scale ~= 1.0): the photo carries no HDR
+        # gain, so the reconstructed gain map is uniformly zero. Returning
+        # explicitly avoids NaN flowing into integer LUT indices below.
+        return np.zeros(mask.shape, dtype=np.uint8)
     knee_range = 1.0 - knee if knee < 1.0 else 0.001
 
     def lut3_fn(x):

--- a/xdremux/python/heif_io.py
+++ b/xdremux/python/heif_io.py
@@ -34,7 +34,35 @@ EXIF_USER_COMMENT_ASCII_PREFIX = b"ASCII\x00\x00\x00"
 def _read_be(data: bytes | bytearray, offset: int, size: int) -> tuple[int, int]:
     if size == 0:
         return 0, offset
-    return int.from_bytes(data[offset:offset + size], "big"), offset + size
+    chunk = data[offset:offset + size]
+    if len(chunk) != size:
+        raise ValueError(
+            f"truncated ISOBMFF structure: needed {size} bytes at offset {offset}, "
+            f"got {len(chunk)}"
+        )
+    return int.from_bytes(chunk, "big"), offset + size
+
+
+def atomic_write_bytes(path: str, payload: bytes) -> None:
+    """Write `payload` to `path` via a same-directory temp file + os.replace.
+
+    In-place conversion overwrites the user's original photo; a direct
+    open(path, 'wb') truncates it before the new bytes are durable, so a
+    crash or full disk destroys the only copy. os.replace keeps either the
+    complete old file or the complete new file at all times.
+    """
+    directory = os.path.dirname(os.path.abspath(path)) or "."
+    fd, tmp_path = tempfile.mkstemp(prefix=".xdremux-", suffix=".tmp", dir=directory)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def _parse_iloc_entries(data: bytes | bytearray, iloc_ds: int) -> list[dict]:
@@ -86,7 +114,9 @@ def _parse_ipma_entries(data: bytes | bytearray, ipma_ds: int) -> tuple[int, int
     count = struct.unpack_from(">I", data, ipma_body)[0]
     pos = ipma_body + 4
     entries = []
-    item_id_size = 4 if (ipma_f & 1) else 2
+    # ISO/IEC 14496-12: item_ID width follows the box *version* (v0 = u16,
+    # v1+ = u32); flags bit 0 only widens the property association field.
+    item_id_size = 4 if ipma_v >= 1 else 2
     assoc_size = 2 if (ipma_f & 1) else 1
     for _ in range(count):
         item_id, pos = _read_be(data, pos, item_id_size)
@@ -492,21 +522,31 @@ def write_heic(output_path: str, base_image: Image.Image,
             else:
                 _inject_exif_user_comment(heif, patched_comment)
 
-    heif.save(output_path, **save_kwargs)
-
-    # Binary-patch for ISO 21496-1 compliance
+    # Encode + patch a same-directory temp file, then atomically replace the
+    # destination: a failed encode or ISO patch must never leave a truncated
+    # or non-compliant file at output_path (which may be the user's original,
+    # and whose whole purpose is ISO 21496-1 compliance).
+    directory = os.path.dirname(os.path.abspath(output_path)) or "."
+    fd, tmp_path = tempfile.mkstemp(prefix=".xdremux-", suffix=".heic", dir=directory)
+    os.close(fd)
     try:
+        heif.save(tmp_path, **save_kwargs)
         from .isobmff_patch import patch_heic_for_iso21496
         patched = patch_heic_for_iso21496(
-            output_path,
+            tmp_path,
             iso_meta=iso_meta,
             replace_primary_colr=replace_primary_colr,
             oppo_compat=oppo_compat,
         )
         if not patched:
             print("note: auxC already present or patching skipped", file=sys.stderr)
-    except Exception as e:
-        print(f"warning: auxC patching failed: {e}", file=sys.stderr)
+        os.replace(tmp_path, output_path)
+    except BaseException:
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def write_heic_passthrough(source_path: str, output_path: str,
@@ -589,9 +629,7 @@ def write_heic_passthrough(source_path: str, output_path: str,
     item_types, iinf_v = _parse_all_items(src, child['iinf']['ds'], child['iinf']['de'])
     source_tmap_item_ids = {iid for iid, item_type in item_types.items() if item_type == "tmap"}
     if source_tmap_item_ids:
-        with open(output_path, 'wb') as f:
-            f.write(src[:src_mdat_off + src_mdat_sz])
-            f.write(src_post_mdat)
+        atomic_write_bytes(output_path, src[:src_mdat_off + src_mdat_sz] + src_post_mdat)
         return
 
     original_max_item_id = max(item_types.keys())
@@ -1168,8 +1206,7 @@ def write_heic_passthrough(source_path: str, output_path: str,
     out += gm_mdat_data
     out += src_post_mdat
 
-    with open(output_path, 'wb') as f:
-        f.write(out)
+    atomic_write_bytes(output_path, bytes(out))
 
 
 def _patch_oppo_tagflags_bytes(data: bytes) -> tuple[bytes, str | None]:

--- a/xdremux/python/isobmff_patch.py
+++ b/xdremux/python/isobmff_patch.py
@@ -54,8 +54,17 @@ def _boxes(d, start, end):
         sz = struct.unpack_from('>I', d, o)[0]
         tp = d[o+4:o+8].decode('latin-1', errors='replace')
         o2 = o + 8; hs = 8
-        if sz == 1: sz = struct.unpack_from('>Q', d, o2)[0]; o2 += 8; hs = 16
-        elif sz == 0: sz = end - o
+        if sz == 1:
+            if o2 + 8 > end:
+                raise ValueError(f"truncated largesize box header at offset {o}")
+            sz = struct.unpack_from('>Q', d, o2)[0]; o2 += 8; hs = 16
+        elif sz == 0:
+            sz = end - o
+        if sz < hs:
+            # A declared size smaller than the header cannot advance the
+            # cursor; without this check a crafted size==1/largesize==0 box
+            # loops forever.
+            raise ValueError(f"invalid ISOBMFF box size {sz} at offset {o}")
         be = min(o + sz, end)
         yield tp, o+hs, be, o, sz
         o = be
@@ -438,10 +447,10 @@ assert len(SWIFT_PQ_ICC_PROFILE) == 564
 def _parse_all_items(data, iinf_ds, iinf_de):
     """Parse iinf and return dict of {item_id: item_type}.
 
-    Pillow-heif uses v=2 with u16 item_id (non-standard).
-    ISO standard uses v=2+ with u32 item_id.
-    Detection: check which offset (ds+8 for u16, ds+10 for u32) contains
-    a valid ASCII FourCC for item_type.
+    Per ISO/IEC 14496-12, infe v2 carries a u16 item_ID and v3 a u32.
+    Some writers have been observed to disagree, so the u16/u32 split is
+    detected empirically: check which offset (ds+8 for u16, ds+10 for u32)
+    contains a valid ASCII FourCC for item_type.
     """
     iinf_v = data[iinf_ds]
     ec_size = 4 if iinf_v >= 1 else 2
@@ -456,7 +465,7 @@ def _parse_all_items(data, iinf_ds, iinf_de):
         try:
             s = b.decode('ascii')
             return all(c.isalnum() or c in ' _-.!' for c in s)
-        except:
+        except UnicodeDecodeError:
             return False
 
     for tp, ds, de, bs, bsz in _boxes(data, infe_start, iinf_de):
@@ -665,6 +674,20 @@ def patch_heic_for_iso21496(path: str, gainmap_item_id: int = None,
         parsed_entries.append({'iid': iid, 'cm': cm, 'dri': dri,
                                'bo': bo, 'extents': extents})
 
+    # The size-delta bookkeeping below assumes the pillow-heif output shape:
+    # iloc v0 (no construction_method/index fields) with one extent per item.
+    # Reject anything else loudly instead of writing a silently corrupt meta.
+    if iloc_v_orig != 0 or isz_orig:
+        raise ValueError(
+            f"ISO patcher supports iloc version 0 sources only (got v{iloc_v_orig})"
+        )
+    for entry in parsed_entries:
+        if len(entry['extents']) != 1:
+            raise ValueError(
+                "ISO patcher supports single-extent iloc entries only "
+                f"(item {entry['iid']} has {len(entry['extents'])})"
+            )
+
     # Target format: v1, osz=4, lsz=4, bosz=0, isz=0
     iloc_v = 1
     target_osz = 4
@@ -679,14 +702,16 @@ def patch_heic_for_iso21496(path: str, gainmap_item_id: int = None,
     entry_size_v1 = 2 + 2 + 2 + 0 + 2 + (target_osz + target_lsz)  # per extent
     # We'll compute actual size when building entries
 
-    # ipma geometry
+    # ipma geometry.
+    # ISO/IEC 14496-12: item_ID width follows the box *version* (v0 = u16,
+    # v1+ = u32); flags bit 0 only widens the property association field.
     ipma_v, ipma_f, ipma_body = _fullbox(data, ipma['ds'])
     pidx_mask = 0x7FFF if (ipma_f & 1) else 0x7F
+    ipma_iid_size = 4 if ipma_v >= 1 else 2
     ipma_entry_cnt = struct.unpack_from('>I', data, ipma_body)[0]
     ipma_pos = ipma_body + 4
     for _ in range(ipma_entry_cnt):
-        if ipma_f & 1: ipma_pos += 4
-        else: ipma_pos += 2
+        ipma_pos += ipma_iid_size
         ac = data[ipma_pos]; ipma_pos += 1
         for _ in range(ac):
             ipma_pos += 2 if (ipma_f & 1) else 1
@@ -715,7 +740,7 @@ def patch_heic_for_iso21496(path: str, gainmap_item_id: int = None,
     primary_colr_idx_pre = None
     scan_pos = ipma_body + 4
     for _ in range(ipma_entry_cnt):
-        if ipma_f & 1:
+        if ipma_iid_size == 4:
             scan_iid = struct.unpack_from('>I', data, scan_pos)[0]; scan_pos += 4
         else:
             scan_iid = struct.unpack_from('>H', data, scan_pos)[0]; scan_pos += 2
@@ -741,6 +766,11 @@ def patch_heic_for_iso21496(path: str, gainmap_item_id: int = None,
     hdr_pixi_prop_idx = prop_count + 4
     base_clli_prop_idx = prop_count + 5
     tmap_clli_prop_idx = prop_count + 6
+    if (ipma_f & 1) == 0 and tmap_clli_prop_idx > 0x7F:
+        raise ValueError(
+            "ISO patcher cannot address property indices above 127 while the "
+            "source ipma uses flags=0 (7-bit association fields)"
+        )
 
     # Parse all ipma entries to modify gain map entry (add auxC)
     gainmap_ispe_idx = None
@@ -750,7 +780,7 @@ def patch_heic_for_iso21496(path: str, gainmap_item_id: int = None,
     orig_ipma_entry_cnt = ipma_entry_cnt  # capture before Phase A modifies data
     ipma_pos2 = ipma_body + 4
     for _ in range(orig_ipma_entry_cnt):
-        if ipma_f & 1:
+        if ipma_iid_size == 4:
             iid = struct.unpack_from('>I', data, ipma_pos2)[0]; ipma_pos2 += 4
         else:
             iid = struct.unpack_from('>H', data, ipma_pos2)[0]; ipma_pos2 += 2
@@ -780,7 +810,7 @@ def patch_heic_for_iso21496(path: str, gainmap_item_id: int = None,
                     break
         # Rebuild entry bytes
         entry = bytearray()
-        if ipma_f & 1:
+        if ipma_iid_size == 4:
             entry += struct.pack('>I', iid)
         else:
             entry += struct.pack('>H', iid)
@@ -812,7 +842,7 @@ def patch_heic_for_iso21496(path: str, gainmap_item_id: int = None,
         ipma_entry_bytes.append(bytes(entry))
     def _encode_ipma_entry(iid, assocs):
         entry = bytearray()
-        if ipma_f & 1:
+        if ipma_iid_size == 4:
             entry += struct.pack('>I', iid)
         else:
             entry += struct.pack('>H', iid)
@@ -904,6 +934,12 @@ def patch_heic_for_iso21496(path: str, gainmap_item_id: int = None,
     existing_cdsc_refs = []  # [(from_id, [to_ids])]
     if 'iref' in child:
         iref_v = data[child['iref']['ds']]
+        if iref_v >= 1:
+            # All sub-box IDs below (and every reference this patcher emits)
+            # use 16-bit item IDs; a v1 iref carries 32-bit IDs.
+            raise ValueError(
+                f"ISO patcher supports iref version 0 sources only (got v{iref_v})"
+            )
         iref_body = child['iref']['ds'] + 4  # skip version(1)+flags(3)
         rpos = iref_body
         while rpos < child['iref']['de'] - 7:
@@ -1379,8 +1415,8 @@ def patch_heic_for_iso21496(path: str, gainmap_item_id: int = None,
     # Everything after meta — copy as-is (tmap config is in idat, not mdat)
     out += data[meta_de:]
 
-    with open(path, 'wb') as f:
-        f.write(out)
+    from .heif_io import atomic_write_bytes
+    atomic_write_bytes(path, bytes(out))
 
     return True
 

--- a/xdremux/python/requirements.txt
+++ b/xdremux/python/requirements.txt
@@ -1,3 +1,4 @@
 pillow-heif>=0.15.0
 Pillow>=11.0.0
 numpy>=2.0.0
+piexif>=1.1.3


### PR DESCRIPTION
Full code review of `main` @ `6d99b56`. 22 findings, all fixed, 11 new regression tests.

## P0 — data loss

- **In-place Python conversion truncated the original photo.** `write_heic` wrote straight to `output_path` (which defaults to the input) and then binary-patched it; a failed encode or auxC patch destroyed the only copy, and a failed patch only printed `warning:` while still reporting success. Now encodes and patches a same-directory temp file and `os.replace`s it into position. Same fix in `isobmff_patch.py`.

## P1 — functional

- **`batch --categorize` was not idempotent** (reproduced end-to-end). Run 2 re-enumerated the capture-mode folders run 1 had written and failed every file with `invalid LHDR payload`. `enumerateInputs` now excludes a nested output directory and the capture-mode output folders, mirroring the logic `PhotoCategorizationEngine.collectInputFiles` already had.
- **`edr_scale == 1.0` crashed with `ZeroDivisionError`** — a valid early-LHDR photo carrying no HDR gain. Matches the C path's ±inf → non-finite behaviour and returns a zero gain map.
- **Fallback XMP used the wrong float layout** for LHDR inputs (36-float `local.hdr.meta.data` where the 20-float UHDR info layout was expected).
- **OPPO tail neutralization matched bare name bytes**; entry names nest (`local.hdr.linear.mask` ⊂ `src.local.hdr.linear.mask`), so it patched the wrong entry then failed on the right one. Now matches the quoted JSON token.
- **Combined Styles+Portrait swallowed arbitrary portrait failures** as "unavailable". New `portraitPrerequisitesMissing` case is the only one swallowed; every real failure surfaces.
- **The macOS app deleted an existing output before converting**, so a failed conversion left the user with neither file. Now stages and publishes atomically.
- **ci.yml called a nonexistent `xdremux-dev` binary** plus `--language`, `--format jsonl`, `--diagnostics-dir`, and `--validate-only`, none of which exist. These steps only run when the fixture secret is set, so the workflow stayed green while being guaranteed to fail. All aligned to the real CLI; `--validate-only` genuinely implemented in the sample harness.
- **`scripts/build_and_run.sh` was missing** although both READMEs document it and a policy test asserts its contents — that test failed on a clean checkout of `main`.
- **`.gitignore` silently dropped new files under the tracked `docs/` tree**, and also ignored `scripts/agent_completion_gate.py` and `Tests/validation/verify_swift_cli_sample.py` — the latter is what CI step 5 runs.
- Four broken relative doc links.

## P2 — robustness

- `iloc`/`iinf`/`ipma`/`pitm` field counts come from the file being parsed but indexed `Data` directly, so a truncated HEIC trapped the process instead of reporting `invalidContainer`. Shared `requireBytes` guard, throwing parsers, checked `UInt64` offset accumulation.
- `makeBox` force-unwrapped `.ascii` for box types decoded as ISO Latin-1 — any vendor 4CC with a byte ≥ 0x80 crashed.
- Ten `Dictionary(uniqueKeysWithValues:)` over file-supplied keys; duplicate item IDs trapped.
- `size == 1` with a zero largesize looped forever in the Python box walker.
- `ipma` item_ID width was keyed off flags bit 0 instead of the box version (ISO/IEC 14496-12), in two implementations.
- NaN passed the UHDR fallback check and reached `Int32` rational serialization; two `Int(f[34]) == 1` conversions trapped on NaN/Inf.
- `decompressZstd` resolved zstd through `PATH` (a Finder-launched app cannot find Homebrew), drained pipes serially, and had no timeout.
- The Vision semantic helper was the only native helper without a timeout — and the heaviest.
- The native compile cache was guarded by an in-process lock but shared machine-wide; concurrent runs could exec a half-written binary. Now published with an atomic rename.
- Styles scratch evidence was deleted on the failure path, where it is the only diagnostic left.
- The completion gate did not treat `Sources/` as production code and ignored deletions.

## P3

- Three dropped backslashes in string interpolation turned RAW pairing diagnostics into literal parentheses.
- The Python CLI printed `converted ... overwritten` and exited 0 from the `ImportError` branch without writing anything.
- Missing `piexif` in requirements; bare `except:`; unconverted LHDR mask mode; unchecked `None` gain map.

## Verification

`swift build`, `swift test` (67 tests, 0 failures), macOS app build, `XDRemuxAppModelTests`, all nine Python policy suites, gate self-test, doc link scan, and `batch --categorize` idempotence on real OPPO samples. The completion gate passes for the tip commit with a verified receipt.

Not fixed and left for a separate change: pointing `convert` at XDRemux's own output still fails with a confusing `invalid LHDR payload` message. `prepareProductInput` calls `LHDRExtractor.extract` unconditionally. The batch impact is gone; the single-file message needs its own round of real-sample validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)