### PR TITLE
Android / OPPO Motion Photo to Apple Live Photo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,13 @@ jobs:
           echo "::endgroup::"
           echo "MACOS_APP_RESULT=Passed" >> "$GITHUB_ENV"
 
+      # This bundle is the pre-existing ProXDR / Apple feature regression fixture set. Keep it
+      # separate from XDREMUX_FIXTURE_ARCHIVE_URL, which is reserved for the dedicated real
+      # Samsung/Xiaomi/OPPO/vivo Motion Photo gate.
       - name: Prepare private fixtures
         shell: bash
         env:
-          FIXTURE_ARCHIVE_URL: ${{ secrets.XDREMUX_FIXTURE_ARCHIVE_URL }}
+          FIXTURE_ARCHIVE_URL: ${{ secrets.XDREMUX_REGRESSION_FIXTURE_ARCHIVE_URL }}
         run: |
           if [[ -z "$FIXTURE_ARCHIVE_URL" ]]; then
             echo "FIXTURE_ROOT=" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,29 @@ jobs:
           ditto -x -k "$RUNNER_TEMP/xdremux-fixtures.zip" "$RUNNER_TEMP/xdremux-fixtures"
           echo "FIXTURE_ROOT=$RUNNER_TEMP/xdremux-fixtures" >> "$GITHUB_ENV"
 
+      - name: Run private Motion Photo fixtures
+        shell: bash
+        run: |
+          if [[ -z "${FIXTURE_ROOT:-}" ]]; then
+            echo "MOTION_PHOTO_REAL_RESULT=Not configured" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          C15="$(find "$FIXTURE_ROOT" -type f -name 'IMG20250425184722.jpg' -print -quit)"
+          C16="$(find "$FIXTURE_ROOT" -type f -name 'IMG20250901181353.jpg' -print -quit)"
+          if [[ -z "$C15" && -z "$C16" ]]; then
+            echo "MOTION_PHOTO_REAL_RESULT=Fixtures not present" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          echo "::group::Real OPPO Motion Photo characterization and conversion"
+          XDREMUX_MOTION_PHOTO_FIXTURE_ROOT="$FIXTURE_ROOT" \
+            swift test --filter RealMotionPhotoFixtureTests 2>&1 | tee artifacts/motion-photo-real-fixtures.log
+          echo "::endgroup::"
+          if [[ -n "$C15" && -n "$C16" ]]; then
+            echo "MOTION_PHOTO_REAL_RESULT=Passed (ColorOS 15 + 16)" >> "$GITHUB_ENV"
+          else
+            echo "MOTION_PHOTO_REAL_RESULT=Passed available fixture; one generation absent" >> "$GITHUB_ENV"
+          fi
+
       - name: "[4/5] Run fixture conversions"
         shell: bash
         run: |
@@ -166,6 +189,7 @@ jobs:
             echo "| Swift package build | ${SWIFT_BUILD_RESULT:-Failed} |"
             echo "| Unit tests | ${UNIT_TEST_RESULT:-Not run} |"
             echo "| macOS App build | ${MACOS_APP_RESULT:-Not run} |"
+            echo "| Real OPPO Motion Photo fixtures | ${MOTION_PHOTO_REAL_RESULT:-Not run} |"
             echo "| Standard ISO fixture | ${STANDARD_FIXTURE_RESULT:-Not run} |"
             echo "| OPPO compatibility fixture | ${OPPO_FIXTURE_RESULT:-Not run} |"
             echo "| Apple styles fixture | ${APPLE_STYLES_RESULT:-Not run} |"

--- a/.github/workflows/motion-photo-real-fixtures.yml
+++ b/.github/workflows/motion-photo-real-fixtures.yml
@@ -1,0 +1,68 @@
+name: Motion Photo Real Fixtures
+
+on:
+  pull_request:
+    paths:
+      - "Sources/XDRemuxCore/MotionPhoto/**"
+      - "Sources/XDRemuxAppleFeatures/LivePhoto/**"
+      - "Sources/XDRemuxCLI/Commands/MotionPhoto*.swift"
+      - "Tests/**/*MotionPhoto*.swift"
+      - "Tests/**/*LivePhoto*.swift"
+      - ".github/workflows/motion-photo-real-fixtures.yml"
+
+jobs:
+  real-oppo-fixtures:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Resolve private fixture archive
+        shell: bash
+        env:
+          FIXTURE_ARCHIVE_URL: ${{ secrets.XDREMUX_FIXTURE_ARCHIVE_URL }}
+        run: |
+          mkdir -p artifacts
+          if [[ -z "$FIXTURE_ARCHIVE_URL" ]]; then
+            echo "not-configured" > artifacts/motion-photo-real-fixture-status.txt
+            echo "FIXTURE_ROOT=" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          mkdir -p "$RUNNER_TEMP/xdremux-fixtures"
+          curl --fail --location --silent --show-error \
+            "$FIXTURE_ARCHIVE_URL" \
+            --output "$RUNNER_TEMP/xdremux-fixtures.zip"
+          ditto -x -k \
+            "$RUNNER_TEMP/xdremux-fixtures.zip" \
+            "$RUNNER_TEMP/xdremux-fixtures"
+          echo "FIXTURE_ROOT=$RUNNER_TEMP/xdremux-fixtures" >> "$GITHUB_ENV"
+
+      - name: Characterize and convert real OPPO Motion Photos
+        shell: bash
+        run: |
+          if [[ -z "${FIXTURE_ROOT:-}" ]]; then
+            exit 0
+          fi
+          C15="$(find "$FIXTURE_ROOT" -type f -name 'IMG20250425184722.jpg' -print -quit)"
+          C16="$(find "$FIXTURE_ROOT" -type f -name 'IMG20250901181353.jpg' -print -quit)"
+          {
+            if [[ -n "$C15" ]]; then echo "coloros15=present"; else echo "coloros15=absent"; fi
+            if [[ -n "$C16" ]]; then echo "coloros16=present"; else echo "coloros16=absent"; fi
+          } > artifacts/motion-photo-real-fixture-status.txt
+          if [[ -z "$C15" && -z "$C16" ]]; then
+            exit 0
+          fi
+          XDREMUX_MOTION_PHOTO_FIXTURE_ROOT="$FIXTURE_ROOT" \
+            swift test --filter RealMotionPhotoFixtureTests \
+            2>&1 | tee artifacts/motion-photo-real-fixtures.log
+          echo "tests=passed" >> artifacts/motion-photo-real-fixture-status.txt
+
+      - name: Upload real-fixture status
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: motion-photo-real-fixture-status
+          if-no-files-found: error
+          path: |
+            artifacts/motion-photo-real-fixture-status.txt
+            artifacts/motion-photo-real-fixtures.log

--- a/.github/workflows/motion-photo-real-fixtures.yml
+++ b/.github/workflows/motion-photo-real-fixtures.yml
@@ -1,6 +1,7 @@
-name: Motion Photo Real Fixtures
+name: Motion Photo Real Fixture Gate
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "Sources/XDRemuxCore/MotionPhoto/**"
@@ -11,22 +12,31 @@ on:
       - ".github/workflows/motion-photo-real-fixtures.yml"
 
 jobs:
-  real-oppo-fixtures:
+  real-motion-photo-fixtures:
     runs-on: macos-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
+
+      - name: Record macOS runner
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          {
+            echo "runner_os=$(sw_vers -productVersion)"
+            echo "runner_build=$(sw_vers -buildVersion)"
+            echo "arch=$(uname -m)"
+          } | tee artifacts/motion-photo-runner.txt
 
       - name: Resolve private fixture archive
         shell: bash
         env:
           FIXTURE_ARCHIVE_URL: ${{ secrets.XDREMUX_FIXTURE_ARCHIVE_URL }}
         run: |
-          mkdir -p artifacts
           if [[ -z "$FIXTURE_ARCHIVE_URL" ]]; then
-            echo "not-configured" > artifacts/motion-photo-real-fixture-status.txt
-            echo "FIXTURE_ROOT=" >> "$GITHUB_ENV"
-            exit 0
+            echo "missing XDREMUX_FIXTURE_ARCHIVE_URL" | tee artifacts/motion-photo-real-fixture-status.txt
+            echo "::error::Motion Photo real-fixture gate cannot run without the private fixture archive URL"
+            exit 1
           fi
           mkdir -p "$RUNNER_TEMP/xdremux-fixtures"
           curl --fail --location --silent --show-error \
@@ -37,32 +47,75 @@ jobs:
             "$RUNNER_TEMP/xdremux-fixtures"
           echo "FIXTURE_ROOT=$RUNNER_TEMP/xdremux-fixtures" >> "$GITHUB_ENV"
 
-      - name: Characterize and convert real OPPO Motion Photos
+      - name: Verify supplied fixture inventory
         shell: bash
         run: |
-          if [[ -z "${FIXTURE_ROOT:-}" ]]; then
-            exit 0
+          expected=(
+            'IMG20250502131605.jpg'
+            'IMG20250502131608.jpg'
+            'IMG20250819170327.jpg'
+            'IMG20260710191114_ColorOS_16.jpg'
+            'IMG20260801190843_ColorOS_16.jpg'
+            'MVIMG_20260419_151324_2_3..jpg'
+            '20260312_135625..jpg'
+            '20260312_135627..jpg'
+            '20260312_135609..heic'
+            'R002_20260312_135609..heic'
+            '20260312_135610..heic'
+            'R003_20260312_135610..heic'
+            'IMG_20260620_160335..jpg'
+            'IMG_20260620_160410..jpg'
+          )
+          : > artifacts/motion-photo-real-fixture-status.txt
+          missing=0
+          for name in "${expected[@]}"; do
+            if find "$FIXTURE_ROOT" -type f -name "$name" -print -quit | grep -q .; then
+              echo "$name=present" >> artifacts/motion-photo-real-fixture-status.txt
+            else
+              echo "$name=MISSING" >> artifacts/motion-photo-real-fixture-status.txt
+              missing=1
+            fi
+          done
+          if [[ "$missing" -ne 0 ]]; then
+            echo "::error::Private fixture archive is incomplete"
+            exit 1
           fi
+
+      - name: Characterize and convert every supplied Motion Photo
+        shell: bash
+        env:
+          XDREMUX_MOTION_PHOTO_FIXTURE_ROOT: ${{ env.FIXTURE_ROOT }}
+        run: |
+          echo "::group::Real Samsung / Xiaomi / OPPO / vivo Motion Photo gate"
+          swift test --filter UploadedMotionPhotoFixtureGateTests \
+            2>&1 | tee artifacts/motion-photo-real-fixtures.log
+          echo "::endgroup::"
+          echo "tests=passed" >> artifacts/motion-photo-real-fixture-status.txt
+          echo "photoKit=passed" >> artifacts/motion-photo-real-fixture-status.txt
+
+      - name: Run historical OPPO characterization when present
+        shell: bash
+        env:
+          XDREMUX_MOTION_PHOTO_FIXTURE_ROOT: ${{ env.FIXTURE_ROOT }}
+        run: |
           C15="$(find "$FIXTURE_ROOT" -type f -name 'IMG20250425184722.jpg' -print -quit)"
           C16="$(find "$FIXTURE_ROOT" -type f -name 'IMG20250901181353.jpg' -print -quit)"
-          {
-            if [[ -n "$C15" ]]; then echo "coloros15=present"; else echo "coloros15=absent"; fi
-            if [[ -n "$C16" ]]; then echo "coloros16=present"; else echo "coloros16=absent"; fi
-          } > artifacts/motion-photo-real-fixture-status.txt
           if [[ -z "$C15" && -z "$C16" ]]; then
+            echo "historical_oppo=not-present" >> artifacts/motion-photo-real-fixture-status.txt
             exit 0
           fi
-          XDREMUX_MOTION_PHOTO_FIXTURE_ROOT="$FIXTURE_ROOT" \
-            swift test --filter RealMotionPhotoFixtureTests \
-            2>&1 | tee artifacts/motion-photo-real-fixtures.log
-          echo "tests=passed" >> artifacts/motion-photo-real-fixture-status.txt
+          swift test --filter RealMotionPhotoFixtureTests \
+            2>&1 | tee artifacts/motion-photo-historical-oppo.log
+          echo "historical_oppo=passed" >> artifacts/motion-photo-real-fixture-status.txt
 
-      - name: Upload real-fixture status
+      - name: Upload real-fixture evidence
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: motion-photo-real-fixture-status
+          name: motion-photo-real-fixture-evidence
           if-no-files-found: error
           path: |
+            artifacts/motion-photo-runner.txt
             artifacts/motion-photo-real-fixture-status.txt
             artifacts/motion-photo-real-fixtures.log
+            artifacts/motion-photo-historical-oppo.log

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoConversionEngine.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoConversionEngine.swift
@@ -1,0 +1,222 @@
+import Foundation
+@preconcurrency import AVFoundation
+import CoreMedia
+import XDRemuxCore
+
+public struct LivePhotoConversionResult: Sendable {
+    public let imageURL: URL
+    public let videoURL: URL
+    public let assetIdentifier: String
+    public let stillImageTime: CMTime
+    public let sourceKind: MotionPhotoSourceKind
+    public let diagnostics: [String]
+}
+
+public enum AppleLivePhotoConversionEngine {
+    public static func isMotionPhotoInput(_ inputURL: URL) -> Bool {
+        let ext = inputURL.pathExtension.lowercased()
+        guard ext == "jpg" || ext == "jpeg" else { return false }
+        return (try? OppoMotionPhotoParser.parse(url: inputURL)) != nil
+    }
+
+    public static func companionVideoURL(for imageURL: URL) -> URL {
+        imageURL.deletingPathExtension().appendingPathExtension("mov")
+    }
+
+    /// Synchronous entry point for the existing CLI and batch architecture.
+    public static func convert(
+        inputURL: URL,
+        outputImageURL: URL,
+        requirePhotoKitValidation: Bool = true
+    ) throws -> LivePhotoConversionResult {
+        let semaphore = DispatchSemaphore(value: 0)
+        let box = LivePhotoConversionResultBox()
+        Task.detached(priority: .userInitiated) {
+            do {
+                let value = try await convertAsync(
+                    inputURL: inputURL,
+                    outputImageURL: outputImageURL,
+                    requirePhotoKitValidation: requirePhotoKitValidation
+                )
+                box.set(.success(value))
+            } catch {
+                box.set(.failure(error))
+            }
+            semaphore.signal()
+        }
+        semaphore.wait()
+        return try box.result.get()
+    }
+
+    public static func convertAsync(
+        inputURL: URL,
+        outputImageURL: URL,
+        requirePhotoKitValidation: Bool = true
+    ) async throws -> LivePhotoConversionResult {
+        guard let asset = try OppoMotionPhotoParser.parse(url: inputURL) else {
+            throw AppleLivePhotoError.transactionFailed("input is not a supported JPEG Motion Photo")
+        }
+        let inputPath = inputURL.standardizedFileURL.path
+        let outputPath = outputImageURL.standardizedFileURL.path
+        guard inputPath != outputPath else {
+            throw AppleLivePhotoError.transactionFailed("Motion Photo conversion never overwrites the source JPEG in place")
+        }
+        let ext = outputImageURL.pathExtension.lowercased()
+        guard ext == "heic" || ext == "heif" else {
+            throw AppleLivePhotoError.transactionFailed("Live Photo still output must use .heic or .heif")
+        }
+
+        let outputVideoURL = companionVideoURL(for: outputImageURL)
+        try FileManager.default.createDirectory(
+            at: outputImageURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-livephoto-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let stillSourceURL = scratch.appendingPathComponent("still.jpg")
+        let videoSourceURL = scratch.appendingPathComponent("motion.mp4")
+        try MotionPhotoPayloadExtractor.copy(
+            range: asset.stillResourceRange,
+            from: inputURL,
+            to: stillSourceURL
+        )
+        let primaryVideoRange = try OppoMotionPhotoStreamResolver.primaryVideoRange(for: asset)
+        try MotionPhotoPayloadExtractor.copy(
+            range: primaryVideoRange,
+            from: inputURL,
+            to: videoSourceURL
+        )
+
+        let timeline = try await AppleLivePhotoTimelineResolver.resolve(
+            videoURL: videoSourceURL,
+            requestedTimestampUs: asset.presentationTimestampUs,
+            requestedSource: asset.presentationSource
+        )
+        let assetIdentifier = UUID().uuidString
+        let transactionID = UUID().uuidString
+        let directory = outputImageURL.deletingLastPathComponent()
+        let stem = outputImageURL.deletingPathExtension().lastPathComponent
+        let temporaryImageURL = directory.appendingPathComponent(".\(stem).\(transactionID).tmp.heic")
+        let temporaryVideoURL = directory.appendingPathComponent(".\(stem).\(transactionID).tmp.mov")
+        defer {
+            try? FileManager.default.removeItem(at: temporaryImageURL)
+            try? FileManager.default.removeItem(at: temporaryVideoURL)
+        }
+
+        let sourceHadGainMap = AppleLivePhotoStillWriter.hasGainMap(stillSourceURL)
+        let sourceAsset = AVURLAsset(url: videoSourceURL)
+        let sourceHadAudio = !(try await sourceAsset.loadTracks(withMediaType: .audio)).isEmpty
+
+        try AppleLivePhotoStillWriter.write(
+            stillInputURL: stillSourceURL,
+            outputURL: temporaryImageURL,
+            assetIdentifier: assetIdentifier
+        )
+        try await AppleLivePhotoVideoWriter.write(
+            videoInputURL: videoSourceURL,
+            outputURL: temporaryVideoURL,
+            assetIdentifier: assetIdentifier,
+            stillImageTime: timeline.stillImageTime,
+            oppoMetadata: asset.vendorMetadata
+        )
+
+        let expectedTransform = asset.vendorMetadata.flatMap(OppoLivePhotoAlignment.transformMatrix) != nil
+        _ = try await AppleLivePhotoValidator.validate(
+            imageURL: temporaryImageURL,
+            videoURL: temporaryVideoURL,
+            expectedAssetIdentifier: assetIdentifier,
+            expectedStillImageTime: timeline.stillImageTime,
+            sourceHadAudio: sourceHadAudio,
+            sourceHadGainMap: sourceHadGainMap,
+            expectsOppoTransform: expectedTransform,
+            requirePhotoKitLoad: requirePhotoKitValidation
+        )
+
+        try commitPair(
+            temporaryImageURL: temporaryImageURL,
+            temporaryVideoURL: temporaryVideoURL,
+            finalImageURL: outputImageURL,
+            finalVideoURL: outputVideoURL
+        )
+
+        var diagnostics: [String] = []
+        if let xmp = asset.presentationTimestampUs,
+           let cover = asset.vendorMetadata?.coverFramePtsUs,
+           xmp != cover {
+            diagnostics.append(
+                "XMP still time \(formatMicroseconds(xmp)) s differs from OPPO coverFramePts \(formatMicroseconds(cover)) s; selected \(timeline.source.rawValue)."
+            )
+        }
+        if let metadata = asset.vendorMetadata, metadata.streamCount >= 2 {
+            diagnostics.append("OPPO dual-stream input detected; selected Stream 1 for Apple paired video.")
+        }
+
+        return LivePhotoConversionResult(
+            imageURL: outputImageURL,
+            videoURL: outputVideoURL,
+            assetIdentifier: assetIdentifier,
+            stillImageTime: timeline.stillImageTime,
+            sourceKind: asset.sourceKind,
+            diagnostics: diagnostics
+        )
+    }
+
+    private static func commitPair(
+        temporaryImageURL: URL,
+        temporaryVideoURL: URL,
+        finalImageURL: URL,
+        finalVideoURL: URL
+    ) throws {
+        let fileManager = FileManager.default
+        let backupID = UUID().uuidString
+        let imageBackup = finalImageURL.deletingLastPathComponent()
+            .appendingPathComponent(".\(finalImageURL.lastPathComponent).\(backupID).backup")
+        let videoBackup = finalVideoURL.deletingLastPathComponent()
+            .appendingPathComponent(".\(finalVideoURL.lastPathComponent).\(backupID).backup")
+        let hadImage = fileManager.fileExists(atPath: finalImageURL.path)
+        let hadVideo = fileManager.fileExists(atPath: finalVideoURL.path)
+        var newImageInstalled = false
+        var newVideoInstalled = false
+
+        do {
+            if hadImage { try fileManager.moveItem(at: finalImageURL, to: imageBackup) }
+            if hadVideo { try fileManager.moveItem(at: finalVideoURL, to: videoBackup) }
+            try fileManager.moveItem(at: temporaryImageURL, to: finalImageURL)
+            newImageInstalled = true
+            try fileManager.moveItem(at: temporaryVideoURL, to: finalVideoURL)
+            newVideoInstalled = true
+            if hadImage { try? fileManager.removeItem(at: imageBackup) }
+            if hadVideo { try? fileManager.removeItem(at: videoBackup) }
+        } catch {
+            if newImageInstalled { try? fileManager.removeItem(at: finalImageURL) }
+            if newVideoInstalled { try? fileManager.removeItem(at: finalVideoURL) }
+            if hadImage, fileManager.fileExists(atPath: imageBackup.path) {
+                try? fileManager.moveItem(at: imageBackup, to: finalImageURL)
+            }
+            if hadVideo, fileManager.fileExists(atPath: videoBackup.path) {
+                try? fileManager.moveItem(at: videoBackup, to: finalVideoURL)
+            }
+            throw AppleLivePhotoError.transactionFailed(error.localizedDescription)
+        }
+    }
+
+    private static func formatMicroseconds(_ value: Int64) -> String {
+        String(format: "%.6f", Double(value) / 1_000_000.0)
+    }
+}
+
+private final class LivePhotoConversionResultBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: Result<LivePhotoConversionResult, Error>?
+    var result: Result<LivePhotoConversionResult, Error> {
+        lock.lock(); defer { lock.unlock() }
+        return stored ?? .failure(AppleLivePhotoError.transactionFailed("conversion task did not produce a result"))
+    }
+    func set(_ value: Result<LivePhotoConversionResult, Error>) {
+        lock.lock(); defer { lock.unlock() }; stored = value
+    }
+}

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoConversionEngine.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoConversionEngine.swift
@@ -15,7 +15,9 @@ public struct LivePhotoConversionResult: Sendable {
 public enum AppleLivePhotoConversionEngine {
     public static func isMotionPhotoInput(_ inputURL: URL) -> Bool {
         let ext = inputURL.pathExtension.lowercased()
-        guard ext == "jpg" || ext == "jpeg" else { return false }
+        guard ext == "jpg" || ext == "jpeg" || ext == "heic" || ext == "heif" else {
+            return false
+        }
         return (try? OppoMotionPhotoParser.parse(url: inputURL)) != nil
     }
 
@@ -53,12 +55,12 @@ public enum AppleLivePhotoConversionEngine {
         requirePhotoKitValidation: Bool = true
     ) async throws -> LivePhotoConversionResult {
         guard let asset = try OppoMotionPhotoParser.parse(url: inputURL) else {
-            throw AppleLivePhotoError.transactionFailed("input is not a supported JPEG Motion Photo")
+            throw AppleLivePhotoError.transactionFailed("input is not a supported Motion Photo")
         }
         let inputPath = inputURL.standardizedFileURL.path
         let outputPath = outputImageURL.standardizedFileURL.path
         guard inputPath != outputPath else {
-            throw AppleLivePhotoError.transactionFailed("Motion Photo conversion never overwrites the source JPEG in place")
+            throw AppleLivePhotoError.transactionFailed("Motion Photo conversion never overwrites the source image in place")
         }
         let ext = outputImageURL.pathExtension.lowercased()
         guard ext == "heic" || ext == "heif" else {
@@ -76,7 +78,8 @@ public enum AppleLivePhotoConversionEngine {
         try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: scratch) }
 
-        let stillSourceURL = scratch.appendingPathComponent("still.jpg")
+        let stillExtension = asset.sourceKind == .androidHeifMotionPhotoV1 ? "heic" : "jpg"
+        let stillSourceURL = scratch.appendingPathComponent("still.\(stillExtension)")
         let videoSourceURL = scratch.appendingPathComponent("motion.mp4")
         try MotionPhotoPayloadExtractor.copy(
             range: asset.stillResourceRange,
@@ -155,6 +158,9 @@ public enum AppleLivePhotoConversionEngine {
         if let metadata = asset.vendorMetadata, metadata.streamCount >= 2 {
             diagnostics.append("OPPO dual-stream input detected; selected Stream 1 for Apple paired video.")
         }
+        if asset.sourceKind == .androidHeifMotionPhotoV1 {
+            diagnostics.append("HEIF Motion Photo mpvd payload extracted without trailing vendor boxes.")
+        }
 
         return LivePhotoConversionResult(
             imageURL: outputImageURL,
@@ -181,7 +187,6 @@ public enum AppleLivePhotoConversionEngine {
         let hadImage = fileManager.fileExists(atPath: finalImageURL.path)
         let hadVideo = fileManager.fileExists(atPath: finalVideoURL.path)
         var newImageInstalled = false
-        var newVideoInstalled = false
 
         do {
             if hadImage { try fileManager.moveItem(at: finalImageURL, to: imageBackup) }
@@ -189,12 +194,13 @@ public enum AppleLivePhotoConversionEngine {
             try fileManager.moveItem(at: temporaryImageURL, to: finalImageURL)
             newImageInstalled = true
             try fileManager.moveItem(at: temporaryVideoURL, to: finalVideoURL)
-            newVideoInstalled = true
             if hadImage { try? fileManager.removeItem(at: imageBackup) }
             if hadVideo { try? fileManager.removeItem(at: videoBackup) }
         } catch {
             if newImageInstalled { try? fileManager.removeItem(at: finalImageURL) }
-            if newVideoInstalled { try? fileManager.removeItem(at: finalVideoURL) }
+            // A throwing move of the temporary video cannot have installed it successfully, and
+            // there are no throwing operations after the successful video move. Therefore no
+            // separate newVideoInstalled state is needed here.
             if hadImage, fileManager.fileExists(atPath: imageBackup.path) {
                 try? fileManager.moveItem(at: imageBackup, to: finalImageURL)
             }

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoConversionEngine.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoConversionEngine.swift
@@ -23,7 +23,6 @@ public enum AppleLivePhotoConversionEngine {
         imageURL.deletingPathExtension().appendingPathExtension("mov")
     }
 
-    /// Synchronous entry point for the existing CLI and batch architecture.
     public static func convert(
         inputURL: URL,
         outputImageURL: URL,
@@ -130,6 +129,8 @@ public enum AppleLivePhotoConversionEngine {
             videoURL: temporaryVideoURL,
             expectedAssetIdentifier: assetIdentifier,
             expectedStillImageTime: timeline.stillImageTime,
+            sourceStillURL: stillSourceURL,
+            sourceVideoURL: videoSourceURL,
             sourceHadAudio: sourceHadAudio,
             sourceHadGainMap: sourceHadGainMap,
             expectsOppoTransform: expectedTransform,

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoStillWriter.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoStillWriter.swift
@@ -1,0 +1,121 @@
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+import XDRemuxCore
+
+public enum AppleLivePhotoStillWriter {
+    public static let makerNoteAssetIdentifierKey = "17"
+
+    /// Converts the already-bounded static image resource to HEIC using ImageIO only.
+    /// No XDRemux ProXDR reconstruction path is involved.
+    public static func write(
+        stillInputURL: URL,
+        outputURL: URL,
+        assetIdentifier: String,
+        lossyCompressionQuality: Double? = nil
+    ) throws {
+        let sourceOptions: [CFString: Any] = [
+            kCGImageSourceShouldCache: false,
+            kCGImageSourceShouldCacheImmediately: false,
+        ]
+        guard let source = CGImageSourceCreateWithURL(stillInputURL as CFURL, sourceOptions as CFDictionary),
+              CGImageSourceGetCount(source) > 0 else {
+            throw AppleLivePhotoError.unreadableStillImage
+        }
+
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if FileManager.default.fileExists(atPath: outputURL.path) {
+            try FileManager.default.removeItem(at: outputURL)
+        }
+        guard let destination = CGImageDestinationCreateWithURL(
+            outputURL as CFURL,
+            UTType.heic.identifier as CFString,
+            1,
+            nil
+        ) else {
+            throw AppleLivePhotoError.cannotCreateStillDestination
+        }
+
+        var properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any] ?? [:]
+        var makerApple = properties[kCGImagePropertyMakerAppleDictionary as String] as? [String: Any] ?? [:]
+        makerApple[makerNoteAssetIdentifierKey] = assetIdentifier
+        properties[kCGImagePropertyMakerAppleDictionary as String] = makerApple
+
+        // Motion Photo XMP describes the source's appended-video container and becomes stale once
+        // the still and motion resources are split. Apple documents this flag specifically for
+        // preserving EXIF/IPTC while excluding XMP from the destination.
+        properties[kCGImageMetadataShouldExcludeXMP as String] = true
+        properties[kCGImageDestinationMergeMetadata as String] = true
+        properties[kCGImageDestinationPreserveGainMap as String] = true
+        if let metadata = CGImageSourceCopyMetadataAtIndex(source, 0, nil) {
+            properties[kCGImageDestinationMetadata as String] = metadata
+        }
+        if let quality = lossyCompressionQuality {
+            properties[kCGImageDestinationLossyCompressionQuality as String] = min(1, max(0, quality))
+        }
+
+        CGImageDestinationAddImageFromSource(destination, source, 0, properties as CFDictionary)
+        guard CGImageDestinationFinalize(destination) else {
+            try? FileManager.default.removeItem(at: outputURL)
+            throw AppleLivePhotoError.cannotFinalizeStillImage
+        }
+    }
+
+    public static func assetIdentifier(in imageURL: URL) -> String? {
+        let options = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let source = CGImageSourceCreateWithURL(imageURL as CFURL, options),
+              let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any],
+              let makerApple = properties[kCGImagePropertyMakerAppleDictionary as String] as? [String: Any] else {
+            return nil
+        }
+        if let value = makerApple[makerNoteAssetIdentifierKey] as? String { return value }
+        if let value = makerApple[Int(makerNoteAssetIdentifierKey) ?? 17] as? String { return value }
+        return nil
+    }
+
+    public static func hasGainMap(_ imageURL: URL) -> Bool {
+        let options = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let source = CGImageSourceCreateWithURL(imageURL as CFURL, options) else { return false }
+        if CGImageSourceCopyAuxiliaryDataInfoAtIndex(source, 0, kCGImageAuxiliaryDataTypeISOGainMap) != nil {
+            return true
+        }
+        return CGImageSourceCopyAuxiliaryDataInfoAtIndex(source, 0, kCGImageAuxiliaryDataTypeHDRGainMap) != nil
+    }
+}
+
+public enum AppleLivePhotoError: Error, LocalizedError {
+    case unreadableStillImage
+    case cannotCreateStillDestination
+    case cannotFinalizeStillImage
+    case missingVideoTrack
+    case unsupportedVideoCodec(String)
+    case cannotCreateVideoReader
+    case cannotCreateVideoWriter
+    case cannotStartVideoReader(String)
+    case cannotStartVideoWriter(String)
+    case videoWriteFailed(String)
+    case invalidTimeline
+    case pairValidationFailed(String)
+    case transactionFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unreadableStillImage: return "The Motion Photo still resource cannot be read by ImageIO."
+        case .cannotCreateStillDestination: return "ImageIO could not create the HEIC Live Photo still destination."
+        case .cannotFinalizeStillImage: return "ImageIO could not finalize the HEIC Live Photo still image."
+        case .missingVideoTrack: return "The Motion Photo payload contains no video track."
+        case let .unsupportedVideoCodec(codec): return "The source video codec cannot be passed through to a Live Photo MOV: \(codec)."
+        case .cannotCreateVideoReader: return "AVFoundation could not create the Live Photo video reader."
+        case .cannotCreateVideoWriter: return "AVFoundation could not create the Live Photo MOV writer."
+        case let .cannotStartVideoReader(message): return "AVAssetReader could not start: \(message)."
+        case let .cannotStartVideoWriter(message): return "AVAssetWriter could not start: \(message)."
+        case let .videoWriteFailed(message): return "Live Photo MOV writing failed: \(message)."
+        case .invalidTimeline: return "The Motion Photo still-image time could not be resolved to a valid video timestamp."
+        case let .pairValidationFailed(message): return "Live Photo pair validation failed: \(message)."
+        case let .transactionFailed(message): return "Live Photo output transaction failed: \(message)."
+        }
+    }
+}

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoStillWriter.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoStillWriter.swift
@@ -40,7 +40,7 @@ public enum AppleLivePhotoStillWriter {
         }
 
         var properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any] ?? [:]
-        var makerApple = properties[kCGImagePropertyMakerAppleDictionary as String] as? [String: Any] ?? [:]
+        var makerApple = properties[kCGImagePropertyMakerAppleDictionary as String] as? [AnyHashable: Any] ?? [:]
         makerApple[makerNoteAssetIdentifierKey] = assetIdentifier
         properties[kCGImagePropertyMakerAppleDictionary as String] = makerApple
 
@@ -68,11 +68,11 @@ public enum AppleLivePhotoStillWriter {
         let options = [kCGImageSourceShouldCache: false] as CFDictionary
         guard let source = CGImageSourceCreateWithURL(imageURL as CFURL, options),
               let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any],
-              let makerApple = properties[kCGImagePropertyMakerAppleDictionary as String] as? [String: Any] else {
+              let makerApple = properties[kCGImagePropertyMakerAppleDictionary as String] as? [AnyHashable: Any] else {
             return nil
         }
         if let value = makerApple[makerNoteAssetIdentifierKey] as? String { return value }
-        if let value = makerApple[Int(makerNoteAssetIdentifierKey) ?? 17] as? String { return value }
+        if let value = makerApple[NSNumber(value: 17)] as? String { return value }
         return nil
     }
 

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoTimelineResolver.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoTimelineResolver.swift
@@ -1,0 +1,90 @@
+import Foundation
+@preconcurrency import AVFoundation
+import CoreMedia
+import XDRemuxCore
+
+public struct ResolvedLivePhotoTimeline: Sendable {
+    public let stillImageTime: CMTime
+    public let source: MotionPhotoPresentationSource
+    public let requestedTimestampUs: Int64?
+
+    public var stillImageTimeSeconds: Double { CMTimeGetSeconds(stillImageTime) }
+}
+
+public enum AppleLivePhotoTimelineResolver {
+    public static func resolve(
+        videoURL: URL,
+        requestedTimestampUs: Int64?,
+        requestedSource: MotionPhotoPresentationSource?
+    ) async throws -> ResolvedLivePhotoTimeline {
+        let asset = AVURLAsset(url: videoURL)
+        guard let videoTrack = try await asset.loadTracks(withMediaType: .video).first else {
+            throw AppleLivePhotoError.missingVideoTrack
+        }
+        let duration = try await asset.load(.duration)
+        guard duration.isNumeric, duration > .zero else { throw AppleLivePhotoError.invalidTimeline }
+
+        let timestamps = try samplePresentationTimes(asset: asset, track: videoTrack)
+        guard !timestamps.isEmpty else { throw AppleLivePhotoError.invalidTimeline }
+
+        if let requestedTimestampUs {
+            let requested = CMTime(value: requestedTimestampUs, timescale: 1_000_000)
+            guard requested >= .zero, requested <= duration else { throw AppleLivePhotoError.invalidTimeline }
+            let selected = timestamps.min { lhs, rhs in
+                absoluteDistance(lhs, requested) < absoluteDistance(rhs, requested)
+            } ?? requested
+            return ResolvedLivePhotoTimeline(
+                stillImageTime: selected,
+                source: requestedSource ?? .androidXMP,
+                requestedTimestampUs: requestedTimestampUs
+            )
+        }
+
+        let midpoint = CMTimeMultiplyByFloat64(duration, multiplier: 0.5)
+        var closestIndex = 0
+        var closestDistance = absoluteDistance(timestamps[0], midpoint)
+        if timestamps.count > 1 {
+            for index in 1..<timestamps.count {
+                let distance = absoluteDistance(timestamps[index], midpoint)
+                if distance < closestDistance {
+                    closestDistance = distance
+                    closestIndex = index
+                }
+            }
+        }
+        // Android Motion Photo 1.0 specifies the presentation timestamp immediately preceding
+        // the timestamp closest to the middle of the video track.
+        let selectedIndex = max(0, closestIndex - 1)
+        return ResolvedLivePhotoTimeline(
+            stillImageTime: timestamps[selectedIndex],
+            source: .timelineFallback,
+            requestedTimestampUs: nil
+        )
+    }
+
+    private static func samplePresentationTimes(asset: AVAsset, track: AVAssetTrack) throws -> [CMTime] {
+        let reader = try AVAssetReader(asset: asset)
+        let output = AVAssetReaderTrackOutput(track: track, outputSettings: nil)
+        output.alwaysCopiesSampleData = false
+        guard reader.canAdd(output) else { throw AppleLivePhotoError.cannotCreateVideoReader }
+        reader.add(output)
+        guard reader.startReading() else {
+            throw AppleLivePhotoError.cannotStartVideoReader(reader.error?.localizedDescription ?? "unknown error")
+        }
+
+        var timestamps: [CMTime] = []
+        timestamps.reserveCapacity(256)
+        while let sample = output.copyNextSampleBuffer() {
+            let pts = CMSampleBufferGetPresentationTimeStamp(sample)
+            if pts.isNumeric, pts >= .zero { timestamps.append(pts) }
+        }
+        guard reader.status == .completed || reader.status == .reading else {
+            throw AppleLivePhotoError.cannotStartVideoReader(reader.error?.localizedDescription ?? "sample scan failed")
+        }
+        return timestamps
+    }
+
+    private static func absoluteDistance(_ lhs: CMTime, _ rhs: CMTime) -> Double {
+        abs(CMTimeGetSeconds(lhs) - CMTimeGetSeconds(rhs))
+    }
+}

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
@@ -98,7 +98,7 @@ public enum AppleLivePhotoValidator {
         }
 
         if requirePhotoKitLoad {
-            try await validateWithPhotoKit(imageURL: imageURL, videoURL: videoURL)
+            try validateWithPhotoKit(imageURL: imageURL, videoURL: videoURL)
         }
 
         return AppleLivePhotoValidationReport(
@@ -127,7 +127,7 @@ public enum AppleLivePhotoValidator {
             }
             semaphore.signal()
         }
-        semaphore.wait()
+        guard semaphore.wait(timeout: .now() + 30) == .success else { return false }
         return box.value
     }
 
@@ -181,27 +181,31 @@ public enum AppleLivePhotoValidator {
         return nil
     }
 
-    private static func validateWithPhotoKit(imageURL: URL, videoURL: URL) async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            let state = PhotoKitContinuationState()
-            PHLivePhoto.request(
-                withResourceFileURLs: [imageURL, videoURL],
-                placeholderImage: nil,
-                targetSize: .zero,
-                contentMode: .aspectFit
-            ) { livePhoto, info in
-                if (info[PHLivePhotoInfoIsDegradedKey] as? Bool) == true { return }
-                guard state.beginIfNeeded() else { return }
-                if livePhoto != nil {
-                    continuation.resume()
-                } else {
-                    let error = info[PHLivePhotoInfoErrorKey] as? Error
-                    continuation.resume(throwing: AppleLivePhotoError.pairValidationFailed(
-                        error?.localizedDescription ?? "PhotoKit could not construct PHLivePhoto from the resource pair"
-                    ))
-                }
+    private static func validateWithPhotoKit(imageURL: URL, videoURL: URL) throws {
+        let semaphore = DispatchSemaphore(value: 0)
+        let box = PhotoKitValidationBox()
+        PHLivePhoto.request(
+            withResourceFileURLs: [imageURL, videoURL],
+            placeholderImage: nil,
+            targetSize: .zero,
+            contentMode: .aspectFit
+        ) { livePhoto, info in
+            if (info[PHLivePhotoInfoIsDegradedKey] as? Bool) == true { return }
+            if livePhoto != nil {
+                box.set(.success(()))
+            } else {
+                let underlying = info[PHLivePhotoInfoErrorKey] as? Error
+                box.set(.failure(AppleLivePhotoError.pairValidationFailed(
+                    underlying?.localizedDescription
+                        ?? "PhotoKit could not construct PHLivePhoto from the resource pair"
+                )))
             }
+            semaphore.signal()
         }
+        guard semaphore.wait(timeout: .now() + 30) == .success else {
+            throw AppleLivePhotoError.pairValidationFailed("PhotoKit validation timed out")
+        }
+        try box.result.get()
     }
 }
 
@@ -212,13 +216,16 @@ private final class ValidationResultBox: @unchecked Sendable {
     func set(_ value: Bool) { lock.lock(); defer { lock.unlock() }; stored = value }
 }
 
-private final class PhotoKitContinuationState: @unchecked Sendable {
+private final class PhotoKitValidationBox: @unchecked Sendable {
     private let lock = NSLock()
-    private var resumed = false
-    func beginIfNeeded() -> Bool {
+    private var stored: Result<Void, Error>?
+    var result: Result<Void, Error> {
         lock.lock(); defer { lock.unlock() }
-        guard !resumed else { return false }
-        resumed = true
-        return true
+        return stored ?? .failure(AppleLivePhotoError.pairValidationFailed("PhotoKit validation produced no final result"))
+    }
+    func set(_ value: Result<Void, Error>) {
+        lock.lock(); defer { lock.unlock() }
+        guard stored == nil else { return }
+        stored = value
     }
 }

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
@@ -2,6 +2,7 @@ import Foundation
 import AppKit
 @preconcurrency import AVFoundation
 import CoreMedia
+import ImageIO
 import Photos
 import XDRemuxCore
 
@@ -24,6 +25,8 @@ public enum AppleLivePhotoValidator {
         videoURL: URL,
         expectedAssetIdentifier: String? = nil,
         expectedStillImageTime: CMTime? = nil,
+        sourceStillURL: URL? = nil,
+        sourceVideoURL: URL? = nil,
         sourceHadAudio: Bool? = nil,
         sourceHadGainMap: Bool? = nil,
         expectsOppoTransform: Bool = false,
@@ -42,6 +45,9 @@ public enum AppleLivePhotoValidator {
         if let expectedAssetIdentifier, imageIdentifier != expectedAssetIdentifier {
             throw AppleLivePhotoError.pairValidationFailed("HEIC asset identifier does not match the requested identifier")
         }
+        if let sourceStillURL {
+            try validateStillGeometry(source: sourceStillURL, output: imageURL)
+        }
 
         let asset = AVURLAsset(url: videoURL)
         let videoTracks = try await asset.loadTracks(withMediaType: .video)
@@ -51,6 +57,9 @@ public enum AppleLivePhotoValidator {
         let duration = try await asset.load(.duration)
         guard duration.isNumeric, duration > .zero else {
             throw AppleLivePhotoError.pairValidationFailed("MOV duration is invalid")
+        }
+        if let sourceVideoURL {
+            try await validateCompressedPassthrough(sourceURL: sourceVideoURL, outputAsset: asset)
         }
 
         guard let videoIdentifier = await AppleLivePhotoVideoWriter.contentIdentifier(in: videoURL),
@@ -136,6 +145,69 @@ public enum AppleLivePhotoValidator {
         var stillImageTimes: [CMTime] = []
         var hasTransform = false
         var hasTransformReferenceDimensions = false
+    }
+
+    private struct StillGeometry: Equatable {
+        let width: Int
+        let height: Int
+        let orientation: Int
+    }
+
+    private static func validateStillGeometry(source: URL, output: URL) throws {
+        guard let sourceGeometry = stillGeometry(source),
+              let outputGeometry = stillGeometry(output) else {
+            throw AppleLivePhotoError.pairValidationFailed("could not read source/output still geometry")
+        }
+        guard sourceGeometry == outputGeometry else {
+            throw AppleLivePhotoError.pairValidationFailed(
+                "HEIC still geometry/orientation changed from \(sourceGeometry) to \(outputGeometry)"
+            )
+        }
+    }
+
+    private static func stillGeometry(_ url: URL) -> StillGeometry? {
+        guard let source = CGImageSourceCreateWithURL(
+            url as CFURL,
+            [kCGImageSourceShouldCache: false] as CFDictionary
+        ),
+        let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+        let width = (properties[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue,
+        let height = (properties[kCGImagePropertyPixelHeight] as? NSNumber)?.intValue else {
+            return nil
+        }
+        let orientation = (properties[kCGImagePropertyOrientation] as? NSNumber)?.intValue ?? 1
+        return StillGeometry(width: width, height: height, orientation: orientation)
+    }
+
+    private static func validateCompressedPassthrough(
+        sourceURL: URL,
+        outputAsset: AVAsset
+    ) async throws {
+        let sourceAsset = AVURLAsset(url: sourceURL)
+        let sourceVideo = try await mediaSubtypes(asset: sourceAsset, mediaType: .video)
+        let outputVideo = try await mediaSubtypes(asset: outputAsset, mediaType: .video)
+        guard sourceVideo == outputVideo else {
+            throw AppleLivePhotoError.pairValidationFailed(
+                "video codec/layout changed during passthrough: \(sourceVideo) -> \(outputVideo)"
+            )
+        }
+        let sourceAudio = try await mediaSubtypes(asset: sourceAsset, mediaType: .audio)
+        let outputAudio = try await mediaSubtypes(asset: outputAsset, mediaType: .audio)
+        guard sourceAudio == outputAudio else {
+            throw AppleLivePhotoError.pairValidationFailed(
+                "audio codec/layout changed during passthrough: \(sourceAudio) -> \(outputAudio)"
+            )
+        }
+    }
+
+    private static func mediaSubtypes(asset: AVAsset, mediaType: AVMediaType) async throws -> [FourCharCode] {
+        let tracks = try await asset.loadTracks(withMediaType: mediaType)
+        var result: [FourCharCode] = []
+        for track in tracks {
+            let descriptions = try await track.load(.formatDescriptions)
+            result.append(contentsOf: descriptions.map(CMFormatDescriptionGetMediaSubType))
+        }
+        return result
     }
 
     private static func readTimedMetadata(from asset: AVAsset) async throws -> TimedMetadataSummary {

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AppKit
 @preconcurrency import AVFoundation
 import CoreMedia
 import Photos

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
@@ -157,7 +157,7 @@ public enum AppleLivePhotoValidator {
     private struct CompressedTrackFingerprint: Equatable {
         let mediaSubtype: FourCharCode
         let byteCount: Int64
-        let sampleBufferCount: Int
+        let sampleCount: Int64
         let sha256: String
     }
 
@@ -209,9 +209,10 @@ public enum AppleLivePhotoValidator {
         }
     }
 
-    /// Fingerprints the compressed sample payload rather than decoded frames. Equality proves that
-    /// AVAssetReader/Writer remuxing did not silently transcode H.264/HEVC/AAC content. Sample-buffer
-    /// boundaries are included because the writer receives those same buffers in passthrough mode.
+    /// Hashes exact compressed sample bytes directly from each track's storage ranges. This avoids
+    /// relying on CMSampleBufferGetDataBuffer, which may legitimately be nil for samples represented
+    /// by another backing object. AVSampleCursor exposes the encoded sample's storage URL, offset and
+    /// length, so equality across MP4 -> MOV proves remuxing without a decode/re-encode step.
     private static func compressedFingerprints(
         asset: AVAsset,
         mediaType: AVMediaType
@@ -221,65 +222,67 @@ public enum AppleLivePhotoValidator {
         fingerprints.reserveCapacity(tracks.count)
 
         for track in tracks {
+            guard let cursor = track.makeSampleCursorAtFirstSampleInDecodeOrder() else {
+                throw AppleLivePhotoError.pairValidationFailed("media track cannot provide a sample cursor")
+            }
             let descriptions = try await track.load(.formatDescriptions)
             guard let description = descriptions.first else {
                 throw AppleLivePhotoError.pairValidationFailed("media track has no format description")
             }
-            let reader = try AVAssetReader(asset: asset)
-            let output = AVAssetReaderTrackOutput(track: track, outputSettings: nil)
-            output.alwaysCopiesSampleData = false
-            guard reader.canAdd(output) else {
-                throw AppleLivePhotoError.pairValidationFailed("cannot read compressed media track")
-            }
-            reader.add(output)
-            guard reader.startReading() else {
-                throw AppleLivePhotoError.pairValidationFailed(
-                    reader.error?.localizedDescription ?? "compressed media reader failed to start"
-                )
-            }
 
             var hasher = SHA256()
             var byteCount: Int64 = 0
-            var sampleBufferCount = 0
-            while let sample = output.copyNextSampleBuffer() {
-                guard let block = CMSampleBufferGetDataBuffer(sample) else {
-                    throw AppleLivePhotoError.pairValidationFailed("compressed sample has no data buffer")
-                }
-                let length = CMBlockBufferGetDataLength(block)
-                guard length >= 0 else {
-                    throw AppleLivePhotoError.pairValidationFailed("compressed sample has an invalid data length")
-                }
-                var data = Data(count: length)
-                let copyStatus = data.withUnsafeMutableBytes { rawBuffer -> OSStatus in
-                    guard let base = rawBuffer.baseAddress else { return kCMBlockBufferBadOffsetParameterErr }
-                    return CMBlockBufferCopyDataBytes(
-                        block,
-                        atOffset: 0,
-                        dataLength: length,
-                        destination: base
-                    )
-                }
-                guard copyStatus == kCMBlockBufferNoErr else {
+            var sampleCount: Int64 = 0
+            var handles: [URL: FileHandle] = [:]
+            defer {
+                for handle in handles.values { try? handle.close() }
+            }
+
+            while true {
+                let range = cursor.currentSampleStorageRange
+                guard range.offset >= 0, range.length > 0 else {
                     throw AppleLivePhotoError.pairValidationFailed(
-                        "could not read compressed sample bytes (\(copyStatus))"
+                        "compressed media sample is not stored contiguously"
                     )
                 }
-                var lengthBE = UInt64(length).bigEndian
-                withUnsafeBytes(of: &lengthBE) { hasher.update(bufferPointer: $0) }
-                hasher.update(data: data)
-                byteCount += Int64(length)
-                sampleBufferCount += 1
+                guard let storageURL = cursor.currentChunkStorageURL else {
+                    throw AppleLivePhotoError.pairValidationFailed(
+                        "compressed media sample has no storage URL"
+                    )
+                }
+                let standardizedURL = storageURL.standardizedFileURL
+                let handle: FileHandle
+                if let existing = handles[standardizedURL] {
+                    handle = existing
+                } else {
+                    let created = try FileHandle(forReadingFrom: standardizedURL)
+                    handles[standardizedURL] = created
+                    handle = created
+                }
+                try handle.seek(toOffset: UInt64(range.offset))
+
+                var remaining = range.length
+                while remaining > 0 {
+                    let request = Int(min(remaining, 1 << 20))
+                    guard let chunk = try handle.read(upToCount: request), !chunk.isEmpty else {
+                        throw AppleLivePhotoError.pairValidationFailed(
+                            "compressed media sample storage is truncated"
+                        )
+                    }
+                    hasher.update(data: chunk)
+                    byteCount += Int64(chunk.count)
+                    remaining -= Int64(chunk.count)
+                }
+                sampleCount += 1
+
+                if cursor.stepInDecodeOrder(byCount: 1) != 1 { break }
             }
-            guard reader.status == .completed else {
-                throw AppleLivePhotoError.pairValidationFailed(
-                    reader.error?.localizedDescription ?? "compressed media reader did not complete"
-                )
-            }
+
             fingerprints.append(
                 CompressedTrackFingerprint(
                     mediaSubtype: CMFormatDescriptionGetMediaSubType(description),
                     byteCount: byteCount,
-                    sampleBufferCount: sampleBufferCount,
+                    sampleCount: sampleCount,
                     sha256: hasher.finalize().map { String(format: "%02x", $0) }.joined()
                 )
             )
@@ -289,7 +292,7 @@ public enum AppleLivePhotoValidator {
 
     private static func fingerprintSummary(_ fingerprints: [CompressedTrackFingerprint]) -> String {
         fingerprints.map {
-            "\(fourCC($0.mediaSubtype))/\($0.sampleBufferCount)/\($0.byteCount)/\($0.sha256.prefix(12))"
+            "\(fourCC($0.mediaSubtype))/\($0.sampleCount)/\($0.byteCount)/\($0.sha256.prefix(12))"
         }.joined(separator: ",")
     }
 

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
@@ -1,0 +1,242 @@
+import Foundation
+@preconcurrency import AVFoundation
+import CoreMedia
+import Photos
+import XDRemuxCore
+
+public struct AppleLivePhotoValidationReport: Sendable {
+    public let assetIdentifier: String
+    public let stillImageTime: CMTime
+    public let hasAudio: Bool
+    public let hasGainMap: Bool
+    public let hasTransform: Bool
+    public let hasTransformReferenceDimensions: Bool
+}
+
+public enum AppleLivePhotoValidator {
+    private static let stillImageTimeKey = "com.apple.quicktime.still-image-time"
+    private static let transformKey = "com.apple.quicktime.live-photo-still-image-transform"
+    private static let transformReferenceDimensionsKey = "com.apple.quicktime.live-photo-still-image-transform-reference-dimensions"
+
+    public static func validate(
+        imageURL: URL,
+        videoURL: URL,
+        expectedAssetIdentifier: String? = nil,
+        expectedStillImageTime: CMTime? = nil,
+        sourceHadAudio: Bool? = nil,
+        sourceHadGainMap: Bool? = nil,
+        expectsOppoTransform: Bool = false,
+        requirePhotoKitLoad: Bool = true
+    ) async throws -> AppleLivePhotoValidationReport {
+        guard FileManager.default.fileExists(atPath: imageURL.path) else {
+            throw AppleLivePhotoError.pairValidationFailed("HEIC resource is missing")
+        }
+        guard FileManager.default.fileExists(atPath: videoURL.path) else {
+            throw AppleLivePhotoError.pairValidationFailed("MOV resource is missing")
+        }
+        guard let imageIdentifier = AppleLivePhotoStillWriter.assetIdentifier(in: imageURL),
+              !imageIdentifier.isEmpty else {
+            throw AppleLivePhotoError.pairValidationFailed("HEIC MakerApple[17] asset identifier is missing")
+        }
+        if let expectedAssetIdentifier, imageIdentifier != expectedAssetIdentifier {
+            throw AppleLivePhotoError.pairValidationFailed("HEIC asset identifier does not match the requested identifier")
+        }
+
+        let asset = AVURLAsset(url: videoURL)
+        let videoTracks = try await asset.loadTracks(withMediaType: .video)
+        guard !videoTracks.isEmpty else {
+            throw AppleLivePhotoError.pairValidationFailed("MOV contains no video track")
+        }
+        let duration = try await asset.load(.duration)
+        guard duration.isNumeric, duration > .zero else {
+            throw AppleLivePhotoError.pairValidationFailed("MOV duration is invalid")
+        }
+
+        guard let videoIdentifier = await AppleLivePhotoVideoWriter.contentIdentifier(in: videoURL),
+              videoIdentifier == imageIdentifier else {
+            throw AppleLivePhotoError.pairValidationFailed("HEIC and MOV content identifiers do not match")
+        }
+
+        let timed = try readTimedMetadata(from: asset)
+        guard timed.stillImageTimes.count == 1 else {
+            throw AppleLivePhotoError.pairValidationFailed(
+                "MOV must contain exactly one still-image-time sample; found \(timed.stillImageTimes.count)"
+            )
+        }
+        let stillImageTime = timed.stillImageTimes[0]
+        guard stillImageTime >= .zero, stillImageTime <= duration else {
+            throw AppleLivePhotoError.pairValidationFailed("still-image-time lies outside the MOV timeline")
+        }
+        if let expectedStillImageTime {
+            let delta = abs(CMTimeGetSeconds(stillImageTime) - CMTimeGetSeconds(expectedStillImageTime))
+            guard delta <= 0.001 else {
+                throw AppleLivePhotoError.pairValidationFailed(
+                    "still-image-time differs from the resolved source timestamp by \(delta) seconds"
+                )
+            }
+        }
+
+        let audioTracks = try await asset.loadTracks(withMediaType: .audio)
+        let hasAudio = !audioTracks.isEmpty
+        if sourceHadAudio == true, !hasAudio {
+            throw AppleLivePhotoError.pairValidationFailed("source audio track was not preserved")
+        }
+        if sourceHadAudio == false, hasAudio {
+            throw AppleLivePhotoError.pairValidationFailed("output unexpectedly gained an audio track")
+        }
+
+        let hasGainMap = AppleLivePhotoStillWriter.hasGainMap(imageURL)
+        if sourceHadGainMap == true, !hasGainMap {
+            throw AppleLivePhotoError.pairValidationFailed("source gain map was not preserved in the HEIC still")
+        }
+
+        if expectsOppoTransform, !timed.hasTransform {
+            throw AppleLivePhotoError.pairValidationFailed("expected OPPO Live Photo transform metadata is missing")
+        }
+        if timed.hasTransform, !timed.hasTransformReferenceDimensions {
+            throw AppleLivePhotoError.pairValidationFailed("Live Photo transform is missing reference dimensions")
+        }
+
+        if requirePhotoKitLoad {
+            try await validateWithPhotoKit(imageURL: imageURL, videoURL: videoURL)
+        }
+
+        return AppleLivePhotoValidationReport(
+            assetIdentifier: imageIdentifier,
+            stillImageTime: stillImageTime,
+            hasAudio: hasAudio,
+            hasGainMap: hasGainMap,
+            hasTransform: timed.hasTransform,
+            hasTransformReferenceDimensions: timed.hasTransformReferenceDimensions
+        )
+    }
+
+    public static func isValidPair(imageURL: URL, videoURL: URL) -> Bool {
+        let semaphore = DispatchSemaphore(value: 0)
+        let box = ValidationResultBox()
+        Task.detached {
+            do {
+                _ = try await validate(
+                    imageURL: imageURL,
+                    videoURL: videoURL,
+                    requirePhotoKitLoad: false
+                )
+                box.set(true)
+            } catch {
+                box.set(false)
+            }
+            semaphore.signal()
+        }
+        semaphore.wait()
+        return box.value
+    }
+
+    private struct TimedMetadataSummary {
+        var stillImageTimes: [CMTime] = []
+        var hasTransform = false
+        var hasTransformReferenceDimensions = false
+    }
+
+    private static func readTimedMetadata(from asset: AVAsset) throws -> TimedMetadataSummary {
+        let semaphore = DispatchSemaphore(value: 0)
+        let box = TimedMetadataResultBox()
+        Task.detached {
+            do {
+                let metadataTracks = try await asset.loadTracks(withMediaType: .metadata)
+                var summary = TimedMetadataSummary()
+                for track in metadataTracks {
+                    let reader = try AVAssetReader(asset: asset)
+                    let output = AVAssetReaderTrackOutput(track: track, outputSettings: nil)
+                    output.alwaysCopiesSampleData = false
+                    guard reader.canAdd(output) else { continue }
+                    reader.add(output)
+                    let adaptor = AVAssetReaderOutputMetadataAdaptor(assetReaderTrackOutput: output)
+                    guard reader.startReading() else { continue }
+                    while let group = adaptor.nextTimedMetadataGroup() {
+                        for item in group.items {
+                            let key = metadataKey(item)
+                            if key == stillImageTimeKey {
+                                summary.stillImageTimes.append(group.timeRange.start)
+                            } else if key == transformKey {
+                                summary.hasTransform = true
+                            } else if key == transformReferenceDimensionsKey {
+                                summary.hasTransformReferenceDimensions = true
+                            }
+                        }
+                    }
+                }
+                box.set(.success(summary))
+            } catch {
+                box.set(.failure(error))
+            }
+            semaphore.signal()
+        }
+        semaphore.wait()
+        return try box.result.get()
+    }
+
+    private static func metadataKey(_ item: AVMetadataItem) -> String? {
+        if let key = item.key as? String { return key }
+        if let key = item.key as? NSString { return key as String }
+        if let identifier = item.identifier?.rawValue {
+            if let slash = identifier.lastIndex(of: "/") {
+                return String(identifier[identifier.index(after: slash)...])
+            }
+            return identifier
+        }
+        return nil
+    }
+
+    private static func validateWithPhotoKit(imageURL: URL, videoURL: URL) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            let state = PhotoKitContinuationState()
+            PHLivePhoto.request(
+                withResourceFileURLs: [imageURL, videoURL],
+                placeholderImage: nil,
+                targetSize: .zero,
+                contentMode: .aspectFit
+            ) { livePhoto, info in
+                if (info[PHLivePhotoInfoIsDegradedKey] as? Bool) == true { return }
+                guard state.beginIfNeeded() else { return }
+                if livePhoto != nil {
+                    continuation.resume()
+                } else {
+                    let error = info[PHLivePhotoInfoErrorKey] as? Error
+                    continuation.resume(throwing: AppleLivePhotoError.pairValidationFailed(
+                        error?.localizedDescription ?? "PhotoKit could not construct PHLivePhoto from the resource pair"
+                    ))
+                }
+            }
+        }
+    }
+}
+
+private final class ValidationResultBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored = false
+    var value: Bool { lock.lock(); defer { lock.unlock() }; return stored }
+    func set(_ value: Bool) { lock.lock(); defer { lock.unlock() }; stored = value }
+}
+
+private final class TimedMetadataResultBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: Result<AppleLivePhotoValidator.TimedMetadataSummary, Error>?
+    var result: Result<AppleLivePhotoValidator.TimedMetadataSummary, Error> {
+        lock.lock(); defer { lock.unlock() }
+        return stored ?? .failure(AppleLivePhotoError.pairValidationFailed("timed metadata validation did not complete"))
+    }
+    func set(_ value: Result<AppleLivePhotoValidator.TimedMetadataSummary, Error>) {
+        lock.lock(); defer { lock.unlock() }; stored = value
+    }
+}
+
+private final class PhotoKitContinuationState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var resumed = false
+    func beginIfNeeded() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard !resumed else { return false }
+        resumed = true
+        return true
+    }
+}

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
@@ -79,10 +79,24 @@ public enum AppleLivePhotoValidator {
             throw AppleLivePhotoError.pairValidationFailed("still-image-time lies outside the MOV timeline")
         }
         if let expectedStillImageTime {
-            let delta = abs(CMTimeGetSeconds(stillImageTime) - CMTimeGetSeconds(expectedStillImageTime))
-            guard delta <= 0.001 else {
+            // AVAssetWriter stores timed metadata on the MOV metadata track's integer timebase.
+            // Real camera timestamps can have microsecond or video-track precision, so the exact
+            // source PTS is not always representable after muxing. Validate at the precision of the
+            // stored metadata timestamp rather than using an arbitrary fixed 1 ms threshold.
+            let storedScale = stillImageTime.timescale
+            guard storedScale > 0 else {
+                throw AppleLivePhotoError.pairValidationFailed("still-image-time has an invalid timescale")
+            }
+            let quantizedExpected = CMTimeConvertScale(
+                expectedStillImageTime,
+                timescale: storedScale,
+                method: .roundHalfAwayFromZero
+            )
+            let delta = abs(CMTimeGetSeconds(stillImageTime) - CMTimeGetSeconds(quantizedExpected))
+            let oneStoredTick = 1.0 / Double(storedScale)
+            guard delta <= oneStoredTick + 1e-9 else {
                 throw AppleLivePhotoError.pairValidationFailed(
-                    "still-image-time differs from the resolved source timestamp by \(delta) seconds"
+                    "still-image-time differs from the resolved source timestamp beyond one stored metadata tick: delta=\(delta) s, timescale=\(storedScale)"
                 )
             }
         }

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
@@ -2,6 +2,7 @@ import Foundation
 import AppKit
 @preconcurrency import AVFoundation
 import CoreMedia
+import CryptoKit
 import ImageIO
 import Photos
 import XDRemuxCore
@@ -153,6 +154,13 @@ public enum AppleLivePhotoValidator {
         let orientation: Int
     }
 
+    private struct CompressedTrackFingerprint: Equatable {
+        let mediaSubtype: FourCharCode
+        let byteCount: Int64
+        let sampleBufferCount: Int
+        let sha256: String
+    }
+
     private static func validateStillGeometry(source: URL, output: URL) throws {
         guard let sourceGeometry = stillGeometry(source),
               let outputGeometry = stillGeometry(output) else {
@@ -184,30 +192,115 @@ public enum AppleLivePhotoValidator {
         outputAsset: AVAsset
     ) async throws {
         let sourceAsset = AVURLAsset(url: sourceURL)
-        let sourceVideo = try await mediaSubtypes(asset: sourceAsset, mediaType: .video)
-        let outputVideo = try await mediaSubtypes(asset: outputAsset, mediaType: .video)
+        let sourceVideo = try await compressedFingerprints(asset: sourceAsset, mediaType: .video)
+        let outputVideo = try await compressedFingerprints(asset: outputAsset, mediaType: .video)
         guard sourceVideo == outputVideo else {
             throw AppleLivePhotoError.pairValidationFailed(
-                "video codec/layout changed during passthrough: \(sourceVideo) -> \(outputVideo)"
+                "compressed video payload changed during passthrough: \(fingerprintSummary(sourceVideo)) -> \(fingerprintSummary(outputVideo))"
             )
         }
-        let sourceAudio = try await mediaSubtypes(asset: sourceAsset, mediaType: .audio)
-        let outputAudio = try await mediaSubtypes(asset: outputAsset, mediaType: .audio)
+
+        let sourceAudio = try await compressedFingerprints(asset: sourceAsset, mediaType: .audio)
+        let outputAudio = try await compressedFingerprints(asset: outputAsset, mediaType: .audio)
         guard sourceAudio == outputAudio else {
             throw AppleLivePhotoError.pairValidationFailed(
-                "audio codec/layout changed during passthrough: \(sourceAudio) -> \(outputAudio)"
+                "compressed audio payload changed during passthrough: \(fingerprintSummary(sourceAudio)) -> \(fingerprintSummary(outputAudio))"
             )
         }
     }
 
-    private static func mediaSubtypes(asset: AVAsset, mediaType: AVMediaType) async throws -> [FourCharCode] {
+    /// Fingerprints the compressed sample payload rather than decoded frames. Equality proves that
+    /// AVAssetReader/Writer remuxing did not silently transcode H.264/HEVC/AAC content. Sample-buffer
+    /// boundaries are included because the writer receives those same buffers in passthrough mode.
+    private static func compressedFingerprints(
+        asset: AVAsset,
+        mediaType: AVMediaType
+    ) async throws -> [CompressedTrackFingerprint] {
         let tracks = try await asset.loadTracks(withMediaType: mediaType)
-        var result: [FourCharCode] = []
+        var fingerprints: [CompressedTrackFingerprint] = []
+        fingerprints.reserveCapacity(tracks.count)
+
         for track in tracks {
             let descriptions = try await track.load(.formatDescriptions)
-            result.append(contentsOf: descriptions.map(CMFormatDescriptionGetMediaSubType))
+            guard let description = descriptions.first else {
+                throw AppleLivePhotoError.pairValidationFailed("media track has no format description")
+            }
+            let reader = try AVAssetReader(asset: asset)
+            let output = AVAssetReaderTrackOutput(track: track, outputSettings: nil)
+            output.alwaysCopiesSampleData = false
+            guard reader.canAdd(output) else {
+                throw AppleLivePhotoError.pairValidationFailed("cannot read compressed media track")
+            }
+            reader.add(output)
+            guard reader.startReading() else {
+                throw AppleLivePhotoError.pairValidationFailed(
+                    reader.error?.localizedDescription ?? "compressed media reader failed to start"
+                )
+            }
+
+            var hasher = SHA256()
+            var byteCount: Int64 = 0
+            var sampleBufferCount = 0
+            while let sample = output.copyNextSampleBuffer() {
+                guard let block = CMSampleBufferGetDataBuffer(sample) else {
+                    throw AppleLivePhotoError.pairValidationFailed("compressed sample has no data buffer")
+                }
+                let length = CMBlockBufferGetDataLength(block)
+                guard length >= 0 else {
+                    throw AppleLivePhotoError.pairValidationFailed("compressed sample has an invalid data length")
+                }
+                var data = Data(count: length)
+                let copyStatus = data.withUnsafeMutableBytes { rawBuffer -> OSStatus in
+                    guard let base = rawBuffer.baseAddress else { return kCMBlockBufferBadOffsetParameterErr }
+                    return CMBlockBufferCopyDataBytes(
+                        block,
+                        atOffset: 0,
+                        dataLength: length,
+                        destination: base
+                    )
+                }
+                guard copyStatus == kCMBlockBufferNoErr else {
+                    throw AppleLivePhotoError.pairValidationFailed(
+                        "could not read compressed sample bytes (\(copyStatus))"
+                    )
+                }
+                var lengthBE = UInt64(length).bigEndian
+                withUnsafeBytes(of: &lengthBE) { hasher.update(bufferPointer: $0) }
+                hasher.update(data: data)
+                byteCount += Int64(length)
+                sampleBufferCount += 1
+            }
+            guard reader.status == .completed else {
+                throw AppleLivePhotoError.pairValidationFailed(
+                    reader.error?.localizedDescription ?? "compressed media reader did not complete"
+                )
+            }
+            fingerprints.append(
+                CompressedTrackFingerprint(
+                    mediaSubtype: CMFormatDescriptionGetMediaSubType(description),
+                    byteCount: byteCount,
+                    sampleBufferCount: sampleBufferCount,
+                    sha256: hasher.finalize().map { String(format: "%02x", $0) }.joined()
+                )
+            )
         }
-        return result
+        return fingerprints
+    }
+
+    private static func fingerprintSummary(_ fingerprints: [CompressedTrackFingerprint]) -> String {
+        fingerprints.map {
+            "\(fourCC($0.mediaSubtype))/\($0.sampleBufferCount)/\($0.byteCount)/\($0.sha256.prefix(12))"
+        }.joined(separator: ",")
+    }
+
+    private static func fourCC(_ code: FourCharCode) -> String {
+        let bytes: [UInt8] = [
+            UInt8((code >> 24) & 0xff),
+            UInt8((code >> 16) & 0xff),
+            UInt8((code >> 8) & 0xff),
+            UInt8(code & 0xff),
+        ]
+        return String(bytes: bytes, encoding: .macOSRoman) ?? String(format: "0x%08x", code)
     }
 
     private static func readTimedMetadata(from asset: AVAsset) async throws -> TimedMetadataSummary {

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
@@ -57,7 +57,7 @@ public enum AppleLivePhotoValidator {
             throw AppleLivePhotoError.pairValidationFailed("HEIC and MOV content identifiers do not match")
         }
 
-        let timed = try readTimedMetadata(from: asset)
+        let timed = try await readTimedMetadata(from: asset)
         guard timed.stillImageTimes.count == 1 else {
             throw AppleLivePhotoError.pairValidationFailed(
                 "MOV must contain exactly one still-image-time sample; found \(timed.stillImageTimes.count)"
@@ -137,42 +137,36 @@ public enum AppleLivePhotoValidator {
         var hasTransformReferenceDimensions = false
     }
 
-    private static func readTimedMetadata(from asset: AVAsset) throws -> TimedMetadataSummary {
-        let semaphore = DispatchSemaphore(value: 0)
-        let box = TimedMetadataResultBox()
-        Task.detached {
-            do {
-                let metadataTracks = try await asset.loadTracks(withMediaType: .metadata)
-                var summary = TimedMetadataSummary()
-                for track in metadataTracks {
-                    let reader = try AVAssetReader(asset: asset)
-                    let output = AVAssetReaderTrackOutput(track: track, outputSettings: nil)
-                    output.alwaysCopiesSampleData = false
-                    guard reader.canAdd(output) else { continue }
-                    reader.add(output)
-                    let adaptor = AVAssetReaderOutputMetadataAdaptor(assetReaderTrackOutput: output)
-                    guard reader.startReading() else { continue }
-                    while let group = adaptor.nextTimedMetadataGroup() {
-                        for item in group.items {
-                            let key = metadataKey(item)
-                            if key == stillImageTimeKey {
-                                summary.stillImageTimes.append(group.timeRange.start)
-                            } else if key == transformKey {
-                                summary.hasTransform = true
-                            } else if key == transformReferenceDimensionsKey {
-                                summary.hasTransformReferenceDimensions = true
-                            }
-                        }
+    private static func readTimedMetadata(from asset: AVAsset) async throws -> TimedMetadataSummary {
+        let metadataTracks = try await asset.loadTracks(withMediaType: .metadata)
+        var summary = TimedMetadataSummary()
+        for track in metadataTracks {
+            let reader = try AVAssetReader(asset: asset)
+            let output = AVAssetReaderTrackOutput(track: track, outputSettings: nil)
+            output.alwaysCopiesSampleData = false
+            guard reader.canAdd(output) else { continue }
+            reader.add(output)
+            let adaptor = AVAssetReaderOutputMetadataAdaptor(assetReaderTrackOutput: output)
+            guard reader.startReading() else { continue }
+            while let group = adaptor.nextTimedMetadataGroup() {
+                for item in group.items {
+                    let key = metadataKey(item)
+                    if key == stillImageTimeKey {
+                        summary.stillImageTimes.append(group.timeRange.start)
+                    } else if key == transformKey {
+                        summary.hasTransform = true
+                    } else if key == transformReferenceDimensionsKey {
+                        summary.hasTransformReferenceDimensions = true
                     }
                 }
-                box.set(.success(summary))
-            } catch {
-                box.set(.failure(error))
             }
-            semaphore.signal()
+            if reader.status == .failed {
+                throw AppleLivePhotoError.pairValidationFailed(
+                    reader.error?.localizedDescription ?? "timed metadata track could not be read"
+                )
+            }
         }
-        semaphore.wait()
-        return try box.result.get()
+        return summary
     }
 
     private static func metadataKey(_ item: AVMetadataItem) -> String? {
@@ -216,18 +210,6 @@ private final class ValidationResultBox: @unchecked Sendable {
     private var stored = false
     var value: Bool { lock.lock(); defer { lock.unlock() }; return stored }
     func set(_ value: Bool) { lock.lock(); defer { lock.unlock() }; stored = value }
-}
-
-private final class TimedMetadataResultBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var stored: Result<AppleLivePhotoValidator.TimedMetadataSummary, Error>?
-    var result: Result<AppleLivePhotoValidator.TimedMetadataSummary, Error> {
-        lock.lock(); defer { lock.unlock() }
-        return stored ?? .failure(AppleLivePhotoError.pairValidationFailed("timed metadata validation did not complete"))
-    }
-    func set(_ value: Result<AppleLivePhotoValidator.TimedMetadataSummary, Error>) {
-        lock.lock(); defer { lock.unlock() }; stored = value
-    }
 }
 
 private final class PhotoKitContinuationState: @unchecked Sendable {

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoVideoWriter.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoVideoWriter.swift
@@ -47,6 +47,10 @@ public enum AppleLivePhotoVideoWriter {
             throw AppleLivePhotoError.cannotCreateVideoWriter
         }
 
+        // nil output settings are intentional. AVFoundation documents nil reader settings as
+        // "samples in their original stored format" and nil writer settings as passthrough without
+        // re-encoding. The pair validator independently hashes the encoded storage samples before
+        // and after remuxing so this contract is also verified at runtime.
         let videoOutput = AVAssetReaderTrackOutput(track: videoTrack, outputSettings: nil)
         videoOutput.alwaysCopiesSampleData = false
         guard reader.canAdd(videoOutput) else { throw AppleLivePhotoError.cannotCreateVideoReader }
@@ -178,7 +182,15 @@ public enum AppleLivePhotoVideoWriter {
         return item
     }
 
-    private struct TimedMetadataSetup {
+    /// AVFoundation owns these callback objects and serializes access through the queues passed to
+    /// requestMediaDataWhenReady. Swift 6 does not annotate every legacy AVFoundation class as
+    /// Sendable, so this small wrapper makes the queue confinement explicit instead of spreading
+    /// unchecked annotations through the writer implementation.
+    private struct UnsafeTransfer<Value>: @unchecked Sendable {
+        let value: Value
+    }
+
+    private struct TimedMetadataSetup: @unchecked Sendable {
         let input: AVAssetWriterInput
         let adaptor: AVAssetWriterInputMetadataAdaptor
     }
@@ -296,7 +308,15 @@ public enum AppleLivePhotoVideoWriter {
     ) {
         group.enter()
         let state = TrackCopyState()
+        let inputTransfer = UnsafeTransfer(value: input)
+        let outputTransfer = UnsafeTransfer(value: output)
+        let readerTransfer = UnsafeTransfer(value: reader)
+        let writerTransfer = UnsafeTransfer(value: writer)
         input.requestMediaDataWhenReady(on: DispatchQueue(label: queueLabel, autoreleaseFrequency: .workItem)) {
+            let input = inputTransfer.value
+            let output = outputTransfer.value
+            let reader = readerTransfer.value
+            let writer = writerTransfer.value
             guard !state.finished else { return }
             while input.isReadyForMoreMediaData, !state.finished {
                 autoreleasepool {
@@ -356,7 +376,12 @@ private final class LockedFailure: @unchecked Sendable {
 }
 
 private final class TrackCopyState: @unchecked Sendable {
-    var finished = false
+    private let lock = NSLock()
+    private var storedFinished = false
+    var finished: Bool {
+        get { lock.lock(); defer { lock.unlock() }; return storedFinished }
+        set { lock.lock(); defer { lock.unlock() }; storedFinished = newValue }
+    }
 }
 
 private final class OneShotState: @unchecked Sendable {

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoVideoWriter.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoVideoWriter.swift
@@ -72,14 +72,13 @@ public enum AppleLivePhotoVideoWriter {
                 sourceFormatHint: audioFormats.first
             )
             input.expectsMediaDataInRealTime = false
-            if reader.canAdd(output), writer.canAdd(input) {
-                reader.add(output)
-                writer.add(input)
-                audioOutput = output
-                audioInput = input
-            } else {
+            guard reader.canAdd(output), writer.canAdd(input) else {
                 throw AppleLivePhotoError.unsupportedVideoCodec("audio passthrough")
             }
+            reader.add(output)
+            writer.add(input)
+            audioOutput = output
+            audioInput = input
         }
 
         writer.metadata = [contentIdentifierMetadata(assetIdentifier)]
@@ -99,6 +98,7 @@ public enum AppleLivePhotoVideoWriter {
             throw AppleLivePhotoError.cannotStartVideoWriter(writer.error?.localizedDescription ?? "unknown error")
         }
         guard reader.startReading() else {
+            writer.cancelWriting()
             throw AppleLivePhotoError.cannotStartVideoReader(reader.error?.localizedDescription ?? "unknown error")
         }
         writer.startSession(atSourceTime: .zero)
@@ -135,7 +135,7 @@ public enum AppleLivePhotoVideoWriter {
             failure: failure
         )
 
-        try await waitForGroup(group)
+        await waitForGroup(group)
         if let error = failure.error {
             reader.cancelReading()
             writer.cancelWriting()
@@ -171,10 +171,11 @@ public enum AppleLivePhotoVideoWriter {
 
     private static func contentIdentifierMetadata(_ assetIdentifier: String) -> AVMetadataItem {
         let item = AVMutableMetadataItem()
-        item.identifier = .quickTimeMetadataContentIdentifier
+        item.key = contentIdentifierKey as NSString
+        item.keySpace = AVMetadataKeySpace(rawValue: quickTimeKeySpace)
         item.value = assetIdentifier as NSString
         item.dataType = kCMMetadataBaseDataType_UTF8 as String
-        return item.copy() as! AVMetadataItem
+        return item
     }
 
     private struct TimedMetadataSetup {
@@ -242,7 +243,7 @@ public enum AppleLivePhotoVideoWriter {
         group.enter()
         let state = OneShotState()
         setup.input.requestMediaDataWhenReady(on: DispatchQueue(label: "xdremux.livephoto.metadata")) {
-            guard state.beginIfNeeded(), setup.input.isReadyForMoreMediaData else { return }
+            guard setup.input.isReadyForMoreMediaData, state.beginIfNeeded() else { return }
             var items: [AVMetadataItem] = []
 
             let still = AVMutableMetadataItem()
@@ -324,7 +325,7 @@ public enum AppleLivePhotoVideoWriter {
         }
     }
 
-    private static func waitForGroup(_ group: DispatchGroup) async throws {
+    private static func waitForGroup(_ group: DispatchGroup) async {
         await withCheckedContinuation { continuation in
             group.notify(queue: .global(qos: .userInitiated)) {
                 continuation.resume()
@@ -344,9 +345,13 @@ public enum AppleLivePhotoVideoWriter {
 private final class LockedFailure: @unchecked Sendable {
     private let lock = NSLock()
     private var stored: Error?
-    var error: Error? { lock.withLock { stored } }
+    var error: Error? {
+        lock.lock(); defer { lock.unlock() }
+        return stored
+    }
     func set(_ error: Error) {
-        lock.withLock { if stored == nil { stored = error } }
+        lock.lock(); defer { lock.unlock() }
+        if stored == nil { stored = error }
     }
 }
 
@@ -358,17 +363,9 @@ private final class OneShotState: @unchecked Sendable {
     private let lock = NSLock()
     private var started = false
     func beginIfNeeded() -> Bool {
-        lock.withLock {
-            guard !started else { return false }
-            started = true
-            return true
-        }
-    }
-}
-
-private extension NSLock {
-    func withLock<T>(_ body: () -> T) -> T {
-        lock(); defer { unlock() }
-        return body()
+        lock.lock(); defer { lock.unlock() }
+        guard !started else { return false }
+        started = true
+        return true
     }
 }

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoVideoWriter.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoVideoWriter.swift
@@ -1,0 +1,374 @@
+import Foundation
+@preconcurrency import AVFoundation
+import CoreMedia
+import XDRemuxCore
+
+public enum AppleLivePhotoVideoWriter {
+    private static let quickTimeKeySpace = "mdta"
+    private static let contentIdentifierKey = "com.apple.quicktime.content.identifier"
+    private static let stillImageTimeKey = "com.apple.quicktime.still-image-time"
+    private static let transformKey = "com.apple.quicktime.live-photo-still-image-transform"
+    private static let transformReferenceDimensionsKey = "com.apple.quicktime.live-photo-still-image-transform-reference-dimensions"
+
+    public static func write(
+        videoInputURL: URL,
+        outputURL: URL,
+        assetIdentifier: String,
+        stillImageTime: CMTime,
+        oppoMetadata: OppoMotionPhotoMetadata? = nil
+    ) async throws {
+        let asset = AVURLAsset(url: videoInputURL)
+        guard let videoTrack = try await asset.loadTracks(withMediaType: .video).first else {
+            throw AppleLivePhotoError.missingVideoTrack
+        }
+        let videoFormatDescriptions = try await videoTrack.load(.formatDescriptions)
+        guard let videoHint = videoFormatDescriptions.first else {
+            throw AppleLivePhotoError.missingVideoTrack
+        }
+
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if FileManager.default.fileExists(atPath: outputURL.path) {
+            try FileManager.default.removeItem(at: outputURL)
+        }
+
+        let reader: AVAssetReader
+        let writer: AVAssetWriter
+        do {
+            reader = try AVAssetReader(asset: asset)
+        } catch {
+            throw AppleLivePhotoError.cannotCreateVideoReader
+        }
+        do {
+            writer = try AVAssetWriter(outputURL: outputURL, fileType: .mov)
+        } catch {
+            throw AppleLivePhotoError.cannotCreateVideoWriter
+        }
+
+        let videoOutput = AVAssetReaderTrackOutput(track: videoTrack, outputSettings: nil)
+        videoOutput.alwaysCopiesSampleData = false
+        guard reader.canAdd(videoOutput) else { throw AppleLivePhotoError.cannotCreateVideoReader }
+        reader.add(videoOutput)
+
+        let videoInput = AVAssetWriterInput(mediaType: .video, outputSettings: nil, sourceFormatHint: videoHint)
+        videoInput.expectsMediaDataInRealTime = false
+        videoInput.transform = try await videoTrack.load(.preferredTransform)
+        guard writer.canAdd(videoInput) else {
+            throw AppleLivePhotoError.unsupportedVideoCodec(fourCC(CMFormatDescriptionGetMediaSubType(videoHint)))
+        }
+        writer.add(videoInput)
+
+        var audioOutput: AVAssetReaderTrackOutput?
+        var audioInput: AVAssetWriterInput?
+        if let audioTrack = try await asset.loadTracks(withMediaType: .audio).first {
+            let output = AVAssetReaderTrackOutput(track: audioTrack, outputSettings: nil)
+            output.alwaysCopiesSampleData = false
+            let audioFormats = try await audioTrack.load(.formatDescriptions)
+            let input = AVAssetWriterInput(
+                mediaType: .audio,
+                outputSettings: nil,
+                sourceFormatHint: audioFormats.first
+            )
+            input.expectsMediaDataInRealTime = false
+            if reader.canAdd(output), writer.canAdd(input) {
+                reader.add(output)
+                writer.add(input)
+                audioOutput = output
+                audioInput = input
+            } else {
+                throw AppleLivePhotoError.unsupportedVideoCodec("audio passthrough")
+            }
+        }
+
+        writer.metadata = [contentIdentifierMetadata(assetIdentifier)]
+
+        let transform = oppoMetadata.flatMap(OppoLivePhotoAlignment.transformMatrix)
+        let referenceDimensions = oppoMetadata.flatMap(OppoLivePhotoAlignment.referenceDimensions)
+        let metadataSetup = try makeTimedMetadataSetup(
+            includeTransform: transform != nil,
+            includeReferenceDimensions: transform != nil && referenceDimensions != nil
+        )
+        guard writer.canAdd(metadataSetup.input) else {
+            throw AppleLivePhotoError.videoWriteFailed("cannot add timed metadata track")
+        }
+        writer.add(metadataSetup.input)
+
+        guard writer.startWriting() else {
+            throw AppleLivePhotoError.cannotStartVideoWriter(writer.error?.localizedDescription ?? "unknown error")
+        }
+        guard reader.startReading() else {
+            throw AppleLivePhotoError.cannotStartVideoReader(reader.error?.localizedDescription ?? "unknown error")
+        }
+        writer.startSession(atSourceTime: .zero)
+
+        let failure = LockedFailure()
+        let group = DispatchGroup()
+
+        copyTrack(
+            input: videoInput,
+            output: videoOutput,
+            queueLabel: "xdremux.livephoto.video",
+            reader: reader,
+            writer: writer,
+            group: group,
+            failure: failure
+        )
+        if let audioInput, let audioOutput {
+            copyTrack(
+                input: audioInput,
+                output: audioOutput,
+                queueLabel: "xdremux.livephoto.audio",
+                reader: reader,
+                writer: writer,
+                group: group,
+                failure: failure
+            )
+        }
+        writeTimedMetadata(
+            setup: metadataSetup,
+            stillImageTime: stillImageTime,
+            transform: transform,
+            referenceDimensions: referenceDimensions,
+            group: group,
+            failure: failure
+        )
+
+        try await waitForGroup(group)
+        if let error = failure.error {
+            reader.cancelReading()
+            writer.cancelWriting()
+            try? FileManager.default.removeItem(at: outputURL)
+            throw error
+        }
+
+        await writer.finishWriting()
+        reader.cancelReading()
+        guard writer.status == .completed else {
+            let message = writer.error?.localizedDescription ?? "writer did not complete"
+            try? FileManager.default.removeItem(at: outputURL)
+            throw AppleLivePhotoError.videoWriteFailed(message)
+        }
+    }
+
+    public static func contentIdentifier(in videoURL: URL) async -> String? {
+        let asset = AVURLAsset(url: videoURL)
+        guard let metadata = try? await asset.load(.metadata) else { return nil }
+        for item in metadata {
+            if item.identifier == .quickTimeMetadataContentIdentifier,
+               let value = try? await item.load(.stringValue) {
+                return value
+            }
+            if let key = item.key as? String,
+               key == contentIdentifierKey,
+               let value = try? await item.load(.stringValue) {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private static func contentIdentifierMetadata(_ assetIdentifier: String) -> AVMetadataItem {
+        let item = AVMutableMetadataItem()
+        item.identifier = .quickTimeMetadataContentIdentifier
+        item.value = assetIdentifier as NSString
+        item.dataType = kCMMetadataBaseDataType_UTF8 as String
+        return item.copy() as! AVMetadataItem
+    }
+
+    private struct TimedMetadataSetup {
+        let input: AVAssetWriterInput
+        let adaptor: AVAssetWriterInputMetadataAdaptor
+    }
+
+    private static func makeTimedMetadataSetup(
+        includeTransform: Bool,
+        includeReferenceDimensions: Bool
+    ) throws -> TimedMetadataSetup {
+        var specifications: [[String: Any]] = [[
+            kCMMetadataFormatDescriptionMetadataSpecificationKey_Identifier as String:
+                "\(quickTimeKeySpace)/\(stillImageTimeKey)",
+            kCMMetadataFormatDescriptionMetadataSpecificationKey_DataType as String:
+                kCMMetadataBaseDataType_SInt8,
+        ]]
+        if includeTransform {
+            specifications.append([
+                kCMMetadataFormatDescriptionMetadataSpecificationKey_Identifier as String:
+                    kCMMetadataIdentifier_QuickTimeMetadataLivePhotoStillImageTransform as String,
+                kCMMetadataFormatDescriptionMetadataSpecificationKey_DataType as String:
+                    "com.apple.metadata.perspective-transform-float64",
+            ])
+        }
+        if includeReferenceDimensions {
+            specifications.append([
+                kCMMetadataFormatDescriptionMetadataSpecificationKey_Identifier as String:
+                    kCMMetadataIdentifier_QuickTimeMetadataLivePhotoStillImageTransformReferenceDimensions as String,
+                kCMMetadataFormatDescriptionMetadataSpecificationKey_DataType as String:
+                    "com.apple.metadata.datatype.dimensions-float32",
+            ])
+        }
+
+        var formatDescription: CMFormatDescription?
+        let status = CMMetadataFormatDescriptionCreateWithMetadataSpecifications(
+            allocator: kCFAllocatorDefault,
+            metadataType: kCMMetadataFormatType_Boxed,
+            metadataSpecifications: specifications as CFArray,
+            formatDescriptionOut: &formatDescription
+        )
+        guard status == noErr, let formatDescription else {
+            throw AppleLivePhotoError.videoWriteFailed("cannot create timed metadata format description")
+        }
+        let input = AVAssetWriterInput(
+            mediaType: .metadata,
+            outputSettings: nil,
+            sourceFormatHint: formatDescription
+        )
+        input.expectsMediaDataInRealTime = false
+        return TimedMetadataSetup(
+            input: input,
+            adaptor: AVAssetWriterInputMetadataAdaptor(assetWriterInput: input)
+        )
+    }
+
+    private static func writeTimedMetadata(
+        setup: TimedMetadataSetup,
+        stillImageTime: CMTime,
+        transform: [Double]?,
+        referenceDimensions: [Float]?,
+        group: DispatchGroup,
+        failure: LockedFailure
+    ) {
+        group.enter()
+        let state = OneShotState()
+        setup.input.requestMediaDataWhenReady(on: DispatchQueue(label: "xdremux.livephoto.metadata")) {
+            guard state.beginIfNeeded(), setup.input.isReadyForMoreMediaData else { return }
+            var items: [AVMetadataItem] = []
+
+            let still = AVMutableMetadataItem()
+            still.key = stillImageTimeKey as NSString
+            still.keySpace = AVMetadataKeySpace(rawValue: quickTimeKeySpace)
+            still.value = NSNumber(value: Int8(0))
+            still.dataType = kCMMetadataBaseDataType_SInt8 as String
+            items.append(still)
+
+            if let transform {
+                let item = AVMutableMetadataItem()
+                item.key = transformKey as NSString
+                item.keySpace = AVMetadataKeySpace(rawValue: quickTimeKeySpace)
+                item.value = transform as NSArray
+                item.dataType = "com.apple.metadata.perspective-transform-float64"
+                items.append(item)
+            }
+            if let referenceDimensions, referenceDimensions.count == 2 {
+                let item = AVMutableMetadataItem()
+                item.key = transformReferenceDimensionsKey as NSString
+                item.keySpace = AVMetadataKeySpace(rawValue: quickTimeKeySpace)
+                item.value = NSValue(size: NSSize(
+                    width: CGFloat(referenceDimensions[0]),
+                    height: CGFloat(referenceDimensions[1])
+                ))
+                item.dataType = "com.apple.metadata.datatype.dimensions-float32"
+                items.append(item)
+            }
+
+            let groupValue = AVTimedMetadataGroup(
+                items: items,
+                timeRange: CMTimeRange(start: stillImageTime, duration: .zero)
+            )
+            if !setup.adaptor.append(groupValue) {
+                failure.set(AppleLivePhotoError.videoWriteFailed("timed metadata append failed"))
+            }
+            setup.input.markAsFinished()
+            group.leave()
+        }
+    }
+
+    private static func copyTrack(
+        input: AVAssetWriterInput,
+        output: AVAssetReaderOutput,
+        queueLabel: String,
+        reader: AVAssetReader,
+        writer: AVAssetWriter,
+        group: DispatchGroup,
+        failure: LockedFailure
+    ) {
+        group.enter()
+        let state = TrackCopyState()
+        input.requestMediaDataWhenReady(on: DispatchQueue(label: queueLabel, autoreleaseFrequency: .workItem)) {
+            guard !state.finished else { return }
+            while input.isReadyForMoreMediaData, !state.finished {
+                autoreleasepool {
+                    if let sample = output.copyNextSampleBuffer() {
+                        if !input.append(sample) {
+                            state.finished = true
+                            input.markAsFinished()
+                            failure.set(AppleLivePhotoError.videoWriteFailed(
+                                writer.error?.localizedDescription ?? "sample append failed"
+                            ))
+                            reader.cancelReading()
+                            group.leave()
+                        }
+                    } else {
+                        state.finished = true
+                        input.markAsFinished()
+                        if reader.status == .failed {
+                            failure.set(AppleLivePhotoError.videoWriteFailed(
+                                reader.error?.localizedDescription ?? "reader failed"
+                            ))
+                        }
+                        group.leave()
+                    }
+                }
+            }
+        }
+    }
+
+    private static func waitForGroup(_ group: DispatchGroup) async throws {
+        await withCheckedContinuation { continuation in
+            group.notify(queue: .global(qos: .userInitiated)) {
+                continuation.resume()
+            }
+        }
+    }
+
+    private static func fourCC(_ code: FourCharCode) -> String {
+        let bytes: [UInt8] = [
+            UInt8((code >> 24) & 0xff), UInt8((code >> 16) & 0xff),
+            UInt8((code >> 8) & 0xff), UInt8(code & 0xff),
+        ]
+        return String(bytes: bytes, encoding: .macOSRoman) ?? String(format: "0x%08x", code)
+    }
+}
+
+private final class LockedFailure: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: Error?
+    var error: Error? { lock.withLock { stored } }
+    func set(_ error: Error) {
+        lock.withLock { if stored == nil { stored = error } }
+    }
+}
+
+private final class TrackCopyState: @unchecked Sendable {
+    var finished = false
+}
+
+private final class OneShotState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var started = false
+    func beginIfNeeded() -> Bool {
+        lock.withLock {
+            guard !started else { return false }
+            started = true
+            return true
+        }
+    }
+}
+
+private extension NSLock {
+    func withLock<T>(_ body: () -> T) -> T {
+        lock(); defer { unlock() }
+        return body()
+    }
+}

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/Oppo/OppoLivePhotoAlignment.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/Oppo/OppoLivePhotoAlignment.swift
@@ -1,0 +1,96 @@
+import Foundation
+import XDRemuxCore
+
+public enum OppoLivePhotoAlignment {
+    private static let colorOS16EISCompensationScale = 0.90
+
+    public static func transformMatrix(for metadata: OppoMotionPhotoMetadata) -> [Double]? {
+        if metadata.version >= 1 {
+            var result: [Double] = [
+                colorOS16EISCompensationScale, 0, 0,
+                0, colorOS16EISCompensationScale, 0,
+                0, 0, 1,
+            ]
+            if let crop = metadata.photoCropMatrix,
+               let inverseCrop = invert3x3(crop) {
+                result = multiply(result, inverseCrop)
+            }
+            if let eis = metadata.photoEisMatrix,
+               let inverseEIS = invert3x3(eis) {
+                result = multiply(result, inverseEIS)
+            }
+            return isIdentity(result) ? nil : result
+        }
+
+        guard metadata.matrixCount > 0, !metadata.matrices.isEmpty,
+              let coverFramePts = metadata.coverFramePtsUs else {
+            return nil
+        }
+        let selected: [Double]?
+        if let exact = metadata.matrices[String(coverFramePts)] {
+            selected = exact
+        } else {
+            let closest = metadata.matrices.keys
+                .compactMap(Int64.init)
+                .min { abs($0 - coverFramePts) < abs($1 - coverFramePts) }
+            selected = closest.flatMap { metadata.matrices[String($0)] }
+        }
+        guard let matrix = selected, matrix.count == 9 else { return nil }
+        let result = invert3x3(matrix) ?? matrix
+        return isIdentity(result) ? nil : result
+    }
+
+    public static func encodeForApple(_ matrix: [Double]) -> Data {
+        guard matrix.count == 9 else { return Data() }
+        var output = Data(capacity: 72)
+        for value in matrix {
+            var bits = value.bitPattern.bigEndian
+            withUnsafeBytes(of: &bits) { output.append(contentsOf: $0) }
+        }
+        return output
+    }
+
+    public static func referenceDimensions(for metadata: OppoMotionPhotoMetadata) -> [Float]? {
+        guard let width = metadata.videoWidth, let height = metadata.videoHeight,
+              width > 0, height > 0 else { return nil }
+        return [Float(width), Float(height)]
+    }
+
+    static func isIdentity(_ matrix: [Double], tolerance: Double = 1e-6) -> Bool {
+        guard matrix.count == 9 else { return false }
+        let identity: [Double] = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+        return zip(matrix, identity).allSatisfy { abs($0 - $1) <= tolerance }
+    }
+
+    static func multiply(_ a: [Double], _ b: [Double]) -> [Double] {
+        guard a.count == 9, b.count == 9 else { return a }
+        return [
+            a[0]*b[0] + a[1]*b[3] + a[2]*b[6],
+            a[0]*b[1] + a[1]*b[4] + a[2]*b[7],
+            a[0]*b[2] + a[1]*b[5] + a[2]*b[8],
+            a[3]*b[0] + a[4]*b[3] + a[5]*b[6],
+            a[3]*b[1] + a[4]*b[4] + a[5]*b[7],
+            a[3]*b[2] + a[4]*b[5] + a[5]*b[8],
+            a[6]*b[0] + a[7]*b[3] + a[8]*b[6],
+            a[6]*b[1] + a[7]*b[4] + a[8]*b[7],
+            a[6]*b[2] + a[7]*b[5] + a[8]*b[8],
+        ]
+    }
+
+    static func invert3x3(_ m: [Double]) -> [Double]? {
+        guard m.count == 9 else { return nil }
+        let a = m[0], b = m[1], c = m[2]
+        let d = m[3], e = m[4], f = m[5]
+        let g = m[6], h = m[7], i = m[8]
+        let determinant = a * (e * i - f * h)
+            - b * (d * i - f * g)
+            + c * (d * h - e * g)
+        guard determinant.isFinite, abs(determinant) > 1e-10 else { return nil }
+        let inv = 1.0 / determinant
+        return [
+            (e*i-f*h)*inv, (c*h-b*i)*inv, (b*f-c*e)*inv,
+            (f*g-d*i)*inv, (a*i-c*g)*inv, (c*d-a*f)*inv,
+            (d*h-e*g)*inv, (b*g-a*h)*inv, (a*e-b*d)*inv,
+        ]
+    }
+}

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoBatchCheckpoint.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoBatchCheckpoint.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+/// Independent sidecar checkpoint for the Motion Photo pre-pass. It intentionally does not share
+/// the existing HEIC checkpoint file because the two passes can run in the same `batch` invocation
+/// and have different output cardinality (one file versus HEIC+MOV pair).
+enum MotionPhotoBatchCheckpoint {
+    enum Status: String, Codable {
+        case success
+        case failure
+        case skippedExisting = "skipped_existing"
+    }
+
+    struct FileSignature: Equatable {
+        let size: Int64
+        let mtimeNs: Int64
+    }
+
+    struct Item: Codable {
+        let kind: String
+        let inputPath: String
+        let outputImagePath: String
+        let outputVideoPath: String
+        let status: Status
+        let inputSize: Int64?
+        let inputMtimeNs: Int64?
+        let error: String?
+
+        func matchesSignature(_ signature: FileSignature?) -> Bool {
+            guard let signature else { return true }
+            if let inputSize, inputSize != signature.size { return false }
+            if let inputMtimeNs, inputMtimeNs != signature.mtimeNs { return false }
+            return true
+        }
+
+        func matchesOutputs(imageURL: URL, videoURL: URL) -> Bool {
+            outputImagePath == imageURL.standardizedFileURL.path
+                && outputVideoPath == videoURL.standardizedFileURL.path
+        }
+    }
+
+    struct Header: Codable {
+        let kind = "header"
+        let schemaVersion = 1
+        let createdAt: String
+    }
+
+    static func resolvedURL(for command: BatchCommand) -> URL {
+        if let requested = command.checkpointURL {
+            let parent = requested.deletingLastPathComponent()
+            let name = requested.lastPathComponent
+            return parent.appendingPathComponent("\(name).motion-photo")
+        }
+        return command.outputDirURL.appendingPathComponent(".xdremux-motion-photo-checkpoint.jsonl")
+    }
+
+    static func signature(for url: URL) throws -> FileSignature {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        let size = (attributes[.size] as? NSNumber)?.int64Value ?? 0
+        let modified = (attributes[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+        return FileSignature(
+            size: size,
+            mtimeNs: Int64(modified * 1_000_000_000)
+        )
+    }
+
+    static func load(url: URL) throws -> [String: Item] {
+        guard FileManager.default.fileExists(atPath: url.path) else { return [:] }
+        let data = try Data(contentsOf: url, options: [.mappedIfSafe])
+        guard !data.isEmpty else { return [:] }
+        let decoder = JSONDecoder()
+        var state: [String: Item] = [:]
+        for line in data.split(separator: 0x0a) where !line.isEmpty {
+            guard let object = try? JSONSerialization.jsonObject(with: Data(line)) as? [String: Any],
+                  object["kind"] as? String == "item" else {
+                continue
+            }
+            let item = try decoder.decode(Item.self, from: Data(line))
+            state[item.inputPath] = item
+        }
+        return state
+    }
+
+    static func reset(url: URL) throws {
+        if FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.removeItem(at: url)
+        }
+    }
+
+    final class Writer: @unchecked Sendable {
+        private let lock = NSLock()
+        private var handle: FileHandle?
+        private let encoder = JSONEncoder()
+
+        init(url: URL) throws {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            if !FileManager.default.fileExists(atPath: url.path) {
+                guard FileManager.default.createFile(atPath: url.path, contents: nil) else {
+                    throw CocoaError(.fileWriteUnknown)
+                }
+            }
+            let handle = try FileHandle(forWritingTo: url)
+            try handle.seekToEnd()
+            self.handle = handle
+
+            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+            if (attributes[.size] as? NSNumber)?.int64Value == 0 {
+                try appendEncodable(
+                    Header(createdAt: ISO8601DateFormatter().string(from: Date()))
+                )
+            }
+        }
+
+        func append(
+            inputURL: URL,
+            outputImageURL: URL,
+            outputVideoURL: URL,
+            status: Status,
+            signature: FileSignature?,
+            error: String? = nil
+        ) throws {
+            try appendEncodable(
+                Item(
+                    kind: "item",
+                    inputPath: inputURL.standardizedFileURL.path,
+                    outputImagePath: outputImageURL.standardizedFileURL.path,
+                    outputVideoPath: outputVideoURL.standardizedFileURL.path,
+                    status: status,
+                    inputSize: signature?.size,
+                    inputMtimeNs: signature?.mtimeNs,
+                    error: error
+                )
+            )
+        }
+
+        func close() throws {
+            lock.lock()
+            defer { lock.unlock() }
+            guard let handle else { return }
+            try handle.synchronize()
+            try handle.close()
+            self.handle = nil
+        }
+
+        private func appendEncodable<T: Encodable>(_ value: T) throws {
+            let data = try encoder.encode(value)
+            lock.lock()
+            defer { lock.unlock() }
+            guard let handle else { throw CocoaError(.fileWriteUnknown) }
+            try handle.write(contentsOf: data)
+            try handle.write(contentsOf: Data([0x0a]))
+            try handle.synchronize()
+        }
+
+        deinit {
+            try? close()
+        }
+    }
+}

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoBatchCheckpoint.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoBatchCheckpoint.swift
@@ -39,9 +39,15 @@ enum MotionPhotoBatchCheckpoint {
     }
 
     struct Header: Codable {
-        let kind = "header"
-        let schemaVersion = 1
+        let kind: String
+        let schemaVersion: Int
         let createdAt: String
+
+        init(createdAt: String) {
+            self.kind = "header"
+            self.schemaVersion = 1
+            self.createdAt = createdAt
+        }
     }
 
     static func resolvedURL(for command: BatchCommand) -> URL {

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoCLIIntegration.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoCLIIntegration.swift
@@ -19,10 +19,9 @@ enum MotionPhotoCLIIntegration {
         }
     }
 
-    /// Called after XDRemuxCommand.main() returns successfully. Mixed HEIC + Motion Photo batches
-    /// deliberately defer the Motion Photo outputs until this point: otherwise the unchanged HEIC
-    /// batch enumerator could discover the freshly generated Live Photo HEICs and try to convert
-    /// them again as ProXDR inputs when input-dir == output-dir.
+    /// Called after XDRemuxCommand.main() returns successfully. JPEG-only mixed batches can defer
+    /// Motion Photo outputs until the existing HEIC batch completes, preventing those newly created
+    /// Live Photo HEICs from being discovered as ProXDR inputs in the same invocation.
     static func finishPendingBatchIfNeeded() throws {
         guard let pending = pendingBatchStore.take() else { return }
         try runMotionBatch(command: pending.command, workItems: pending.workItems)
@@ -39,7 +38,8 @@ enum MotionPhotoCLIIntegration {
     private static func handleConvert(_ rawArguments: [String]) throws -> Bool {
         guard let inputPath = optionValue("--input", in: rawArguments) else { return false }
         let inputURL = URL(fileURLWithPath: inputPath).standardizedFileURL
-        guard isJPEG(inputURL), AppleLivePhotoConversionEngine.isMotionPhotoInput(inputURL) else {
+        guard isSupportedMotionPhotoSourceExtension(inputURL),
+              AppleLivePhotoConversionEngine.isMotionPhotoInput(inputURL) else {
             return false
         }
 
@@ -61,6 +61,13 @@ enum MotionPhotoCLIIntegration {
         let outputImageURL: URL
         if outputWasExplicit {
             outputImageURL = command.outputURL.standardizedFileURL
+        } else if isHEIC(inputURL) {
+            // A HEIF Motion Photo is already named .heic/.heif. Never overwrite the source just to
+            // obtain the Apple paired representation; the suffix makes the one-to-two conversion
+            // explicit while preserving the original Android file.
+            outputImageURL = inputURL.deletingPathExtension()
+                .appendingPathExtension("live")
+                .appendingPathExtension("heic")
         } else {
             outputImageURL = inputURL.deletingPathExtension().appendingPathExtension("heic")
         }
@@ -81,11 +88,11 @@ enum MotionPhotoCLIIntegration {
     }
 
     /// Plans the Motion Photo portion of a default batch. Explicit --glob retains the old contract.
-    /// On the first mixed run there are no Live Photo HEIC outputs yet, so the unchanged HEIC batch
-    /// can run first and the Motion Photo pass is deferred. On subsequent runs, valid HEIC+MOV Live
-    /// Photo pairs are classified as outputs rather than HEIC inputs; the remaining real HEIC inputs
-    /// are handled here before the Motion Photo pass so the old `*.heic` enumerator can never ingest
-    /// a previously generated Live Photo still.
+    ///
+    /// JPEG Motion Photos can coexist with the unchanged legacy HEIC pass by deferring their output
+    /// until that pass completes. HEIF Motion Photos are themselves `.heic` inputs, so any batch
+    /// containing one must classify HEIC files first; otherwise the legacy `*.heic` enumerator would
+    /// feed the Android Motion Photo container into the ProXDR pipeline.
     private static func prepareDefaultBatch(_ rawArguments: [String]) throws -> Bool {
         guard !rawArguments.contains("--glob") else { return false }
 
@@ -97,8 +104,7 @@ enum MotionPhotoCLIIntegration {
             under: command.inputDirURL,
             excluding: command.outputDirURL
         )
-        let motionInputs = jpegCandidates.filter(AppleLivePhotoConversionEngine.isMotionPhotoInput)
-        guard !motionInputs.isEmpty else { return false }
+        let jpegMotionInputs = jpegCandidates.filter(AppleLivePhotoConversionEngine.isMotionPhotoInput)
 
         let allHEICInputs = try discoverHEICs(
             under: command.inputDirURL,
@@ -108,9 +114,16 @@ enum MotionPhotoCLIIntegration {
         let existingLivePhotoPaths = Set(
             existingLivePhotoStills.map { $0.standardizedFileURL.path }
         )
-        let sourceHEICInputs = allHEICInputs.filter {
+        let unpairedHEICInputs = allHEICInputs.filter {
             !existingLivePhotoPaths.contains($0.standardizedFileURL.path)
         }
+        let heifMotionInputs = unpairedHEICInputs.filter(AppleLivePhotoConversionEngine.isMotionPhotoInput)
+        let heifMotionPaths = Set(heifMotionInputs.map { $0.standardizedFileURL.path })
+        let sourceHEICInputs = unpairedHEICInputs.filter {
+            !heifMotionPaths.contains($0.standardizedFileURL.path)
+        }
+        let motionInputs = jpegMotionInputs + heifMotionInputs
+        guard !motionInputs.isEmpty else { return false }
 
         let workItems = makeWorkItems(
             inputs: motionInputs,
@@ -123,16 +136,16 @@ enum MotionPhotoCLIIntegration {
             return true
         }
 
-        if existingLivePhotoStills.isEmpty {
-            // First mixed run: no Motion Photo output exists yet, so the unchanged HEIC batch can
-            // safely enumerate now. Motion outputs are emitted only after it succeeds.
+        if heifMotionInputs.isEmpty, existingLivePhotoStills.isEmpty {
+            // First JPEG-only mixed run: no Motion Photo HEIC source/output exists, so the unchanged
+            // HEIC batch can enumerate safely. Motion outputs are emitted only after it succeeds.
             pendingBatchStore.set(PendingBatch(command: command, workItems: workItems))
             return false
         }
 
-        // Repeated mixed run (or a directory that already contains unrelated valid Live Photos):
-        // do not invoke the legacy glob-based batch enumerator, because it cannot distinguish those
-        // paired HEIC stills from source ProXDR HEICs. Convert only the classified source HEIC set.
+        // HEIF Motion Photo source or an already generated Live Photo pair is present. Do not invoke
+        // the legacy glob-based batch enumerator because it cannot distinguish those paired/source
+        // Motion Photo HEICs from ProXDR HEIC inputs. Convert only the classified source HEIC set.
         try runClassifiedHEICBatch(command: command, inputs: sourceHEICInputs)
         try runMotionBatch(command: command, workItems: workItems)
         return true
@@ -201,9 +214,6 @@ enum MotionPhotoCLIIntegration {
                 + "\(failures.count) failed"
         )
         if !failures.isEmpty {
-            // Successful files will be skipped by output validation on the next invocation, so a
-            // rerun naturally retries only unresolved inputs even though this compatibility path
-            // does not share the legacy one-output checkpoint file.
             throw ClassifiedHEICBatchError(failures: failures.count)
         }
     }
@@ -392,24 +402,24 @@ enum MotionPhotoCLIIntegration {
     ) -> [MotionBatchWorkItem] {
         var reserved = Set<String>()
 
-        // Predict exactly the output names the unchanged/classified HEIC batch pass will reserve,
-        // including duplicate stems, before assigning Live Photo outputs.
         for item in makeHEICWorkItems(inputs: heicInputs, command: command) {
             reserved.insert(item.outputURL.standardizedFileURL.path)
         }
 
         return inputs.sorted { $0.path < $1.path }.map { input in
             let directory = categorizedOutputDirectory(for: input, command: command)
-            let stem = input.deletingPathExtension().lastPathComponent
+            let sourceStem = input.deletingPathExtension().lastPathComponent
+            let outputStem = isHEIC(input) ? "\(sourceStem).live" : sourceStem
             var sequence = 1
-            var output = directory.appendingPathComponent(stem).appendingPathExtension("heic")
+            var output = directory.appendingPathComponent(outputStem).appendingPathExtension("heic")
             while reserved.contains(output.standardizedFileURL.path)
                 || reserved.contains(
                     AppleLivePhotoConversionEngine.companionVideoURL(for: output)
                         .standardizedFileURL.path
-                ) {
+                )
+                || output.standardizedFileURL.path == input.standardizedFileURL.path {
                 sequence += 1
-                output = directory.appendingPathComponent("\(stem) (\(sequence))").appendingPathExtension("heic")
+                output = directory.appendingPathComponent("\(outputStem) (\(sequence))").appendingPathExtension("heic")
             }
             reserved.insert(output.standardizedFileURL.path)
             reserved.insert(
@@ -438,10 +448,7 @@ enum MotionPhotoCLIIntegration {
     }
 
     private static func discoverHEICs(under root: URL, excluding outputRoot: URL) throws -> [URL] {
-        try discover(under: root, excluding: outputRoot) { url in
-            let ext = url.pathExtension.lowercased()
-            return ext == "heic" || ext == "heif"
-        }
+        try discover(under: root, excluding: outputRoot) { isHEIC($0) }
     }
 
     private static func discover(
@@ -479,9 +486,18 @@ enum MotionPhotoCLIIntegration {
         return results
     }
 
+    private static func isSupportedMotionPhotoSourceExtension(_ url: URL) -> Bool {
+        isJPEG(url) || isHEIC(url)
+    }
+
     private static func isJPEG(_ url: URL) -> Bool {
         let ext = url.pathExtension.lowercased()
         return ext == "jpg" || ext == "jpeg"
+    }
+
+    private static func isHEIC(_ url: URL) -> Bool {
+        let ext = url.pathExtension.lowercased()
+        return ext == "heic" || ext == "heif"
     }
 
     private static func validateLivePhotoOutputExtension(_ outputURL: URL) throws {

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoCLIIntegration.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoCLIIntegration.swift
@@ -221,6 +221,8 @@ enum MotionPhotoCLIIntegration {
     ) throws -> [URL] {
         let root = root.standardizedFileURL
         let outputRoot = outputRoot.standardizedFileURL
+        let shouldExcludeOutputSubtree = outputRoot.path != root.path
+            && outputRoot.path.hasPrefix(root.path + "/")
         let manager = FileManager.default
         let keys: [URLResourceKey] = [.isRegularFileKey, .isDirectoryKey]
         guard let enumerator = manager.enumerator(
@@ -232,7 +234,9 @@ enum MotionPhotoCLIIntegration {
         var results: [URL] = []
         for case let url as URL in enumerator {
             let standardized = url.standardizedFileURL
-            if standardized.path == outputRoot.path || standardized.path.hasPrefix(outputRoot.path + "/") {
+            if shouldExcludeOutputSubtree,
+               (standardized.path == outputRoot.path
+                    || standardized.path.hasPrefix(outputRoot.path + "/")) {
                 if (try? standardized.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true {
                     enumerator.skipDescendants()
                 }

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoCLIIntegration.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoCLIIntegration.swift
@@ -1,0 +1,281 @@
+import Foundation
+import XDRemuxCore
+import XDRemuxAppleFeatures
+
+/// Narrow CLI integration for Motion Photo inputs. Existing HEIC/ProXDR command behavior remains
+/// owned by XDRemuxCommand; this layer only intercepts inputs that normalize as Motion Photos.
+enum MotionPhotoCLIIntegration {
+    static func handleIfNeeded(_ arguments: [String]) throws -> Bool {
+        guard let command = arguments.first else { return false }
+        switch command {
+        case "convert":
+            return try handleConvert(Array(arguments.dropFirst()))
+        case "batch":
+            return try handleDefaultBatchPrepass(Array(arguments.dropFirst()))
+        default:
+            return false
+        }
+    }
+
+    static func printFailure(_ error: Error) {
+        if let localized = error as? LocalizedError, let message = localized.errorDescription {
+            FileHandle.standardError.write(Data("error: \(message)\n".utf8))
+        } else {
+            FileHandle.standardError.write(Data("error: \(error)\n".utf8))
+        }
+    }
+
+    private static func handleConvert(_ rawArguments: [String]) throws -> Bool {
+        guard let inputPath = optionValue("--input", in: rawArguments) else { return false }
+        let inputURL = URL(fileURLWithPath: inputPath).standardizedFileURL
+        guard isJPEG(inputURL), AppleLivePhotoConversionEngine.isMotionPhotoInput(inputURL) else {
+            return false
+        }
+
+        let command = try ConversionArgumentParser.parseConvert(rawArguments)
+        guard !command.appleFeatures.isEnabled else {
+            throw CLIError.invalidValue(
+                option: "--input",
+                value: "Motion Photo conversion cannot be combined with Apple Portrait or Photographic Styles in the same pass"
+            )
+        }
+        guard !command.oppoCompatibility.wantsOppoCompat else {
+            throw CLIError.invalidValue(
+                option: "--oppo-compatible",
+                value: "Motion Photo conversion produces an Apple Live Photo pair"
+            )
+        }
+
+        let outputWasExplicit = rawArguments.contains("--output")
+        let outputImageURL: URL
+        if outputWasExplicit {
+            outputImageURL = command.outputURL.standardizedFileURL
+        } else {
+            outputImageURL = inputURL.deletingPathExtension().appendingPathExtension("heic")
+        }
+        try validateLivePhotoOutputExtension(outputImageURL)
+
+        let result = try AppleLivePhotoConversionEngine.convert(
+            inputURL: inputURL,
+            outputImageURL: outputImageURL
+        )
+        print(
+            "converted Motion Photo \(inputURL.lastPathComponent) -> "
+                + "\(result.imageURL.path) + \(result.videoURL.path)"
+        )
+        for diagnostic in result.diagnostics {
+            print("  \(diagnostic)")
+        }
+        return true
+    }
+
+    /// The existing batch implementation intentionally keeps its HEIC-centric behavior. For the
+    /// default batch command we run a Motion Photo classification/conversion pass first, then return
+    /// false when HEIC inputs remain so XDRemuxCommand can process them exactly as before.
+    /// Ordinary JPEGs are ignored by this automatic pass.
+    private static func handleDefaultBatchPrepass(_ rawArguments: [String]) throws -> Bool {
+        // Explicit --glob retains the existing batch contract. Automatic JPEG discovery is only
+        // enabled for the default batch mode so old scripts using custom globs remain unchanged.
+        guard !rawArguments.contains("--glob") else { return false }
+
+        let command = try ConversionArgumentParser.parseBatch(rawArguments)
+        guard !command.appleFeatures.isEnabled else {
+            // Portrait/style batch semantics remain entirely with XDRemuxCommand.
+            return false
+        }
+        guard !command.oppoCompatibility.wantsOppoCompat else {
+            return false
+        }
+
+        let jpegCandidates = try discoverJPEGs(
+            under: command.inputDirURL,
+            excluding: command.outputDirURL
+        )
+        let motionInputs = jpegCandidates.filter(AppleLivePhotoConversionEngine.isMotionPhotoInput)
+        guard !motionInputs.isEmpty else { return false }
+
+        let heicInputs = try discoverHEICs(
+            under: command.inputDirURL,
+            excluding: command.outputDirURL
+        )
+        let workItems = makeWorkItems(
+            inputs: motionInputs,
+            heicInputs: heicInputs,
+            command: command
+        )
+
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = max(1, command.jobs)
+        queue.qualityOfService = .userInitiated
+        let lock = NSLock()
+        var converted = 0
+        var skipped = 0
+        var failures: [(URL, Error)] = []
+
+        for item in workItems {
+            queue.addOperation {
+                autoreleasepool {
+                    if command.skipExisting,
+                       AppleLivePhotoValidator.isValidPair(
+                           imageURL: item.outputImageURL,
+                           videoURL: AppleLivePhotoConversionEngine.companionVideoURL(for: item.outputImageURL)
+                       ) {
+                        lock.lock(); skipped += 1; lock.unlock()
+                        printSynchronized("skipped \(item.inputURL.lastPathComponent) (Live Photo pair already valid)")
+                        return
+                    }
+                    do {
+                        _ = try AppleLivePhotoConversionEngine.convert(
+                            inputURL: item.inputURL,
+                            outputImageURL: item.outputImageURL
+                        )
+                        lock.lock(); converted += 1; lock.unlock()
+                        printSynchronized("converted Motion Photo \(item.inputURL.lastPathComponent)")
+                    } catch {
+                        lock.lock(); failures.append((item.inputURL, error)); lock.unlock()
+                        printSynchronized("failed \(item.inputURL.lastPathComponent): \(singleLine(error))")
+                    }
+                }
+            }
+        }
+        queue.waitUntilAllOperationsAreFinished()
+
+        print(
+            "Motion Photo batch pass: \(converted) converted, \(skipped) skipped, "
+                + "\(failures.count) failed"
+        )
+        if !failures.isEmpty {
+            throw CLIError.batchFailed(
+                failures: failures.count,
+                checkpoint: command.checkpointURL
+                    ?? command.outputDirURL.appendingPathComponent(".xdremux-motion-photo-retry")
+            )
+        }
+
+        // If HEIC inputs exist, let the original batch implementation continue with its unchanged
+        // checkpoint/resume behavior. If this directory only contained Motion Photos, the batch is
+        // complete and must not fall through to the old "no *.heic matched" error.
+        return heicInputs.isEmpty
+    }
+
+    private struct MotionBatchWorkItem {
+        let inputURL: URL
+        let outputImageURL: URL
+    }
+
+    private static func makeWorkItems(
+        inputs: [URL],
+        heicInputs: [URL],
+        command: BatchCommand
+    ) -> [MotionBatchWorkItem] {
+        var reserved = Set<String>()
+
+        // Reserve the outputs the unchanged HEIC batch pass will choose, preventing a Motion Photo
+        // with the same stem from being overwritten when that pass runs afterward.
+        for input in heicInputs {
+            let directory = categorizedOutputDirectory(for: input, command: command)
+            reserved.insert(
+                directory.appendingPathComponent(input.deletingPathExtension().lastPathComponent)
+                    .appendingPathExtension("heic").standardizedFileURL.path
+            )
+        }
+
+        return inputs.sorted { $0.path < $1.path }.map { input in
+            let directory = categorizedOutputDirectory(for: input, command: command)
+            let stem = input.deletingPathExtension().lastPathComponent
+            var sequence = 1
+            var output = directory.appendingPathComponent(stem).appendingPathExtension("heic")
+            while reserved.contains(output.standardizedFileURL.path) {
+                sequence += 1
+                output = directory.appendingPathComponent("\(stem) (\(sequence))").appendingPathExtension("heic")
+            }
+            reserved.insert(output.standardizedFileURL.path)
+            reserved.insert(AppleLivePhotoConversionEngine.companionVideoURL(for: output).standardizedFileURL.path)
+            return MotionBatchWorkItem(inputURL: input, outputImageURL: output)
+        }
+    }
+
+    private static func categorizedOutputDirectory(for input: URL, command: BatchCommand) -> URL {
+        if command.categorizeOutput,
+           let folder = PhotoCategorizationEngine.categorizedDirectory(for: input) {
+            return command.outputDirURL.appendingPathComponent(folder, isDirectory: true)
+        }
+        return command.outputDirURL
+    }
+
+    private static func discoverJPEGs(under root: URL, excluding outputRoot: URL) throws -> [URL] {
+        try discover(under: root, excluding: outputRoot) { isJPEG($0) }
+    }
+
+    private static func discoverHEICs(under root: URL, excluding outputRoot: URL) throws -> [URL] {
+        try discover(under: root, excluding: outputRoot) { url in
+            let ext = url.pathExtension.lowercased()
+            return ext == "heic" || ext == "heif"
+        }
+    }
+
+    private static func discover(
+        under root: URL,
+        excluding outputRoot: URL,
+        predicate: (URL) -> Bool
+    ) throws -> [URL] {
+        let root = root.standardizedFileURL
+        let outputRoot = outputRoot.standardizedFileURL
+        let manager = FileManager.default
+        let keys: [URLResourceKey] = [.isRegularFileKey, .isDirectoryKey]
+        guard let enumerator = manager.enumerator(
+            at: root,
+            includingPropertiesForKeys: keys,
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        var results: [URL] = []
+        for case let url as URL in enumerator {
+            let standardized = url.standardizedFileURL
+            if standardized.path == outputRoot.path || standardized.path.hasPrefix(outputRoot.path + "/") {
+                if (try? standardized.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true {
+                    enumerator.skipDescendants()
+                }
+                continue
+            }
+            let values = try standardized.resourceValues(forKeys: Set(keys))
+            guard values.isRegularFile == true, predicate(standardized) else { continue }
+            results.append(standardized)
+        }
+        return results
+    }
+
+    private static func isJPEG(_ url: URL) -> Bool {
+        let ext = url.pathExtension.lowercased()
+        return ext == "jpg" || ext == "jpeg"
+    }
+
+    private static func validateLivePhotoOutputExtension(_ outputURL: URL) throws {
+        let ext = outputURL.pathExtension.lowercased()
+        guard ext == "heic" || ext == "heif" else {
+            throw CLIError.invalidValue(
+                option: "--output",
+                value: "Motion Photo output must end in .heic or .heif"
+            )
+        }
+    }
+
+    private static func optionValue(_ name: String, in arguments: [String]) -> String? {
+        guard let index = arguments.firstIndex(of: name), index + 1 < arguments.count else { return nil }
+        return arguments[index + 1]
+    }
+
+    private static let printLock = NSLock()
+    private static func printSynchronized(_ message: String) {
+        printLock.lock(); defer { printLock.unlock() }
+        print(message)
+    }
+
+    private static func singleLine(_ error: Error) -> String {
+        String(describing: error)
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+}

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoCLIIntegration.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoCLIIntegration.swift
@@ -5,16 +5,27 @@ import XDRemuxAppleFeatures
 /// Narrow CLI integration for Motion Photo inputs. Existing HEIC/ProXDR command behavior remains
 /// owned by XDRemuxCommand; this layer only intercepts inputs that normalize as Motion Photos.
 enum MotionPhotoCLIIntegration {
+    private static let pendingBatchStore = PendingBatchStore()
+
     static func handleIfNeeded(_ arguments: [String]) throws -> Bool {
         guard let command = arguments.first else { return false }
         switch command {
         case "convert":
             return try handleConvert(Array(arguments.dropFirst()))
         case "batch":
-            return try handleDefaultBatchPrepass(Array(arguments.dropFirst()))
+            return try prepareDefaultBatch(Array(arguments.dropFirst()))
         default:
             return false
         }
+    }
+
+    /// Called after XDRemuxCommand.main() returns successfully. Mixed HEIC + Motion Photo batches
+    /// deliberately defer the Motion Photo outputs until this point: otherwise the unchanged HEIC
+    /// batch enumerator could discover the freshly generated Live Photo HEICs and try to convert
+    /// them again as ProXDR inputs when input-dir == output-dir.
+    static func finishPendingBatchIfNeeded() throws {
+        guard let pending = pendingBatchStore.take() else { return }
+        try runMotionBatch(command: pending.command, workItems: pending.workItems)
     }
 
     static func printFailure(_ error: Error) {
@@ -69,23 +80,15 @@ enum MotionPhotoCLIIntegration {
         return true
     }
 
-    /// The existing batch implementation intentionally keeps its HEIC-centric behavior. For the
-    /// default batch command we run a Motion Photo classification/conversion pass first, then return
-    /// false when HEIC inputs remain so XDRemuxCommand can process them exactly as before.
-    /// Ordinary JPEGs are ignored by this automatic pass.
-    private static func handleDefaultBatchPrepass(_ rawArguments: [String]) throws -> Bool {
-        // Explicit --glob retains the existing batch contract. Automatic JPEG discovery is only
-        // enabled for the default batch mode so old scripts using custom globs remain unchanged.
+    /// Plans the Motion Photo portion of a default batch. Explicit --glob retains the old contract.
+    /// If there are no existing HEIC inputs, the Motion Photo batch can run immediately. For a mixed
+    /// batch it is queued and runs only after the unchanged HEIC batch pass succeeds.
+    private static func prepareDefaultBatch(_ rawArguments: [String]) throws -> Bool {
         guard !rawArguments.contains("--glob") else { return false }
 
         let command = try ConversionArgumentParser.parseBatch(rawArguments)
-        guard !command.appleFeatures.isEnabled else {
-            // Portrait/style batch semantics remain entirely with XDRemuxCommand.
-            return false
-        }
-        guard !command.oppoCompatibility.wantsOppoCompat else {
-            return false
-        }
+        guard !command.appleFeatures.isEnabled else { return false }
+        guard !command.oppoCompatibility.wantsOppoCompat else { return false }
 
         let jpegCandidates = try discoverJPEGs(
             under: command.inputDirURL,
@@ -104,6 +107,19 @@ enum MotionPhotoCLIIntegration {
             command: command
         )
 
+        if heicInputs.isEmpty {
+            try runMotionBatch(command: command, workItems: workItems)
+            return true
+        }
+
+        pendingBatchStore.set(PendingBatch(command: command, workItems: workItems))
+        return false
+    }
+
+    private static func runMotionBatch(
+        command: BatchCommand,
+        workItems: [MotionBatchWorkItem]
+    ) throws {
         let checkpointURL = MotionPhotoBatchCheckpoint.resolvedURL(for: command)
         if !command.resume {
             try MotionPhotoBatchCheckpoint.reset(url: checkpointURL)
@@ -218,11 +234,27 @@ enum MotionPhotoCLIIntegration {
                 checkpoint: checkpointURL
             )
         }
+    }
 
-        // If HEIC inputs exist, let the original batch implementation continue with its unchanged
-        // checkpoint/resume behavior. If this directory only contained Motion Photos, the batch is
-        // complete and must not fall through to the old "no *.heic matched" error.
-        return heicInputs.isEmpty
+    private struct PendingBatch {
+        let command: BatchCommand
+        let workItems: [MotionBatchWorkItem]
+    }
+
+    private final class PendingBatchStore: @unchecked Sendable {
+        private let lock = NSLock()
+        private var pending: PendingBatch?
+
+        func set(_ value: PendingBatch) {
+            lock.lock(); defer { lock.unlock() }
+            pending = value
+        }
+
+        func take() -> PendingBatch? {
+            lock.lock(); defer { lock.unlock() }
+            defer { pending = nil }
+            return pending
+        }
     }
 
     private struct MotionBatchWorkItem {
@@ -237,17 +269,9 @@ enum MotionPhotoCLIIntegration {
     ) -> [MotionBatchWorkItem] {
         var reserved = Set<String>()
 
-        // Reserve the outputs the unchanged HEIC batch pass will choose, preventing a Motion Photo
-        // with the same stem from being overwritten when that pass runs afterward.
-        for input in heicInputs {
-            let directory = categorizedOutputDirectory(for: input, command: command)
-            reserved.insert(
-                directory.appendingPathComponent(input.deletingPathExtension().lastPathComponent)
-                    .appendingPathExtension("heic").standardizedFileURL.path
-            )
-        }
-
-        return inputs.sorted { $0.path < $1.path }.map { input in
+        // Predict exactly the output names the unchanged HEIC batch pass will reserve, including
+        // duplicate stems, before assigning Live Photo outputs.
+        for input in heicInputs.sorted(by: { $0.path < $1.path }) {
             let directory = categorizedOutputDirectory(for: input, command: command)
             let stem = input.deletingPathExtension().lastPathComponent
             var sequence = 1
@@ -257,7 +281,25 @@ enum MotionPhotoCLIIntegration {
                 output = directory.appendingPathComponent("\(stem) (\(sequence))").appendingPathExtension("heic")
             }
             reserved.insert(output.standardizedFileURL.path)
-            reserved.insert(AppleLivePhotoConversionEngine.companionVideoURL(for: output).standardizedFileURL.path)
+        }
+
+        return inputs.sorted { $0.path < $1.path }.map { input in
+            let directory = categorizedOutputDirectory(for: input, command: command)
+            let stem = input.deletingPathExtension().lastPathComponent
+            var sequence = 1
+            var output = directory.appendingPathComponent(stem).appendingPathExtension("heic")
+            while reserved.contains(output.standardizedFileURL.path)
+                || reserved.contains(
+                    AppleLivePhotoConversionEngine.companionVideoURL(for: output)
+                        .standardizedFileURL.path
+                ) {
+                sequence += 1
+                output = directory.appendingPathComponent("\(stem) (\(sequence))").appendingPathExtension("heic")
+            }
+            reserved.insert(output.standardizedFileURL.path)
+            reserved.insert(
+                AppleLivePhotoConversionEngine.companionVideoURL(for: output).standardizedFileURL.path
+            )
             return MotionBatchWorkItem(inputURL: input, outputImageURL: output)
         }
     }

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoCLIIntegration.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoCLIIntegration.swift
@@ -104,6 +104,16 @@ enum MotionPhotoCLIIntegration {
             command: command
         )
 
+        let checkpointURL = MotionPhotoBatchCheckpoint.resolvedURL(for: command)
+        if !command.resume {
+            try MotionPhotoBatchCheckpoint.reset(url: checkpointURL)
+        }
+        let checkpointState = command.resume
+            ? try MotionPhotoBatchCheckpoint.load(url: checkpointURL)
+            : [:]
+        let checkpointWriter = try MotionPhotoBatchCheckpoint.Writer(url: checkpointURL)
+        defer { try? checkpointWriter.close() }
+
         let queue = OperationQueue()
         queue.maxConcurrentOperationCount = max(1, command.jobs)
         queue.qualityOfService = .userInitiated
@@ -115,40 +125,97 @@ enum MotionPhotoCLIIntegration {
         for item in workItems {
             queue.addOperation {
                 autoreleasepool {
-                    if command.skipExisting,
-                       AppleLivePhotoValidator.isValidPair(
-                           imageURL: item.outputImageURL,
-                           videoURL: AppleLivePhotoConversionEngine.companionVideoURL(for: item.outputImageURL)
-                       ) {
+                    let outputVideoURL = AppleLivePhotoConversionEngine.companionVideoURL(
+                        for: item.outputImageURL
+                    )
+                    let inputKey = item.inputURL.standardizedFileURL.path
+                    let signature = try? MotionPhotoBatchCheckpoint.signature(for: item.inputURL)
+                    let prior = checkpointState[inputKey]
+
+                    func record(
+                        _ status: MotionPhotoBatchCheckpoint.Status,
+                        error: String? = nil
+                    ) {
+                        do {
+                            try checkpointWriter.append(
+                                inputURL: item.inputURL,
+                                outputImageURL: item.outputImageURL,
+                                outputVideoURL: outputVideoURL,
+                                status: status,
+                                signature: signature,
+                                error: error
+                            )
+                        } catch {
+                            printSynchronized("Motion Photo checkpoint write failed: \(singleLine(error))")
+                        }
+                    }
+
+                    func pairIsValid() -> Bool {
+                        AppleLivePhotoValidator.isValidPair(
+                            imageURL: item.outputImageURL,
+                            videoURL: outputVideoURL
+                        )
+                    }
+
+                    let signatureMatches = prior?.matchesSignature(signature) == true
+                    if command.resume,
+                       let prior,
+                       signatureMatches,
+                       prior.matchesOutputs(
+                            imageURL: item.outputImageURL,
+                            videoURL: outputVideoURL
+                       ),
+                       (prior.status == .success || prior.status == .skippedExisting),
+                       pairIsValid() {
                         lock.lock(); skipped += 1; lock.unlock()
-                        printSynchronized("skipped \(item.inputURL.lastPathComponent) (Live Photo pair already valid)")
+                        record(.skippedExisting)
+                        printSynchronized("skipped \(item.inputURL.lastPathComponent) (Live Photo pair already up to date)")
                         return
                     }
+
+                    if command.skipExisting {
+                        let mustRetryFailure = command.resume
+                            && signatureMatches
+                            && prior?.status == .failure
+                        let inputChanged = prior != nil && !signatureMatches
+                        if !mustRetryFailure, !inputChanged, pairIsValid() {
+                            lock.lock(); skipped += 1; lock.unlock()
+                            record(.skippedExisting)
+                            printSynchronized("skipped \(item.inputURL.lastPathComponent) (Live Photo pair already valid)")
+                            return
+                        }
+                    }
+
                     do {
                         _ = try AppleLivePhotoConversionEngine.convert(
                             inputURL: item.inputURL,
                             outputImageURL: item.outputImageURL
                         )
                         lock.lock(); converted += 1; lock.unlock()
+                        record(.success)
                         printSynchronized("converted Motion Photo \(item.inputURL.lastPathComponent)")
                     } catch {
                         lock.lock(); failures.append((item.inputURL, error)); lock.unlock()
+                        record(.failure, error: String(describing: error))
                         printSynchronized("failed \(item.inputURL.lastPathComponent): \(singleLine(error))")
                     }
                 }
             }
         }
         queue.waitUntilAllOperationsAreFinished()
+        try checkpointWriter.close()
 
         print(
             "Motion Photo batch pass: \(converted) converted, \(skipped) skipped, "
                 + "\(failures.count) failed"
         )
-        if !failures.isEmpty {
+        if failures.isEmpty {
+            try? FileManager.default.removeItem(at: checkpointURL)
+        } else {
+            print("run the same command again to retry only the \(failures.count) failed Motion Photo file(s)")
             throw CLIError.batchFailed(
                 failures: failures.count,
-                checkpoint: command.checkpointURL
-                    ?? command.outputDirURL.appendingPathComponent(".xdremux-motion-photo-retry")
+                checkpoint: checkpointURL
             )
         }
 

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoCLIIntegration.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoCLIIntegration.swift
@@ -81,8 +81,11 @@ enum MotionPhotoCLIIntegration {
     }
 
     /// Plans the Motion Photo portion of a default batch. Explicit --glob retains the old contract.
-    /// If there are no existing HEIC inputs, the Motion Photo batch can run immediately. For a mixed
-    /// batch it is queued and runs only after the unchanged HEIC batch pass succeeds.
+    /// On the first mixed run there are no Live Photo HEIC outputs yet, so the unchanged HEIC batch
+    /// can run first and the Motion Photo pass is deferred. On subsequent runs, valid HEIC+MOV Live
+    /// Photo pairs are classified as outputs rather than HEIC inputs; the remaining real HEIC inputs
+    /// are handled here before the Motion Photo pass so the old `*.heic` enumerator can never ingest
+    /// a previously generated Live Photo still.
     private static func prepareDefaultBatch(_ rawArguments: [String]) throws -> Bool {
         guard !rawArguments.contains("--glob") else { return false }
 
@@ -97,23 +100,112 @@ enum MotionPhotoCLIIntegration {
         let motionInputs = jpegCandidates.filter(AppleLivePhotoConversionEngine.isMotionPhotoInput)
         guard !motionInputs.isEmpty else { return false }
 
-        let heicInputs = try discoverHEICs(
+        let allHEICInputs = try discoverHEICs(
             under: command.inputDirURL,
             excluding: command.outputDirURL
         )
+        let existingLivePhotoStills = allHEICInputs.filter(isExistingLivePhotoStill)
+        let existingLivePhotoPaths = Set(
+            existingLivePhotoStills.map { $0.standardizedFileURL.path }
+        )
+        let sourceHEICInputs = allHEICInputs.filter {
+            !existingLivePhotoPaths.contains($0.standardizedFileURL.path)
+        }
+
         let workItems = makeWorkItems(
             inputs: motionInputs,
-            heicInputs: heicInputs,
+            heicInputs: sourceHEICInputs,
             command: command
         )
 
-        if heicInputs.isEmpty {
+        if sourceHEICInputs.isEmpty {
             try runMotionBatch(command: command, workItems: workItems)
             return true
         }
 
-        pendingBatchStore.set(PendingBatch(command: command, workItems: workItems))
-        return false
+        if existingLivePhotoStills.isEmpty {
+            // First mixed run: no Motion Photo output exists yet, so the unchanged HEIC batch can
+            // safely enumerate now. Motion outputs are emitted only after it succeeds.
+            pendingBatchStore.set(PendingBatch(command: command, workItems: workItems))
+            return false
+        }
+
+        // Repeated mixed run (or a directory that already contains unrelated valid Live Photos):
+        // do not invoke the legacy glob-based batch enumerator, because it cannot distinguish those
+        // paired HEIC stills from source ProXDR HEICs. Convert only the classified source HEIC set.
+        try runClassifiedHEICBatch(command: command, inputs: sourceHEICInputs)
+        try runMotionBatch(command: command, workItems: workItems)
+        return true
+    }
+
+    private static func runClassifiedHEICBatch(
+        command: BatchCommand,
+        inputs: [URL]
+    ) throws {
+        let workItems = makeHEICWorkItems(inputs: inputs, command: command)
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = max(1, command.jobs)
+        queue.qualityOfService = .userInitiated
+
+        let lock = NSLock()
+        var converted = 0
+        var skipped = 0
+        var failures: [(URL, Error)] = []
+
+        for item in workItems {
+            queue.addOperation {
+                autoreleasepool {
+                    func outputIsValid() -> Bool {
+                        guard FileManager.default.fileExists(atPath: item.outputURL.path) else {
+                            return false
+                        }
+                        return ConversionEngine.isValidOutput(
+                            item.outputURL,
+                            config: command.conversionConfiguration
+                        )
+                    }
+
+                    if command.skipExisting, outputIsValid() {
+                        lock.lock(); skipped += 1; lock.unlock()
+                        printSynchronized("skipped \(item.inputURL.lastPathComponent) (HEIC output already up to date)")
+                        return
+                    }
+
+                    do {
+                        try FileManager.default.createDirectory(
+                            at: item.outputURL.deletingLastPathComponent(),
+                            withIntermediateDirectories: true
+                        )
+                        if item.outputURL.standardizedFileURL.path != item.inputURL.standardizedFileURL.path,
+                           FileManager.default.fileExists(atPath: item.outputURL.path) {
+                            try FileManager.default.removeItem(at: item.outputURL)
+                        }
+                        try ConversionEngine.convert(
+                            inputURL: item.inputURL,
+                            outputURL: item.outputURL,
+                            config: command.conversionConfiguration
+                        )
+                        lock.lock(); converted += 1; lock.unlock()
+                        printSynchronized("converted \(item.inputURL.lastPathComponent)")
+                    } catch {
+                        lock.lock(); failures.append((item.inputURL, error)); lock.unlock()
+                        printSynchronized("failed \(item.inputURL.lastPathComponent): \(singleLine(error))")
+                    }
+                }
+            }
+        }
+        queue.waitUntilAllOperationsAreFinished()
+
+        print(
+            "classified HEIC batch pass: \(converted) converted, \(skipped) skipped, "
+                + "\(failures.count) failed"
+        )
+        if !failures.isEmpty {
+            // Successful files will be skipped by output validation on the next invocation, so a
+            // rerun naturally retries only unresolved inputs even though this compatibility path
+            // does not share the legacy one-output checkpoint file.
+            throw ClassifiedHEICBatchError(failures: failures.count)
+        }
     }
 
     private static func runMotionBatch(
@@ -241,6 +333,18 @@ enum MotionPhotoCLIIntegration {
         let workItems: [MotionBatchWorkItem]
     }
 
+    private struct HEICWorkItem {
+        let inputURL: URL
+        let outputURL: URL
+    }
+
+    private struct ClassifiedHEICBatchError: LocalizedError {
+        let failures: Int
+        var errorDescription: String? {
+            "classified HEIC batch pass failed for \(failures) file(s); rerun the same command to retry unresolved inputs"
+        }
+    }
+
     private final class PendingBatchStore: @unchecked Sendable {
         private let lock = NSLock()
         private var pending: PendingBatch?
@@ -262,16 +366,12 @@ enum MotionPhotoCLIIntegration {
         let outputImageURL: URL
     }
 
-    private static func makeWorkItems(
+    private static func makeHEICWorkItems(
         inputs: [URL],
-        heicInputs: [URL],
         command: BatchCommand
-    ) -> [MotionBatchWorkItem] {
+    ) -> [HEICWorkItem] {
         var reserved = Set<String>()
-
-        // Predict exactly the output names the unchanged HEIC batch pass will reserve, including
-        // duplicate stems, before assigning Live Photo outputs.
-        for input in heicInputs.sorted(by: { $0.path < $1.path }) {
+        return inputs.sorted { $0.path < $1.path }.map { input in
             let directory = categorizedOutputDirectory(for: input, command: command)
             let stem = input.deletingPathExtension().lastPathComponent
             var sequence = 1
@@ -281,6 +381,21 @@ enum MotionPhotoCLIIntegration {
                 output = directory.appendingPathComponent("\(stem) (\(sequence))").appendingPathExtension("heic")
             }
             reserved.insert(output.standardizedFileURL.path)
+            return HEICWorkItem(inputURL: input, outputURL: output)
+        }
+    }
+
+    private static func makeWorkItems(
+        inputs: [URL],
+        heicInputs: [URL],
+        command: BatchCommand
+    ) -> [MotionBatchWorkItem] {
+        var reserved = Set<String>()
+
+        // Predict exactly the output names the unchanged/classified HEIC batch pass will reserve,
+        // including duplicate stems, before assigning Live Photo outputs.
+        for item in makeHEICWorkItems(inputs: heicInputs, command: command) {
+            reserved.insert(item.outputURL.standardizedFileURL.path)
         }
 
         return inputs.sorted { $0.path < $1.path }.map { input in
@@ -310,6 +425,12 @@ enum MotionPhotoCLIIntegration {
             return command.outputDirURL.appendingPathComponent(folder, isDirectory: true)
         }
         return command.outputDirURL
+    }
+
+    private static func isExistingLivePhotoStill(_ imageURL: URL) -> Bool {
+        let companion = AppleLivePhotoConversionEngine.companionVideoURL(for: imageURL)
+        guard FileManager.default.fileExists(atPath: companion.path) else { return false }
+        return AppleLivePhotoValidator.isValidPair(imageURL: imageURL, videoURL: companion)
     }
 
     private static func discoverJPEGs(under root: URL, excluding outputRoot: URL) throws -> [URL] {

--- a/Sources/XDRemuxCLI/main.swift
+++ b/Sources/XDRemuxCLI/main.swift
@@ -3,8 +3,11 @@ import XDRemuxAppleFeatures
 
 let arguments = Array(CommandLine.arguments.dropFirst())
 do {
-    if try !MotionPhotoCLIIntegration.handleIfNeeded(arguments) {
+    if try MotionPhotoCLIIntegration.handleIfNeeded(arguments) {
+        // The Motion Photo integration fully handled this command.
+    } else {
         XDRemuxCommand.main()
+        try MotionPhotoCLIIntegration.finishPendingBatchIfNeeded()
     }
 } catch {
     MotionPhotoCLIIntegration.printFailure(error)

--- a/Sources/XDRemuxCLI/main.swift
+++ b/Sources/XDRemuxCLI/main.swift
@@ -1,3 +1,12 @@
+import Foundation
 import XDRemuxAppleFeatures
 
-XDRemuxCommand.main()
+let arguments = Array(CommandLine.arguments.dropFirst())
+do {
+    if try !MotionPhotoCLIIntegration.handleIfNeeded(arguments) {
+        XDRemuxCommand.main()
+    }
+} catch {
+    MotionPhotoCLIIntegration.printFailure(error)
+    exit(1)
+}

--- a/Sources/XDRemuxCore/MotionPhoto/Android/AndroidMotionPhotoParser.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Android/AndroidMotionPhotoParser.swift
@@ -1,0 +1,365 @@
+import Foundation
+import FoundationXML
+
+public enum AndroidMotionPhotoParser {
+    private static let maxXMPScanBytes = 4 * 1024 * 1024
+    private static let maxDirectoryItems = 64
+    private static let maxMetadataStringLength = 4096
+
+    public static func parse(url: URL) throws -> MotionPhotoAsset? {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        guard let fileSizeNumber = attributes[.size] as? NSNumber else {
+            throw MotionPhotoParsingError.fileTooSmall
+        }
+        let fileSize = fileSizeNumber.int64Value
+        guard fileSize >= 16 else { throw MotionPhotoParsingError.fileTooSmall }
+
+        guard let xmp = try extractXMP(from: url, fileSize: fileSize) else { return nil }
+        let description = try parseXMP(xmp)
+        guard description.motionPhotoEnabled else { return nil }
+
+        let sourceKind: MotionPhotoSourceKind
+        let items: [MotionPhotoItem]
+        let timestampSource: MotionPhotoPresentationSource?
+
+        if !description.items.isEmpty {
+            guard description.version == 1 else {
+                throw MotionPhotoParsingError.unsupportedVersion(description.version)
+            }
+            sourceKind = .androidMotionPhotoV1
+            items = description.items
+            timestampSource = description.presentationTimestampUs == nil ? nil : .androidXMP
+        } else if let legacyOffset = description.legacyMicroVideoOffset {
+            guard legacyOffset > 0 else { throw MotionPhotoParsingError.invalidItemLength }
+            sourceKind = .legacyMicroVideoV1b
+            items = [
+                MotionPhotoItem(mime: "image/jpeg", semantic: "Primary", length: 0, padding: 0),
+                MotionPhotoItem(mime: "video/mp4", semantic: "MotionPhoto", length: legacyOffset, padding: 0),
+            ]
+            timestampSource = description.presentationTimestampUs == nil ? nil : .legacyMicroVideoXMP
+        } else {
+            throw MotionPhotoParsingError.invalidDirectory
+        }
+
+        try validateDirectory(items)
+        let ranges = try deriveRanges(items: items, fileSize: fileSize)
+        try validateISOBaseMediaPayload(url: url, range: ranges.video)
+
+        return MotionPhotoAsset(
+            sourceURL: url,
+            sourceKind: sourceKind,
+            items: items,
+            stillResourceRange: ranges.still,
+            videoResourceRange: ranges.video,
+            presentationTimestampUs: description.presentationTimestampUs,
+            presentationSource: timestampSource
+        )
+    }
+
+    private static func extractXMP(from url: URL, fileSize: Int64) throws -> Data? {
+        let scanLength = min(Int64(maxXMPScanBytes), fileSize)
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        let prefix = try handle.read(upToCount: Int(scanLength)) ?? Data()
+
+        let openingCandidates = [Data("<x:xmpmeta".utf8), Data("<xmpmeta".utf8)]
+        let closingCandidates = [Data("</x:xmpmeta>".utf8), Data("</xmpmeta>".utf8)]
+
+        guard let start = openingCandidates.compactMap({ prefix.range(of: $0)?.lowerBound }).min() else {
+            return nil
+        }
+
+        var matchingEnd: Data.Index?
+        for closing in closingCandidates {
+            if let range = prefix.range(of: closing, options: [], in: start..<prefix.endIndex) {
+                let end = range.upperBound
+                matchingEnd = matchingEnd.map { min($0, end) } ?? end
+            }
+        }
+
+        guard let end = matchingEnd else {
+            if fileSize > scanLength { throw MotionPhotoParsingError.xmpTooLarge }
+            throw MotionPhotoParsingError.malformedXMP
+        }
+        return prefix.subdata(in: start..<end)
+    }
+
+    private static func parseXMP(_ data: Data) throws -> ParsedXMP {
+        let delegate = XMPDelegate(maxItems: maxDirectoryItems, maxStringLength: maxMetadataStringLength)
+        let parser = XMLParser(data: data)
+        parser.shouldProcessNamespaces = false
+        parser.shouldReportNamespacePrefixes = true
+        parser.shouldResolveExternalEntities = false
+        parser.externalEntityResolvingPolicy = .never
+        parser.delegate = delegate
+        guard parser.parse(), delegate.error == nil else {
+            throw delegate.error ?? MotionPhotoParsingError.malformedXMP
+        }
+        return delegate.result
+    }
+
+    private static func validateDirectory(_ items: [MotionPhotoItem]) throws {
+        guard items.count >= 2, items.count <= maxDirectoryItems else {
+            throw MotionPhotoParsingError.invalidDirectory
+        }
+        guard items.allSatisfy({ $0.length >= 0 && $0.padding >= 0 }) else {
+            throw MotionPhotoParsingError.invalidItemLength
+        }
+
+        let primaryIndices = items.indices.filter { items[$0].semantic.caseInsensitiveCompare("Primary") == .orderedSame }
+        guard primaryIndices == [0] else { throw MotionPhotoParsingError.invalidPrimaryItem }
+
+        let motionIndices = items.indices.filter { items[$0].semantic.caseInsensitiveCompare("MotionPhoto") == .orderedSame }
+        guard motionIndices.count == 1, motionIndices[0] == items.count - 1 else {
+            throw MotionPhotoParsingError.invalidMotionPhotoItem
+        }
+
+        let motion = items[motionIndices[0]]
+        let supportedMime = motion.mime.caseInsensitiveCompare("video/mp4") == .orderedSame
+            || motion.mime.caseInsensitiveCompare("video/quicktime") == .orderedSame
+        guard supportedMime, motion.length > 0 else {
+            throw MotionPhotoParsingError.invalidMotionPhotoItem
+        }
+    }
+
+    private static func deriveRanges(
+        items: [MotionPhotoItem],
+        fileSize: Int64
+    ) throws -> (still: MotionPhotoByteRange, video: MotionPhotoByteRange) {
+        var itemStart = fileSize
+        var itemEnd = fileSize
+        var photoStart: Int64?
+        var photoEnd: Int64?
+        var videoStart: Int64?
+        var videoEnd: Int64?
+
+        for index in items.indices.reversed() {
+            let item = items[index]
+            itemEnd = itemStart
+
+            if index == 0 {
+                let (paddedEnd, overflow) = itemEnd.subtractingReportingOverflow(item.padding)
+                guard !overflow, paddedEnd >= 0 else { throw MotionPhotoParsingError.arithmeticOverflow }
+                itemStart = 0
+                itemEnd = paddedEnd
+            } else {
+                let (candidate, overflow) = itemStart.subtractingReportingOverflow(item.length)
+                guard !overflow, candidate >= 0 else { throw MotionPhotoParsingError.arithmeticOverflow }
+                itemStart = candidate
+            }
+
+            let isVideo = item.mime.caseInsensitiveCompare("video/mp4") == .orderedSame
+                || item.mime.caseInsensitiveCompare("video/quicktime") == .orderedSame
+            if isVideo, itemStart != itemEnd {
+                videoStart = itemStart
+                videoEnd = itemEnd
+            }
+            if index == 0 {
+                photoStart = itemStart
+                photoEnd = itemEnd
+            }
+        }
+
+        guard let photoStart, let photoEnd, let videoStart, let videoEnd else {
+            throw MotionPhotoParsingError.invalidByteRange
+        }
+        guard photoEnd <= fileSize, videoEnd == fileSize, photoEnd <= videoStart else {
+            throw MotionPhotoParsingError.invalidByteRange
+        }
+
+        return (
+            try MotionPhotoByteRange(lowerBound: photoStart, upperBound: photoEnd),
+            try MotionPhotoByteRange(lowerBound: videoStart, upperBound: videoEnd)
+        )
+    }
+
+    private static func validateISOBaseMediaPayload(url: URL, range: MotionPhotoByteRange) throws {
+        guard range.length >= 12 else { throw MotionPhotoParsingError.invalidVideoPayload }
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        try handle.seek(toOffset: UInt64(range.lowerBound))
+        let header = try handle.read(upToCount: 16) ?? Data()
+        guard header.count >= 8 else { throw MotionPhotoParsingError.invalidVideoPayload }
+
+        let size = header.prefix(4).reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+        let type = String(bytes: header[4..<8], encoding: .ascii)
+        guard type == "ftyp" else { throw MotionPhotoParsingError.invalidVideoPayload }
+        guard size == 1 || (size >= 8 && Int64(size) <= range.length) else {
+            throw MotionPhotoParsingError.invalidVideoPayload
+        }
+        if size == 1 {
+            guard header.count >= 16 else { throw MotionPhotoParsingError.invalidVideoPayload }
+            let largeSize = header[8..<16].reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
+            guard largeSize >= 16, largeSize <= UInt64(range.length) else {
+                throw MotionPhotoParsingError.invalidVideoPayload
+            }
+        }
+    }
+}
+
+private struct ParsedXMP {
+    var motionPhotoEnabled = false
+    var version: Int?
+    var presentationTimestampUs: Int64?
+    var legacyMicroVideoOffset: Int64?
+    var items: [MotionPhotoItem] = []
+}
+
+private final class XMPDelegate: NSObject, XMLParserDelegate {
+    private let maxItems: Int
+    private let maxStringLength: Int
+    fileprivate var result = ParsedXMP()
+    fileprivate var error: MotionPhotoParsingError?
+    private var directoryPrefix: String?
+
+    init(maxItems: Int, maxStringLength: Int) {
+        self.maxItems = maxItems
+        self.maxStringLength = maxStringLength
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String]
+    ) {
+        guard error == nil else { parser.abortParsing(); return }
+        let name = qName ?? elementName
+
+        if name == "rdf:Description" || elementName == "rdf:Description" {
+            do {
+                try parseDescription(attributeDict)
+            } catch let parsingError as MotionPhotoParsingError {
+                error = parsingError
+                parser.abortParsing()
+            } catch {
+                self.error = .malformedXMP
+                parser.abortParsing()
+            }
+            return
+        }
+
+        if name == "Container:Directory" || elementName == "Container:Directory" {
+            directoryPrefix = "Container"
+            return
+        }
+        if name == "GContainer:Directory" || elementName == "GContainer:Directory" {
+            directoryPrefix = "GContainer"
+            return
+        }
+
+        guard let directoryPrefix else { return }
+        let itemElement = "\(directoryPrefix):Item"
+        guard name == itemElement || elementName == itemElement else { return }
+
+        guard result.items.count < maxItems else {
+            error = .invalidDirectory
+            parser.abortParsing()
+            return
+        }
+
+        let attributePrefix = directoryPrefix == "Container" ? "Item" : "GContainerItem"
+        guard let mime = bounded(attributeDict["\(attributePrefix):Mime"]),
+              let semantic = bounded(attributeDict["\(attributePrefix):Semantic"]) else {
+            error = .invalidDirectory
+            parser.abortParsing()
+            return
+        }
+        let length = parseNonnegativeInt64(attributeDict["\(attributePrefix):Length"], defaultValue: 0)
+        let padding = parseNonnegativeInt64(attributeDict["\(attributePrefix):Padding"], defaultValue: 0)
+        guard let length, let padding else {
+            error = .invalidItemLength
+            parser.abortParsing()
+            return
+        }
+        result.items.append(MotionPhotoItem(mime: mime, semantic: semantic, length: length, padding: padding))
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        let name = qName ?? elementName
+        if name == "Container:Directory" || name == "GContainer:Directory"
+            || elementName == "Container:Directory" || elementName == "GContainer:Directory" {
+            directoryPrefix = nil
+        }
+    }
+
+    func parser(_ parser: XMLParser, parseErrorOccurred parseError: Error) {
+        if error == nil { error = .malformedXMP }
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        resolveExternalEntityName name: String,
+        systemID: String?
+    ) -> Data? {
+        error = .malformedXMP
+        parser.abortParsing()
+        return nil
+    }
+
+    private func parseDescription(_ attributes: [String: String]) throws {
+        let motionNames = ["Camera:MotionPhoto", "GCamera:MotionPhoto"]
+        let microVideoNames = ["Camera:MicroVideo", "GCamera:MicroVideo"]
+        let versionNames = ["Camera:MotionPhotoVersion", "GCamera:MotionPhotoVersion"]
+        let timestampNames = [
+            "Camera:MotionPhotoPresentationTimestampUs",
+            "GCamera:MotionPhotoPresentationTimestampUs",
+            "Camera:MicroVideoPresentationTimestampUs",
+            "GCamera:MicroVideoPresentationTimestampUs",
+        ]
+        let offsetNames = ["Camera:MicroVideoOffset", "GCamera:MicroVideoOffset"]
+
+        if let flag = firstInt(attributes, names: motionNames) {
+            result.motionPhotoEnabled = flag == 1
+        } else if let flag = firstInt(attributes, names: microVideoNames) {
+            result.motionPhotoEnabled = flag == 1
+        }
+
+        if let version = firstInt(attributes, names: versionNames) {
+            result.version = version
+        }
+        if let timestamp = firstInt64(attributes, names: timestampNames) {
+            result.presentationTimestampUs = timestamp == -1 ? nil : timestamp
+        }
+        if let offset = firstInt64(attributes, names: offsetNames) {
+            result.legacyMicroVideoOffset = offset
+        }
+    }
+
+    private func bounded(_ value: String?) -> String? {
+        guard let value, !value.isEmpty, value.utf8.count <= maxStringLength else { return nil }
+        return value
+    }
+
+    private func parseNonnegativeInt64(_ value: String?, defaultValue: Int64) -> Int64? {
+        guard let value else { return defaultValue }
+        guard value.utf8.count <= 32, let parsed = Int64(value), parsed >= 0 else { return nil }
+        return parsed
+    }
+
+    private func firstInt(_ attributes: [String: String], names: [String]) -> Int? {
+        for name in names {
+            if let raw = attributes[name] {
+                guard raw.utf8.count <= 32 else { return nil }
+                return Int(raw)
+            }
+        }
+        return nil
+    }
+
+    private func firstInt64(_ attributes: [String: String], names: [String]) -> Int64? {
+        for name in names {
+            if let raw = attributes[name] {
+                guard raw.utf8.count <= 32 else { return nil }
+                return Int64(raw)
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/XDRemuxCore/MotionPhoto/Android/AndroidMotionPhotoParser.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Android/AndroidMotionPhotoParser.swift
@@ -25,8 +25,10 @@ public enum AndroidMotionPhotoParser {
             guard description.version == 1 else {
                 throw MotionPhotoParsingError.unsupportedVersion(description.version)
             }
-            sourceKind = .androidMotionPhotoV1
             items = description.items
+            sourceKind = ISOBMFFMotionPhotoRangeResolver.isHEIFMime(items[0].mime)
+                ? .androidHeifMotionPhotoV1
+                : .androidMotionPhotoV1
             timestampSource = description.presentationTimestampUs == nil ? nil : .androidXMP
         } else if let legacyOffset = description.legacyMicroVideoOffset {
             guard legacyOffset > 0 else { throw MotionPhotoParsingError.invalidItemLength }
@@ -41,13 +43,22 @@ public enum AndroidMotionPhotoParser {
         }
 
         try validateDirectory(items)
-        let ranges = try deriveRanges(items: items, fileSize: fileSize)
-        guard try ISOBaseMediaStreamScanner.isFTYPBoxStart(
-            in: url,
-            offset: ranges.video.lowerBound,
-            upperBound: ranges.video.upperBound
-        ) else {
-            throw MotionPhotoParsingError.invalidVideoPayload
+        let ranges: (still: MotionPhotoByteRange, video: MotionPhotoByteRange)
+        if sourceKind == .androidHeifMotionPhotoV1 {
+            ranges = try ISOBMFFMotionPhotoRangeResolver.resolve(
+                url: url,
+                items: items,
+                fileSize: fileSize
+            )
+        } else {
+            ranges = try deriveJPEGStyleRanges(items: items, fileSize: fileSize)
+            guard try ISOBaseMediaStreamScanner.isFTYPBoxStart(
+                in: url,
+                offset: ranges.video.lowerBound,
+                upperBound: ranges.video.upperBound
+            ) else {
+                throw MotionPhotoParsingError.invalidVideoPayload
+            }
         }
 
         return MotionPhotoAsset(
@@ -85,9 +96,8 @@ public enum AndroidMotionPhotoParser {
     }
 
     private static func parseXMP(_ data: Data) throws -> ParsedXMP {
-        // Motion Photo metadata does not require DTDs or custom entities. Rejecting declarations
-        // before invoking XMLParser gives us an explicit XXE/DTD safety boundary in addition to
-        // disabling external entity resolution below.
+        // Motion Photo metadata does not require DTDs or custom entities. Reject declarations
+        // before invoking XMLParser, in addition to disabling external entity resolution below.
         if data.range(of: Data("<!DOCTYPE".utf8)) != nil
             || data.range(of: Data("<!ENTITY".utf8)) != nil {
             throw MotionPhotoParsingError.malformedXMP
@@ -138,7 +148,7 @@ public enum AndroidMotionPhotoParser {
         }
     }
 
-    private static func deriveRanges(
+    private static func deriveJPEGStyleRanges(
         items: [MotionPhotoItem],
         fileSize: Int64
     ) throws -> (still: MotionPhotoByteRange, video: MotionPhotoByteRange) {
@@ -181,10 +191,10 @@ public enum AndroidMotionPhotoParser {
             throw MotionPhotoParsingError.invalidByteRange
         }
 
-        // For conversion we need the complete still-image container, not only the Primary item.
-        // In Ultra HDR JPEG Motion Photos the positive-length GainMap secondary resource lives
-        // between the primary JPEG encoding and the final MotionPhoto video. Supplying 0..<videoStart
-        // to ImageIO preserves that gain-map resource while still excluding the appended MP4.
+        // For JPEG conversion we need the complete still-image resource, not only the Primary item.
+        // Ultra HDR Motion Photos can carry a positive-length GainMap secondary JPEG between the
+        // primary encoding and the trailing MotionPhoto video. Supplying 0..<videoStart to ImageIO
+        // preserves that resource while excluding only the appended MP4.
         return (
             try MotionPhotoByteRange(lowerBound: 0, upperBound: videoStart),
             try MotionPhotoByteRange(lowerBound: videoStart, upperBound: videoEnd)

--- a/Sources/XDRemuxCore/MotionPhoto/Android/AndroidMotionPhotoParser.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Android/AndroidMotionPhotoParser.swift
@@ -85,6 +85,14 @@ public enum AndroidMotionPhotoParser {
     }
 
     private static func parseXMP(_ data: Data) throws -> ParsedXMP {
+        // Motion Photo metadata does not require DTDs or custom entities. Rejecting declarations
+        // before invoking XMLParser gives us an explicit XXE/DTD safety boundary in addition to
+        // disabling external entity resolution below.
+        if data.range(of: Data("<!DOCTYPE".utf8)) != nil
+            || data.range(of: Data("<!ENTITY".utf8)) != nil {
+            throw MotionPhotoParsingError.malformedXMP
+        }
+
         let delegate = XMPDelegate(
             maxItems: maxDirectoryItems,
             maxStringLength: maxMetadataStringLength

--- a/Sources/XDRemuxCore/MotionPhoto/Android/AndroidMotionPhotoParser.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Android/AndroidMotionPhotoParser.swift
@@ -136,7 +136,7 @@ public enum AndroidMotionPhotoParser {
     ) throws -> (still: MotionPhotoByteRange, video: MotionPhotoByteRange) {
         var itemStart = fileSize
         var itemEnd = fileSize
-        var photoEnd: Int64?
+        var primaryEncodingEnd: Int64?
         var videoStart: Int64?
         var videoEnd: Int64?
 
@@ -144,13 +144,13 @@ public enum AndroidMotionPhotoParser {
             let item = items[index]
             itemEnd = itemStart
             if index == 0 {
-                let (paddedEnd, overflow) = itemEnd.subtractingReportingOverflow(item.padding)
-                guard !overflow, paddedEnd >= 0 else {
+                let (unpaddedEnd, overflow) = itemEnd.subtractingReportingOverflow(item.padding)
+                guard !overflow, unpaddedEnd >= 0 else {
                     throw MotionPhotoParsingError.arithmeticOverflow
                 }
                 itemStart = 0
-                itemEnd = paddedEnd
-                photoEnd = itemEnd
+                itemEnd = unpaddedEnd
+                primaryEncodingEnd = itemEnd
             } else {
                 let (candidate, overflow) = itemStart.subtractingReportingOverflow(item.length)
                 guard !overflow, candidate >= 0 else {
@@ -166,14 +166,19 @@ public enum AndroidMotionPhotoParser {
             }
         }
 
-        guard let photoEnd, let videoStart, let videoEnd,
-              photoEnd <= fileSize,
-              videoEnd == fileSize,
-              photoEnd <= videoStart else {
+        guard let primaryEncodingEnd, let videoStart, let videoEnd,
+              primaryEncodingEnd <= videoStart,
+              videoStart >= 0,
+              videoEnd == fileSize else {
             throw MotionPhotoParsingError.invalidByteRange
         }
+
+        // For conversion we need the complete still-image container, not only the Primary item.
+        // In Ultra HDR JPEG Motion Photos the positive-length GainMap secondary resource lives
+        // between the primary JPEG encoding and the final MotionPhoto video. Supplying 0..<videoStart
+        // to ImageIO preserves that gain-map resource while still excluding the appended MP4.
         return (
-            try MotionPhotoByteRange(lowerBound: 0, upperBound: photoEnd),
+            try MotionPhotoByteRange(lowerBound: 0, upperBound: videoStart),
             try MotionPhotoByteRange(lowerBound: videoStart, upperBound: videoEnd)
         )
     }

--- a/Sources/XDRemuxCore/MotionPhoto/Android/AndroidMotionPhotoParser.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Android/AndroidMotionPhotoParser.swift
@@ -1,5 +1,4 @@
 import Foundation
-import FoundationXML
 
 public enum AndroidMotionPhotoParser {
     private static let maxXMPScanBytes = 4 * 1024 * 1024
@@ -43,7 +42,13 @@ public enum AndroidMotionPhotoParser {
 
         try validateDirectory(items)
         let ranges = try deriveRanges(items: items, fileSize: fileSize)
-        try validateISOBaseMediaPayload(url: url, range: ranges.video)
+        guard try ISOBaseMediaStreamScanner.isFTYPBoxStart(
+            in: url,
+            offset: ranges.video.lowerBound,
+            upperBound: ranges.video.upperBound
+        ) else {
+            throw MotionPhotoParsingError.invalidVideoPayload
+        }
 
         return MotionPhotoAsset(
             sourceURL: url,
@@ -61,31 +66,29 @@ public enum AndroidMotionPhotoParser {
         let handle = try FileHandle(forReadingFrom: url)
         defer { try? handle.close() }
         let prefix = try handle.read(upToCount: Int(scanLength)) ?? Data()
-
-        let openingCandidates = [Data("<x:xmpmeta".utf8), Data("<xmpmeta".utf8)]
-        let closingCandidates = [Data("</x:xmpmeta>".utf8), Data("</xmpmeta>".utf8)]
-
-        guard let start = openingCandidates.compactMap({ prefix.range(of: $0)?.lowerBound }).min() else {
+        let openings = [Data("<x:xmpmeta".utf8), Data("<xmpmeta".utf8)]
+        let closings = [Data("</x:xmpmeta>".utf8), Data("</xmpmeta>".utf8)]
+        guard let start = openings.compactMap({ prefix.range(of: $0)?.lowerBound }).min() else {
             return nil
         }
-
-        var matchingEnd: Data.Index?
-        for closing in closingCandidates {
-            if let range = prefix.range(of: closing, options: [], in: start..<prefix.endIndex) {
-                let end = range.upperBound
-                matchingEnd = matchingEnd.map { min($0, end) } ?? end
+        var endIndex: Data.Index?
+        for closing in closings {
+            if let range = prefix.range(of: closing, in: start..<prefix.endIndex) {
+                endIndex = endIndex.map { min($0, range.upperBound) } ?? range.upperBound
             }
         }
-
-        guard let end = matchingEnd else {
+        guard let endIndex else {
             if fileSize > scanLength { throw MotionPhotoParsingError.xmpTooLarge }
             throw MotionPhotoParsingError.malformedXMP
         }
-        return prefix.subdata(in: start..<end)
+        return prefix.subdata(in: start..<endIndex)
     }
 
     private static func parseXMP(_ data: Data) throws -> ParsedXMP {
-        let delegate = XMPDelegate(maxItems: maxDirectoryItems, maxStringLength: maxMetadataStringLength)
+        let delegate = XMPDelegate(
+            maxItems: maxDirectoryItems,
+            maxStringLength: maxMetadataStringLength
+        )
         let parser = XMLParser(data: data)
         parser.shouldProcessNamespaces = false
         parser.shouldReportNamespacePrefixes = true
@@ -105,15 +108,20 @@ public enum AndroidMotionPhotoParser {
         guard items.allSatisfy({ $0.length >= 0 && $0.padding >= 0 }) else {
             throw MotionPhotoParsingError.invalidItemLength
         }
-
-        let primaryIndices = items.indices.filter { items[$0].semantic.caseInsensitiveCompare("Primary") == .orderedSame }
-        guard primaryIndices == [0] else { throw MotionPhotoParsingError.invalidPrimaryItem }
-
-        let motionIndices = items.indices.filter { items[$0].semantic.caseInsensitiveCompare("MotionPhoto") == .orderedSame }
+        guard items[0].semantic.caseInsensitiveCompare("Primary") == .orderedSame,
+              items.dropFirst().allSatisfy({ $0.semantic.caseInsensitiveCompare("Primary") != .orderedSame }),
+              items[0].length == 0 else {
+            throw MotionPhotoParsingError.invalidPrimaryItem
+        }
+        guard items.dropFirst().allSatisfy({ $0.padding == 0 }) else {
+            throw MotionPhotoParsingError.invalidItemLength
+        }
+        let motionIndices = items.indices.filter {
+            items[$0].semantic.caseInsensitiveCompare("MotionPhoto") == .orderedSame
+        }
         guard motionIndices.count == 1, motionIndices[0] == items.count - 1 else {
             throw MotionPhotoParsingError.invalidMotionPhotoItem
         }
-
         let motion = items[motionIndices[0]]
         let supportedMime = motion.mime.caseInsensitiveCompare("video/mp4") == .orderedSame
             || motion.mime.caseInsensitiveCompare("video/quicktime") == .orderedSame
@@ -128,7 +136,6 @@ public enum AndroidMotionPhotoParser {
     ) throws -> (still: MotionPhotoByteRange, video: MotionPhotoByteRange) {
         var itemStart = fileSize
         var itemEnd = fileSize
-        var photoStart: Int64?
         var photoEnd: Int64?
         var videoStart: Int64?
         var videoEnd: Int64?
@@ -136,64 +143,39 @@ public enum AndroidMotionPhotoParser {
         for index in items.indices.reversed() {
             let item = items[index]
             itemEnd = itemStart
-
             if index == 0 {
                 let (paddedEnd, overflow) = itemEnd.subtractingReportingOverflow(item.padding)
-                guard !overflow, paddedEnd >= 0 else { throw MotionPhotoParsingError.arithmeticOverflow }
+                guard !overflow, paddedEnd >= 0 else {
+                    throw MotionPhotoParsingError.arithmeticOverflow
+                }
                 itemStart = 0
                 itemEnd = paddedEnd
+                photoEnd = itemEnd
             } else {
                 let (candidate, overflow) = itemStart.subtractingReportingOverflow(item.length)
-                guard !overflow, candidate >= 0 else { throw MotionPhotoParsingError.arithmeticOverflow }
+                guard !overflow, candidate >= 0 else {
+                    throw MotionPhotoParsingError.arithmeticOverflow
+                }
                 itemStart = candidate
             }
-
             let isVideo = item.mime.caseInsensitiveCompare("video/mp4") == .orderedSame
                 || item.mime.caseInsensitiveCompare("video/quicktime") == .orderedSame
             if isVideo, itemStart != itemEnd {
                 videoStart = itemStart
                 videoEnd = itemEnd
             }
-            if index == 0 {
-                photoStart = itemStart
-                photoEnd = itemEnd
-            }
         }
 
-        guard let photoStart, let photoEnd, let videoStart, let videoEnd else {
+        guard let photoEnd, let videoStart, let videoEnd,
+              photoEnd <= fileSize,
+              videoEnd == fileSize,
+              photoEnd <= videoStart else {
             throw MotionPhotoParsingError.invalidByteRange
         }
-        guard photoEnd <= fileSize, videoEnd == fileSize, photoEnd <= videoStart else {
-            throw MotionPhotoParsingError.invalidByteRange
-        }
-
         return (
-            try MotionPhotoByteRange(lowerBound: photoStart, upperBound: photoEnd),
+            try MotionPhotoByteRange(lowerBound: 0, upperBound: photoEnd),
             try MotionPhotoByteRange(lowerBound: videoStart, upperBound: videoEnd)
         )
-    }
-
-    private static func validateISOBaseMediaPayload(url: URL, range: MotionPhotoByteRange) throws {
-        guard range.length >= 12 else { throw MotionPhotoParsingError.invalidVideoPayload }
-        let handle = try FileHandle(forReadingFrom: url)
-        defer { try? handle.close() }
-        try handle.seek(toOffset: UInt64(range.lowerBound))
-        let header = try handle.read(upToCount: 16) ?? Data()
-        guard header.count >= 8 else { throw MotionPhotoParsingError.invalidVideoPayload }
-
-        let size = header.prefix(4).reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
-        let type = String(bytes: header[4..<8], encoding: .ascii)
-        guard type == "ftyp" else { throw MotionPhotoParsingError.invalidVideoPayload }
-        guard size == 1 || (size >= 8 && Int64(size) <= range.length) else {
-            throw MotionPhotoParsingError.invalidVideoPayload
-        }
-        if size == 1 {
-            guard header.count >= 16 else { throw MotionPhotoParsingError.invalidVideoPayload }
-            let largeSize = header[8..<16].reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
-            guard largeSize >= 16, largeSize <= UInt64(range.length) else {
-                throw MotionPhotoParsingError.invalidVideoPayload
-            }
-        }
     }
 }
 
@@ -226,54 +208,37 @@ private final class XMPDelegate: NSObject, XMLParserDelegate {
     ) {
         guard error == nil else { parser.abortParsing(); return }
         let name = qName ?? elementName
-
-        if name == "rdf:Description" || elementName == "rdf:Description" {
-            do {
-                try parseDescription(attributeDict)
-            } catch let parsingError as MotionPhotoParsingError {
-                error = parsingError
-                parser.abortParsing()
-            } catch {
-                self.error = .malformedXMP
-                parser.abortParsing()
-            }
+        if name == "rdf:Description" {
+            parseDescription(attributeDict)
             return
         }
-
-        if name == "Container:Directory" || elementName == "Container:Directory" {
+        if name == "Container:Directory" {
             directoryPrefix = "Container"
             return
         }
-        if name == "GContainer:Directory" || elementName == "GContainer:Directory" {
+        if name == "GContainer:Directory" {
             directoryPrefix = "GContainer"
             return
         }
-
-        guard let directoryPrefix else { return }
-        let itemElement = "\(directoryPrefix):Item"
-        guard name == itemElement || elementName == itemElement else { return }
-
+        guard let directoryPrefix,
+              name == "\(directoryPrefix):Item" else { return }
         guard result.items.count < maxItems else {
             error = .invalidDirectory
             parser.abortParsing()
             return
         }
-
-        let attributePrefix = directoryPrefix == "Container" ? "Item" : "GContainerItem"
-        guard let mime = bounded(attributeDict["\(attributePrefix):Mime"]),
-              let semantic = bounded(attributeDict["\(attributePrefix):Semantic"]) else {
+        let prefix = directoryPrefix == "Container" ? "Item" : "GContainerItem"
+        guard let mime = bounded(attributeDict["\(prefix):Mime"]),
+              let semantic = bounded(attributeDict["\(prefix):Semantic"]),
+              let length = nonnegative(attributeDict["\(prefix):Length"], defaultValue: 0),
+              let padding = nonnegative(attributeDict["\(prefix):Padding"], defaultValue: 0) else {
             error = .invalidDirectory
             parser.abortParsing()
             return
         }
-        let length = parseNonnegativeInt64(attributeDict["\(attributePrefix):Length"], defaultValue: 0)
-        let padding = parseNonnegativeInt64(attributeDict["\(attributePrefix):Padding"], defaultValue: 0)
-        guard let length, let padding else {
-            error = .invalidItemLength
-            parser.abortParsing()
-            return
-        }
-        result.items.append(MotionPhotoItem(mime: mime, semantic: semantic, length: length, padding: padding))
+        result.items.append(
+            MotionPhotoItem(mime: mime, semantic: semantic, length: length, padding: padding)
+        )
     }
 
     func parser(
@@ -283,8 +248,7 @@ private final class XMPDelegate: NSObject, XMLParserDelegate {
         qualifiedName qName: String?
     ) {
         let name = qName ?? elementName
-        if name == "Container:Directory" || name == "GContainer:Directory"
-            || elementName == "Container:Directory" || elementName == "GContainer:Directory" {
+        if name == "Container:Directory" || name == "GContainer:Directory" {
             directoryPrefix = nil
         }
     }
@@ -303,33 +267,33 @@ private final class XMPDelegate: NSObject, XMLParserDelegate {
         return nil
     }
 
-    private func parseDescription(_ attributes: [String: String]) throws {
+    private func parseDescription(_ attributes: [String: String]) {
         let motionNames = ["Camera:MotionPhoto", "GCamera:MotionPhoto"]
-        let microVideoNames = ["Camera:MicroVideo", "GCamera:MicroVideo"]
-        let versionNames = ["Camera:MotionPhotoVersion", "GCamera:MotionPhotoVersion"]
-        let timestampNames = [
-            "Camera:MotionPhotoPresentationTimestampUs",
-            "GCamera:MotionPhotoPresentationTimestampUs",
-            "Camera:MicroVideoPresentationTimestampUs",
-            "GCamera:MicroVideoPresentationTimestampUs",
-        ]
-        let offsetNames = ["Camera:MicroVideoOffset", "GCamera:MicroVideoOffset"]
-
+        let legacyNames = ["Camera:MicroVideo", "GCamera:MicroVideo"]
         if let flag = firstInt(attributes, names: motionNames) {
             result.motionPhotoEnabled = flag == 1
-        } else if let flag = firstInt(attributes, names: microVideoNames) {
+        } else if let flag = firstInt(attributes, names: legacyNames) {
             result.motionPhotoEnabled = flag == 1
         }
-
-        if let version = firstInt(attributes, names: versionNames) {
-            result.version = version
+        result.version = firstInt(
+            attributes,
+            names: ["Camera:MotionPhotoVersion", "GCamera:MotionPhotoVersion"]
+        )
+        if let value = firstInt64(
+            attributes,
+            names: [
+                "Camera:MotionPhotoPresentationTimestampUs",
+                "GCamera:MotionPhotoPresentationTimestampUs",
+                "Camera:MicroVideoPresentationTimestampUs",
+                "GCamera:MicroVideoPresentationTimestampUs",
+            ]
+        ) {
+            result.presentationTimestampUs = value == -1 ? nil : value
         }
-        if let timestamp = firstInt64(attributes, names: timestampNames) {
-            result.presentationTimestampUs = timestamp == -1 ? nil : timestamp
-        }
-        if let offset = firstInt64(attributes, names: offsetNames) {
-            result.legacyMicroVideoOffset = offset
-        }
+        result.legacyMicroVideoOffset = firstInt64(
+            attributes,
+            names: ["Camera:MicroVideoOffset", "GCamera:MicroVideoOffset"]
+        )
     }
 
     private func bounded(_ value: String?) -> String? {
@@ -337,28 +301,24 @@ private final class XMPDelegate: NSObject, XMLParserDelegate {
         return value
     }
 
-    private func parseNonnegativeInt64(_ value: String?, defaultValue: Int64) -> Int64? {
+    private func nonnegative(_ value: String?, defaultValue: Int64) -> Int64? {
         guard let value else { return defaultValue }
         guard value.utf8.count <= 32, let parsed = Int64(value), parsed >= 0 else { return nil }
         return parsed
     }
 
     private func firstInt(_ attributes: [String: String], names: [String]) -> Int? {
-        for name in names {
-            if let raw = attributes[name] {
-                guard raw.utf8.count <= 32 else { return nil }
-                return Int(raw)
-            }
+        for name in names where attributes[name] != nil {
+            guard let raw = attributes[name], raw.utf8.count <= 32 else { return nil }
+            return Int(raw)
         }
         return nil
     }
 
     private func firstInt64(_ attributes: [String: String], names: [String]) -> Int64? {
-        for name in names {
-            if let raw = attributes[name] {
-                guard raw.utf8.count <= 32 else { return nil }
-                return Int64(raw)
-            }
+        for name in names where attributes[name] != nil {
+            guard let raw = attributes[name], raw.utf8.count <= 32 else { return nil }
+            return Int64(raw)
         }
         return nil
     }

--- a/Sources/XDRemuxCore/MotionPhoto/Android/ISOBMFFMotionPhotoRangeResolver.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Android/ISOBMFFMotionPhotoRangeResolver.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+/// Resolves Android Motion Photo resources when the primary image is an ISO BMFF image (HEIC/HEIF).
+///
+/// Android Motion Photo V1 stores the video bytes inside a top-level `mpvd` box and declares a
+/// Primary-item padding of 8 bytes for the normal box header. Real Samsung files may append a
+/// vendor `sefd` box after `mpvd`; their XMP MotionPhoto Length then spans the `mpvd` payload plus
+/// the trailing vendor box. The semantic start still points exactly at the `mpvd` payload. We use
+/// that invariant to validate the directory, but extract only the `mpvd` payload as the video.
+public enum ISOBMFFMotionPhotoRangeResolver {
+    private static let maxTopLevelBoxes = 4_096
+
+    public static func resolve(
+        url: URL,
+        items: [MotionPhotoItem],
+        fileSize: Int64
+    ) throws -> (still: MotionPhotoByteRange, video: MotionPhotoByteRange) {
+        guard let primary = items.first,
+              let motion = items.last,
+              isHEIFMime(primary.mime),
+              motion.semantic.caseInsensitiveCompare("MotionPhoto") == .orderedSame else {
+            throw MotionPhotoParsingError.invalidDirectory
+        }
+        // Motion Photo V1 requires the 8-byte mpvd box header to be represented as Primary padding
+        // for HEIC/AVIF primary images. We currently route HEIC/HEIF only; AVIF remains a follow-up.
+        guard primary.padding == 8 else {
+            throw MotionPhotoParsingError.invalidItemLength
+        }
+
+        let boxes = try topLevelBoxes(in: url, fileSize: fileSize)
+        guard boxes.first?.type == "ftyp" else {
+            throw MotionPhotoParsingError.invalidVideoPayload
+        }
+        let mpvdBoxes = boxes.filter { $0.type == "mpvd" }
+        guard mpvdBoxes.count == 1, let mpvd = mpvdBoxes.first else {
+            throw MotionPhotoParsingError.invalidVideoPayload
+        }
+        let payloadStart = mpvd.payloadOffset
+        let payloadEnd = mpvd.endOffset
+        guard payloadStart < payloadEnd else {
+            throw MotionPhotoParsingError.invalidVideoPayload
+        }
+
+        let (declaredStart, overflow) = fileSize.subtractingReportingOverflow(motion.length)
+        guard !overflow, declaredStart >= 0, declaredStart == payloadStart else {
+            throw MotionPhotoParsingError.invalidByteRange
+        }
+        guard try ISOBaseMediaStreamScanner.isFTYPBoxStart(
+            in: url,
+            offset: payloadStart,
+            upperBound: payloadEnd
+        ) else {
+            throw MotionPhotoParsingError.invalidVideoPayload
+        }
+
+        // Removing mpvd (and any vendor boxes after it) leaves a standalone HEIF still container.
+        // The paired video is exactly the mpvd payload and never includes Samsung's trailing sefd.
+        return (
+            try MotionPhotoByteRange(lowerBound: 0, upperBound: mpvd.offset),
+            try MotionPhotoByteRange(lowerBound: payloadStart, upperBound: payloadEnd)
+        )
+    }
+
+    public static func isHEIFMime(_ mime: String) -> Bool {
+        let lower = mime.lowercased()
+        return lower == "image/heic" || lower == "image/heif"
+    }
+
+    private struct TopLevelBox {
+        let offset: Int64
+        let endOffset: Int64
+        let headerSize: Int64
+        let type: String
+
+        var payloadOffset: Int64 { offset + headerSize }
+    }
+
+    private static func topLevelBoxes(in url: URL, fileSize: Int64) throws -> [TopLevelBox] {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+
+        var boxes: [TopLevelBox] = []
+        var offset: Int64 = 0
+        while offset < fileSize {
+            guard boxes.count < maxTopLevelBoxes else {
+                throw MotionPhotoParsingError.invalidVideoPayload
+            }
+            let remaining = fileSize - offset
+            guard remaining >= 8 else {
+                throw MotionPhotoParsingError.invalidVideoPayload
+            }
+            try handle.seek(toOffset: UInt64(offset))
+            guard let header = try handle.read(upToCount: 8), header.count == 8 else {
+                throw MotionPhotoParsingError.invalidVideoPayload
+            }
+            let size32 = readUInt32BE(header, at: 0)
+            guard let type = String(data: header.subdata(in: 4..<8), encoding: .ascii),
+                  type.utf8.count == 4 else {
+                throw MotionPhotoParsingError.invalidVideoPayload
+            }
+
+            let headerSize: Int64
+            let boxSize: Int64
+            if size32 == 1 {
+                guard remaining >= 16,
+                      let extended = try handle.read(upToCount: 8), extended.count == 8 else {
+                    throw MotionPhotoParsingError.invalidVideoPayload
+                }
+                let size64 = readUInt64BE(extended, at: 0)
+                guard size64 <= UInt64(Int64.max) else {
+                    throw MotionPhotoParsingError.arithmeticOverflow
+                }
+                headerSize = 16
+                boxSize = Int64(size64)
+            } else if size32 == 0 {
+                headerSize = 8
+                boxSize = remaining
+            } else {
+                headerSize = 8
+                boxSize = Int64(size32)
+            }
+
+            guard boxSize >= headerSize else {
+                throw MotionPhotoParsingError.invalidVideoPayload
+            }
+            let (endOffset, overflow) = offset.addingReportingOverflow(boxSize)
+            guard !overflow, endOffset > offset, endOffset <= fileSize else {
+                throw MotionPhotoParsingError.arithmeticOverflow
+            }
+            boxes.append(
+                TopLevelBox(
+                    offset: offset,
+                    endOffset: endOffset,
+                    headerSize: headerSize,
+                    type: type
+                )
+            )
+            offset = endOffset
+        }
+        guard offset == fileSize else {
+            throw MotionPhotoParsingError.invalidVideoPayload
+        }
+        return boxes
+    }
+
+    private static func readUInt32BE(_ data: Data, at offset: Int) -> UInt32 {
+        data.withUnsafeBytes { raw in
+            let bytes = raw.bindMemory(to: UInt8.self)
+            return (UInt32(bytes[offset]) << 24)
+                | (UInt32(bytes[offset + 1]) << 16)
+                | (UInt32(bytes[offset + 2]) << 8)
+                | UInt32(bytes[offset + 3])
+        }
+    }
+
+    private static func readUInt64BE(_ data: Data, at offset: Int) -> UInt64 {
+        data.withUnsafeBytes { raw in
+            let bytes = raw.bindMemory(to: UInt8.self)
+            var value: UInt64 = 0
+            for index in 0..<8 {
+                value = (value << 8) | UInt64(bytes[offset + index])
+            }
+            return value
+        }
+    }
+}

--- a/Sources/XDRemuxCore/MotionPhoto/IO/ISOBaseMediaStreamScanner.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/IO/ISOBaseMediaStreamScanner.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+public enum ISOBaseMediaStreamScanner {
+    public static func ftypBoxOffsets(
+        in url: URL,
+        range: MotionPhotoByteRange,
+        bufferSize: Int = 1_048_576
+    ) throws -> [Int64] {
+        guard bufferSize >= 64 else { throw MotionPhotoParsingError.invalidByteRange }
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        try handle.seek(toOffset: UInt64(range.lowerBound))
+
+        let needle = Data("ftyp".utf8)
+        var remaining = range.length
+        var absoluteChunkStart = range.lowerBound
+        var carry = Data()
+        var offsets = Set<Int64>()
+
+        while remaining > 0 {
+            let count = Int(min(Int64(bufferSize), remaining))
+            guard let chunk = try handle.read(upToCount: count), !chunk.isEmpty else { break }
+            var window = carry
+            window.append(chunk)
+            let windowStart = absoluteChunkStart - Int64(carry.count)
+
+            var search = window.startIndex
+            while search < window.endIndex,
+                  let found = window.range(of: needle, in: search..<window.endIndex) {
+                let typeIndex = found.lowerBound
+                if typeIndex >= window.index(window.startIndex, offsetBy: 4) {
+                    let sizeStart = window.index(typeIndex, offsetBy: -4)
+                    let sizeBytes = window[sizeStart..<typeIndex]
+                    let size = sizeBytes.reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+                    let boxStart = windowStart + Int64(window.distance(from: window.startIndex, to: sizeStart))
+                    if boxStart >= range.lowerBound,
+                       boxStart < range.upperBound,
+                       (size == 1 || size >= 8) {
+                        offsets.insert(boxStart)
+                    }
+                }
+                search = found.upperBound
+            }
+
+            carry = window.suffix(min(16, window.count))
+            remaining -= Int64(chunk.count)
+            absoluteChunkStart += Int64(chunk.count)
+        }
+
+        return offsets.sorted()
+    }
+}

--- a/Sources/XDRemuxCore/MotionPhoto/IO/ISOBaseMediaStreamScanner.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/IO/ISOBaseMediaStreamScanner.swift
@@ -49,4 +49,27 @@ public enum ISOBaseMediaStreamScanner {
 
         return offsets.sorted()
     }
+
+    public static func isFTYPBoxStart(
+        in url: URL,
+        offset: Int64,
+        upperBound: Int64
+    ) throws -> Bool {
+        guard offset >= 0, upperBound - offset >= 12 else { return false }
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        try handle.seek(toOffset: UInt64(offset))
+        let header = try handle.read(upToCount: 16) ?? Data()
+        guard header.count >= 8,
+              String(bytes: header[4..<8], encoding: .ascii) == "ftyp" else {
+            return false
+        }
+        let size = header.prefix(4).reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+        if size == 1 {
+            guard header.count >= 16 else { return false }
+            let largeSize = header[8..<16].reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
+            return largeSize >= 16 && largeSize <= UInt64(upperBound - offset)
+        }
+        return size >= 8 && Int64(size) <= upperBound - offset
+    }
 }

--- a/Sources/XDRemuxCore/MotionPhoto/IO/ISOBaseMediaStreamScanner.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/IO/ISOBaseMediaStreamScanner.swift
@@ -15,7 +15,7 @@ public enum ISOBaseMediaStreamScanner {
         var remaining = range.length
         var absoluteChunkStart = range.lowerBound
         var carry = Data()
-        var offsets = Set<Int64>()
+        var roughOffsets = Set<Int64>()
 
         while remaining > 0 {
             let count = Int(min(Int64(bufferSize), remaining))
@@ -30,24 +30,29 @@ public enum ISOBaseMediaStreamScanner {
                 let typeIndex = found.lowerBound
                 if typeIndex >= window.index(window.startIndex, offsetBy: 4) {
                     let sizeStart = window.index(typeIndex, offsetBy: -4)
-                    let sizeBytes = window[sizeStart..<typeIndex]
-                    let size = sizeBytes.reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
                     let boxStart = windowStart + Int64(window.distance(from: window.startIndex, to: sizeStart))
-                    if boxStart >= range.lowerBound,
-                       boxStart < range.upperBound,
-                       (size == 1 || size >= 8) {
-                        offsets.insert(boxStart)
+                    if boxStart >= range.lowerBound, boxStart < range.upperBound {
+                        roughOffsets.insert(boxStart)
                     }
                 }
                 search = found.upperBound
             }
 
-            carry = window.suffix(min(16, window.count))
+            // Four bytes before a candidate plus the largest ftyp header fields we validate must be
+            // available across a chunk boundary. A 32-byte overlap is deliberately conservative.
+            carry = window.suffix(min(32, window.count))
             remaining -= Int64(chunk.count)
             absoluteChunkStart += Int64(chunk.count)
         }
 
-        return offsets.sorted()
+        var validated: [Int64] = []
+        validated.reserveCapacity(roughOffsets.count)
+        for offset in roughOffsets.sorted() {
+            if try isFTYPBoxStart(in: url, offset: offset, upperBound: range.upperBound) {
+                validated.append(offset)
+            }
+        }
+        return validated
     }
 
     public static func isFTYPBoxStart(
@@ -55,21 +60,41 @@ public enum ISOBaseMediaStreamScanner {
         offset: Int64,
         upperBound: Int64
     ) throws -> Bool {
-        guard offset >= 0, upperBound - offset >= 12 else { return false }
+        guard offset >= 0, upperBound > offset else { return false }
+        let available = upperBound - offset
+        // ISO BMFF FileTypeBox is at least: size(4) + type(4) + major_brand(4) + minor_version(4).
+        guard available >= 16 else { return false }
+
         let handle = try FileHandle(forReadingFrom: url)
         defer { try? handle.close() }
         try handle.seek(toOffset: UInt64(offset))
-        let header = try handle.read(upToCount: 16) ?? Data()
-        guard header.count >= 8,
+        let header = try handle.read(upToCount: 24) ?? Data()
+        guard header.count >= 16,
               String(bytes: header[4..<8], encoding: .ascii) == "ftyp" else {
             return false
         }
-        let size = header.prefix(4).reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
-        if size == 1 {
-            guard header.count >= 16 else { return false }
+
+        let size32 = header.prefix(4).reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+        let majorBrandRange: Range<Data.Index>
+        if size32 == 1 {
+            // Large-size box adds an 8-byte largesize field before major_brand.
+            guard available >= 24, header.count >= 24 else { return false }
             let largeSize = header[8..<16].reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
-            return largeSize >= 16 && largeSize <= UInt64(upperBound - offset)
+            guard largeSize >= 24, largeSize <= UInt64(available) else { return false }
+            majorBrandRange = 16..<20
+        } else {
+            guard size32 >= 16, Int64(size32) <= available else { return false }
+            majorBrandRange = 8..<12
         }
-        return size >= 8 && Int64(size) <= upperBound - offset
+
+        // A valid brand is a printable four-character code (spaces are valid, e.g. QuickTime's
+        // `qt  `). This removes the common false-positive case of the byte sequence "ftyp" inside
+        // arbitrary media payloads without assuming a fixed brand allow-list.
+        let majorBrand = header[majorBrandRange]
+        guard majorBrand.count == 4,
+              majorBrand.allSatisfy({ $0 >= 0x20 && $0 <= 0x7e }) else {
+            return false
+        }
+        return true
     }
 }

--- a/Sources/XDRemuxCore/MotionPhoto/IO/MotionPhotoPayloadExtractor.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/IO/MotionPhotoPayloadExtractor.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+public enum MotionPhotoPayloadExtractor {
+    public static func copy(
+        range: MotionPhotoByteRange,
+        from sourceURL: URL,
+        to destinationURL: URL,
+        maxBytes: Int64 = 1_073_741_824,
+        bufferSize: Int = 1_048_576
+    ) throws {
+        guard range.length <= maxBytes else { throw MotionPhotoParsingError.payloadTooLarge }
+        guard bufferSize > 0 else { throw MotionPhotoParsingError.invalidByteRange }
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: sourceURL.path)
+        guard let fileSizeNumber = attributes[.size] as? NSNumber else {
+            throw MotionPhotoParsingError.invalidByteRange
+        }
+        let fileSize = fileSizeNumber.int64Value
+        guard range.upperBound <= fileSize else { throw MotionPhotoParsingError.invalidByteRange }
+
+        let parent = destinationURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        if FileManager.default.fileExists(atPath: destinationURL.path) {
+            try FileManager.default.removeItem(at: destinationURL)
+        }
+        guard FileManager.default.createFile(atPath: destinationURL.path, contents: nil) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+
+        let source = try FileHandle(forReadingFrom: sourceURL)
+        let destination = try FileHandle(forWritingTo: destinationURL)
+        var succeeded = false
+        defer {
+            try? source.close()
+            try? destination.close()
+            if !succeeded { try? FileManager.default.removeItem(at: destinationURL) }
+        }
+
+        try source.seek(toOffset: UInt64(range.lowerBound))
+        var remaining = range.length
+        while remaining > 0 {
+            let chunkSize = Int(min(Int64(bufferSize), remaining))
+            guard let chunk = try source.read(upToCount: chunkSize), !chunk.isEmpty else {
+                throw MotionPhotoParsingError.invalidByteRange
+            }
+            try destination.write(contentsOf: chunk)
+            remaining -= Int64(chunk.count)
+        }
+        try destination.synchronize()
+        succeeded = true
+    }
+}

--- a/Sources/XDRemuxCore/MotionPhoto/MotionPhotoModels.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/MotionPhotoModels.swift
@@ -46,29 +46,50 @@ public struct MotionPhotoByteRange: Sendable, Equatable {
     public var length: Int64 { upperBound - lowerBound }
 }
 
-/// Vendor metadata is intentionally separated from the generic Android container description.
+/// OPPO vendor extension data. Generic Android parsing does not depend on any of these fields.
 public struct OppoMotionPhotoMetadata: Sendable, Equatable {
     public let coverFramePtsUs: Int64?
-    public let colorOSVersion: Int?
+    public let version: Int
+    public let matrixCount: Int
+    public let photoCropMatrix: [Double]?
+    public let photoEisMatrix: [Double]?
+    public let matrices: [String: [Double]]
+    public let videoWidth: Int?
+    public let videoHeight: Int?
+    public let originPhotoWidth: Int?
+    public let originPhotoHeight: Int?
+    public let eisCropFactor: [Double]?
+    public let photoCropFactor: Double?
     public let streamCount: Int
-    public let transformMatrix: [Double]?
-    public let referenceWidth: Double?
-    public let referenceHeight: Double?
 
     public init(
         coverFramePtsUs: Int64? = nil,
-        colorOSVersion: Int? = nil,
-        streamCount: Int = 1,
-        transformMatrix: [Double]? = nil,
-        referenceWidth: Double? = nil,
-        referenceHeight: Double? = nil
+        version: Int = 0,
+        matrixCount: Int = 0,
+        photoCropMatrix: [Double]? = nil,
+        photoEisMatrix: [Double]? = nil,
+        matrices: [String: [Double]] = [:],
+        videoWidth: Int? = nil,
+        videoHeight: Int? = nil,
+        originPhotoWidth: Int? = nil,
+        originPhotoHeight: Int? = nil,
+        eisCropFactor: [Double]? = nil,
+        photoCropFactor: Double? = nil,
+        streamCount: Int = 1
     ) {
         self.coverFramePtsUs = coverFramePtsUs
-        self.colorOSVersion = colorOSVersion
-        self.streamCount = streamCount
-        self.transformMatrix = transformMatrix
-        self.referenceWidth = referenceWidth
-        self.referenceHeight = referenceHeight
+        self.version = version
+        self.matrixCount = matrixCount
+        self.photoCropMatrix = photoCropMatrix
+        self.photoEisMatrix = photoEisMatrix
+        self.matrices = matrices
+        self.videoWidth = videoWidth
+        self.videoHeight = videoHeight
+        self.originPhotoWidth = originPhotoWidth
+        self.originPhotoHeight = originPhotoHeight
+        self.eisCropFactor = eisCropFactor
+        self.photoCropFactor = photoCropFactor
+        self.streamCount = max(1, streamCount)
     }
 }
 
@@ -133,6 +154,7 @@ public enum MotionPhotoParsingError: Error, LocalizedError, Equatable {
     case arithmeticOverflow
     case invalidByteRange
     case invalidVideoPayload
+    case payloadTooLarge
 
     public var errorDescription: String? {
         switch self {
@@ -159,6 +181,8 @@ public enum MotionPhotoParsingError: Error, LocalizedError, Equatable {
             return "Motion Photo contains an invalid byte range."
         case .invalidVideoPayload:
             return "Motion Photo video payload is not a valid ISO BMFF stream."
+        case .payloadTooLarge:
+            return "Motion Photo payload exceeds the configured extraction limit."
         }
     }
 }

--- a/Sources/XDRemuxCore/MotionPhoto/MotionPhotoModels.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/MotionPhotoModels.swift
@@ -3,6 +3,7 @@ import Foundation
 /// Source format used to derive a normalized Motion Photo asset.
 public enum MotionPhotoSourceKind: String, Sendable, Equatable {
     case androidMotionPhotoV1
+    case androidHeifMotionPhotoV1
     case legacyMicroVideoV1b
     case oppoLivePhoto
 }

--- a/Sources/XDRemuxCore/MotionPhoto/MotionPhotoModels.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/MotionPhotoModels.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+/// Source format used to derive a normalized Motion Photo asset.
+public enum MotionPhotoSourceKind: String, Sendable, Equatable {
+    case androidMotionPhotoV1
+    case legacyMicroVideoV1b
+    case oppoLivePhoto
+}
+
+/// Explains where the selected still-image presentation timestamp came from.
+public enum MotionPhotoPresentationSource: String, Sendable, Equatable {
+    case androidXMP
+    case legacyMicroVideoXMP
+    case oppoCoverFrame
+    case timelineFallback
+}
+
+/// One logical item declared by the Android Motion Photo container directory.
+public struct MotionPhotoItem: Sendable, Equatable {
+    public let mime: String
+    public let semantic: String
+    public let length: Int64
+    public let padding: Int64
+
+    public init(mime: String, semantic: String, length: Int64, padding: Int64) {
+        self.mime = mime
+        self.semantic = semantic
+        self.length = length
+        self.padding = padding
+    }
+}
+
+/// Checked byte range used instead of unchecked offset/length arithmetic.
+public struct MotionPhotoByteRange: Sendable, Equatable {
+    public let lowerBound: Int64
+    public let upperBound: Int64
+
+    public init(lowerBound: Int64, upperBound: Int64) throws {
+        guard lowerBound >= 0, upperBound >= lowerBound else {
+            throw MotionPhotoParsingError.invalidByteRange
+        }
+        self.lowerBound = lowerBound
+        self.upperBound = upperBound
+    }
+
+    public var length: Int64 { upperBound - lowerBound }
+}
+
+/// Vendor metadata is intentionally separated from the generic Android container description.
+public struct OppoMotionPhotoMetadata: Sendable, Equatable {
+    public let coverFramePtsUs: Int64?
+    public let colorOSVersion: Int?
+    public let streamCount: Int
+    public let transformMatrix: [Double]?
+    public let referenceWidth: Double?
+    public let referenceHeight: Double?
+
+    public init(
+        coverFramePtsUs: Int64? = nil,
+        colorOSVersion: Int? = nil,
+        streamCount: Int = 1,
+        transformMatrix: [Double]? = nil,
+        referenceWidth: Double? = nil,
+        referenceHeight: Double? = nil
+    ) {
+        self.coverFramePtsUs = coverFramePtsUs
+        self.colorOSVersion = colorOSVersion
+        self.streamCount = streamCount
+        self.transformMatrix = transformMatrix
+        self.referenceWidth = referenceWidth
+        self.referenceHeight = referenceHeight
+    }
+}
+
+/// Normalized representation consumed by the Apple Live Photo writer.
+public struct MotionPhotoAsset: Sendable, Equatable {
+    public let sourceURL: URL
+    public let sourceKind: MotionPhotoSourceKind
+    public let items: [MotionPhotoItem]
+    public let stillResourceRange: MotionPhotoByteRange
+    public let videoResourceRange: MotionPhotoByteRange
+    public let presentationTimestampUs: Int64?
+    public let presentationSource: MotionPhotoPresentationSource?
+    public let vendorMetadata: OppoMotionPhotoMetadata?
+
+    public init(
+        sourceURL: URL,
+        sourceKind: MotionPhotoSourceKind,
+        items: [MotionPhotoItem],
+        stillResourceRange: MotionPhotoByteRange,
+        videoResourceRange: MotionPhotoByteRange,
+        presentationTimestampUs: Int64?,
+        presentationSource: MotionPhotoPresentationSource?,
+        vendorMetadata: OppoMotionPhotoMetadata? = nil
+    ) {
+        self.sourceURL = sourceURL
+        self.sourceKind = sourceKind
+        self.items = items
+        self.stillResourceRange = stillResourceRange
+        self.videoResourceRange = videoResourceRange
+        self.presentationTimestampUs = presentationTimestampUs
+        self.presentationSource = presentationSource
+        self.vendorMetadata = vendorMetadata
+    }
+
+    public func enrichingWithOppoMetadata(
+        _ metadata: OppoMotionPhotoMetadata,
+        presentationTimestampUs: Int64? = nil,
+        presentationSource: MotionPhotoPresentationSource? = nil
+    ) -> MotionPhotoAsset {
+        MotionPhotoAsset(
+            sourceURL: sourceURL,
+            sourceKind: .oppoLivePhoto,
+            items: items,
+            stillResourceRange: stillResourceRange,
+            videoResourceRange: videoResourceRange,
+            presentationTimestampUs: presentationTimestampUs ?? self.presentationTimestampUs,
+            presentationSource: presentationSource ?? self.presentationSource,
+            vendorMetadata: metadata
+        )
+    }
+}
+
+public enum MotionPhotoParsingError: Error, LocalizedError, Equatable {
+    case fileTooSmall
+    case xmpTooLarge
+    case malformedXMP
+    case unsupportedVersion(Int?)
+    case invalidDirectory
+    case invalidPrimaryItem
+    case invalidMotionPhotoItem
+    case invalidItemLength
+    case arithmeticOverflow
+    case invalidByteRange
+    case invalidVideoPayload
+
+    public var errorDescription: String? {
+        switch self {
+        case .fileTooSmall:
+            return "Motion Photo input is too small."
+        case .xmpTooLarge:
+            return "Motion Photo XMP exceeds the supported safety limit."
+        case .malformedXMP:
+            return "Motion Photo XMP is malformed."
+        case let .unsupportedVersion(version):
+            if let version { return "Unsupported Motion Photo version: \(version)." }
+            return "Motion Photo version is missing."
+        case .invalidDirectory:
+            return "Motion Photo container directory is invalid."
+        case .invalidPrimaryItem:
+            return "Motion Photo must contain exactly one leading Primary item."
+        case .invalidMotionPhotoItem:
+            return "Motion Photo must contain exactly one trailing MP4/QuickTime MotionPhoto item."
+        case .invalidItemLength:
+            return "Motion Photo item length or padding is invalid."
+        case .arithmeticOverflow:
+            return "Motion Photo byte-range arithmetic overflowed."
+        case .invalidByteRange:
+            return "Motion Photo contains an invalid byte range."
+        case .invalidVideoPayload:
+            return "Motion Photo video payload is not a valid ISO BMFF stream."
+        }
+    }
+}

--- a/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoLpexParser.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoLpexParser.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+public enum OppoLpexParser {
+    private static let needles = [
+        Data("lpexLivePhotoExtension".utf8),
+        Data("LivePhotoExtension".utf8),
+        Data("pexLivePhotoExtension".utf8),
+    ]
+    private static let maxJSONBytes = 256 * 1024
+    private static let scanChunkBytes = 2 * 1024 * 1024
+    private static let overlapBytes = maxJSONBytes + 128
+
+    public static func parse(from url: URL) throws -> OppoMotionPhotoMetadata? {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        let fileSize = try handle.seekToEnd()
+        try handle.seek(toOffset: 0)
+
+        var absoluteOffset: UInt64 = 0
+        var carry = Data()
+        while absoluteOffset < fileSize {
+            let readCount = Int(min(UInt64(scanChunkBytes), fileSize - absoluteOffset))
+            let chunk = try handle.read(upToCount: readCount) ?? Data()
+            if chunk.isEmpty { break }
+
+            var window = Data()
+            window.reserveCapacity(carry.count + chunk.count)
+            window.append(carry)
+            window.append(chunk)
+            if let metadata = parseFirstObject(in: window) { return metadata }
+
+            if window.count > overlapBytes {
+                carry = window.suffix(overlapBytes)
+            } else {
+                carry = window
+            }
+            absoluteOffset += UInt64(chunk.count)
+        }
+        return nil
+    }
+
+    static func parseFirstObject(in data: Data) -> OppoMotionPhotoMetadata? {
+        for needle in needles {
+            var searchStart = data.startIndex
+            while searchStart < data.endIndex,
+                  let found = data.range(of: needle, in: searchStart..<data.endIndex) {
+                let after = found.upperBound
+                guard after < data.endIndex else { break }
+                guard let brace = data[after..<data.endIndex].firstIndex(of: UInt8(ascii: "{")) else {
+                    searchStart = found.upperBound
+                    continue
+                }
+                guard data.distance(from: after, to: brace) <= 32 else {
+                    searchStart = found.upperBound
+                    continue
+                }
+                if let objectRange = extractJSONObjectRange(in: data, startingAt: brace),
+                   objectRange.count <= maxJSONBytes,
+                   let parsed = parseJSON(data.subdata(in: objectRange)) {
+                    return parsed
+                }
+                searchStart = found.upperBound
+            }
+        }
+        return nil
+    }
+
+    static func extractJSONObjectRange(in data: Data, startingAt startIndex: Data.Index) -> Range<Data.Index>? {
+        guard startIndex < data.endIndex, data[startIndex] == UInt8(ascii: "{") else { return nil }
+        var depth = 0
+        var inString = false
+        var escaping = false
+        var index = startIndex
+        while index < data.endIndex {
+            let byte = data[index]
+            if inString {
+                if escaping {
+                    escaping = false
+                } else if byte == UInt8(ascii: "\\") {
+                    escaping = true
+                } else if byte == UInt8(ascii: "\"") {
+                    inString = false
+                }
+            } else if byte == UInt8(ascii: "\"") {
+                inString = true
+            } else if byte == UInt8(ascii: "{") {
+                depth += 1
+            } else if byte == UInt8(ascii: "}") {
+                depth -= 1
+                if depth == 0 { return startIndex..<data.index(after: index) }
+                if depth < 0 { return nil }
+            }
+            if data.distance(from: startIndex, to: index) > maxJSONBytes { return nil }
+            index = data.index(after: index)
+        }
+        return nil
+    }
+
+    static func parseJSON(_ data: Data) -> OppoMotionPhotoMetadata? {
+        guard data.count <= maxJSONBytes,
+              let object = try? JSONSerialization.jsonObject(with: data, options: []),
+              let dictionary = object as? [String: Any] else {
+            return nil
+        }
+
+        let coverFramePts = int64(dictionary["coverFramePts"])
+        let version = int(dictionary["version"]) ?? 0
+        let matrixCount = int(dictionary["matrixCount"]) ?? 0
+        let photoCropMatrix = matrix(dictionary["photoCropMatrix"])
+        let photoEisMatrix = matrix(dictionary["photoEisMatrix"])
+
+        var matrices: [String: [Double]] = [:]
+        if let raw = dictionary["matrices"] as? [String: Any], raw.count <= 4096 {
+            for (key, value) in raw where key.utf8.count <= 128 {
+                if let parsed = matrix(value) { matrices[key] = parsed }
+            }
+        }
+
+        let videoSize = size(dictionary["videoSize"])
+        let originPhotoSize = size(dictionary["originPhotoSize"])
+        let eisCropFactor = numberArray(dictionary["eisCropFactor"], maxCount: 8)
+        let photoCropFactor = double(dictionary["photoCropFactor"])
+
+        return OppoMotionPhotoMetadata(
+            coverFramePtsUs: coverFramePts,
+            version: version,
+            matrixCount: matrixCount,
+            photoCropMatrix: photoCropMatrix,
+            photoEisMatrix: photoEisMatrix,
+            matrices: matrices,
+            videoWidth: videoSize?.0,
+            videoHeight: videoSize?.1,
+            originPhotoWidth: originPhotoSize?.0,
+            originPhotoHeight: originPhotoSize?.1,
+            eisCropFactor: eisCropFactor,
+            photoCropFactor: photoCropFactor
+        )
+    }
+
+    private static func matrix(_ value: Any?) -> [Double]? {
+        guard let array = numberArray(value, maxCount: 9), array.count == 9,
+              array.allSatisfy(\.isFinite) else { return nil }
+        return array
+    }
+
+    private static func size(_ value: Any?) -> (Int, Int)? {
+        guard let array = value as? [Any], array.count >= 2,
+              let width = int(array[0]), let height = int(array[1]),
+              width > 0, height > 0 else { return nil }
+        return (width, height)
+    }
+
+    private static func numberArray(_ value: Any?, maxCount: Int) -> [Double]? {
+        guard let array = value as? [Any], array.count <= maxCount else { return nil }
+        let result = array.compactMap(double)
+        guard result.count == array.count, result.allSatisfy(\.isFinite) else { return nil }
+        return result
+    }
+
+    private static func int64(_ value: Any?) -> Int64? {
+        if let value = value as? NSNumber { return value.int64Value }
+        if let value = value as? Int64 { return value }
+        if let value = value as? Int { return Int64(value) }
+        if let value = value as? String, value.utf8.count <= 32 { return Int64(value) }
+        return nil
+    }
+
+    private static func int(_ value: Any?) -> Int? {
+        if let value = value as? NSNumber { return value.intValue }
+        if let value = value as? Int { return value }
+        if let value = value as? String, value.utf8.count <= 32 { return Int(value) }
+        return nil
+    }
+
+    private static func double(_ value: Any?) -> Double? {
+        if let value = value as? NSNumber { return value.doubleValue }
+        if let value = value as? Double { return value }
+        if let value = value as? Int { return Double(value) }
+        if let value = value as? String, value.utf8.count <= 64 { return Double(value) }
+        return nil
+    }
+}

--- a/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoFallbackParser.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoFallbackParser.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+/// Compatibility parser for OPPO JPEG Live Photos that predate or deviate from Android Motion
+/// Photo V1 directory semantics. It is deliberately gated on OPPO-specific metadata so a random
+/// JPEG with appended BMFF bytes is not accepted as an OPPO Live Photo.
+public enum OppoMotionPhotoFallbackParser {
+    private static let maxHeaderBytes = 4 * 1024 * 1024
+    private static let maxTailScanBytes: Int64 = 512 * 1024 * 1024
+
+    public static func parse(url: URL) throws -> MotionPhotoAsset? {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        guard let sizeNumber = attributes[.size] as? NSNumber else { return nil }
+        let fileSize = sizeNumber.int64Value
+        guard fileSize >= 16 else { return nil }
+
+        let header = try readPrefix(url: url, count: min(Int64(maxHeaderBytes), fileSize))
+        let xmp = extractXMPString(from: header)
+        let lpex = try OppoLpexParser.parse(from: url)
+        let hasOppoSignature = lpex != nil
+            || xmp?.contains("OpCamera:") == true
+            || xmp?.localizedCaseInsensitiveContains("oppo") == true
+            || xmp?.localizedCaseInsensitiveContains("oplus") == true
+        guard hasOppoSignature else { return nil }
+
+        let declaredLength = xmp.flatMap(extractVideoLength)
+        let presentation = xmp.flatMap(extractPresentationTimestamp)
+        let videoRange: MotionPhotoByteRange
+        var streamCount = 1
+
+        if let declaredLength, declaredLength > 0, declaredLength <= fileSize {
+            let start = fileSize - declaredLength
+            guard try ISOBaseMediaStreamScanner.isFTYPBoxStart(
+                in: url,
+                offset: start,
+                upperBound: fileSize
+            ) else {
+                return nil
+            }
+            videoRange = try MotionPhotoByteRange(lowerBound: start, upperBound: fileSize)
+            streamCount = max(
+                1,
+                try ISOBaseMediaStreamScanner.ftypBoxOffsets(in: url, range: videoRange).count
+            )
+        } else {
+            let tailStart = max(0, fileSize - maxTailScanBytes)
+            let scanRange = try MotionPhotoByteRange(lowerBound: tailStart, upperBound: fileSize)
+            let offsets = try ISOBaseMediaStreamScanner.ftypBoxOffsets(in: url, range: scanRange)
+            guard let last = offsets.last else { return nil }
+            if let lpex, lpex.version >= 1, offsets.count >= 2 {
+                videoRange = try MotionPhotoByteRange(
+                    lowerBound: offsets[offsets.count - 2],
+                    upperBound: fileSize
+                )
+                streamCount = 2
+            } else {
+                videoRange = try MotionPhotoByteRange(lowerBound: last, upperBound: fileSize)
+                streamCount = 1
+            }
+        }
+
+        let stillRange = try MotionPhotoByteRange(lowerBound: 0, upperBound: videoRange.lowerBound)
+        var metadata = lpex ?? OppoMotionPhotoMetadata()
+        metadata = OppoMotionPhotoMetadata(
+            coverFramePtsUs: metadata.coverFramePtsUs,
+            version: metadata.version,
+            matrixCount: metadata.matrixCount,
+            photoCropMatrix: metadata.photoCropMatrix,
+            photoEisMatrix: metadata.photoEisMatrix,
+            matrices: metadata.matrices,
+            videoWidth: metadata.videoWidth,
+            videoHeight: metadata.videoHeight,
+            originPhotoWidth: metadata.originPhotoWidth,
+            originPhotoHeight: metadata.originPhotoHeight,
+            eisCropFactor: metadata.eisCropFactor,
+            photoCropFactor: metadata.photoCropFactor,
+            streamCount: streamCount
+        )
+        let selectedPresentation = presentation ?? metadata.coverFramePtsUs
+        let selectedSource: MotionPhotoPresentationSource? = presentation != nil
+            ? .androidXMP
+            : (metadata.coverFramePtsUs != nil ? .oppoCoverFrame : nil)
+
+        return MotionPhotoAsset(
+            sourceURL: url,
+            sourceKind: .oppoLivePhoto,
+            items: [
+                MotionPhotoItem(mime: "image/jpeg", semantic: "Primary", length: 0, padding: 0),
+                MotionPhotoItem(
+                    mime: "video/mp4",
+                    semantic: "MotionPhoto",
+                    length: videoRange.length,
+                    padding: 0
+                ),
+            ],
+            stillResourceRange: stillRange,
+            videoResourceRange: videoRange,
+            presentationTimestampUs: selectedPresentation,
+            presentationSource: selectedSource,
+            vendorMetadata: metadata
+        )
+    }
+
+    private static func readPrefix(url: URL, count: Int64) throws -> Data {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        return try handle.read(upToCount: Int(count)) ?? Data()
+    }
+
+    private static func extractXMPString(from data: Data) -> String? {
+        guard let start = data.range(of: Data("<x:xmpmeta".utf8))?.lowerBound,
+              let endRange = data.range(
+                of: Data("</x:xmpmeta>".utf8),
+                in: start..<data.endIndex
+              ) else { return nil }
+        return String(data: data.subdata(in: start..<endRange.upperBound), encoding: .utf8)
+    }
+
+    private static func extractVideoLength(from xmp: String) -> Int64? {
+        var values: [Int64] = []
+        let patterns = [
+            #"Item:Length\s*=\s*["'](\d+)["']"#,
+            #"OpCamera:VideoLength\s*=\s*["'](\d+)["']"#,
+            #"GCamera:VideoLength\s*=\s*["'](\d+)["']"#,
+            #"<OpCamera:VideoLength>\s*(\d+)\s*</OpCamera:VideoLength>"#,
+            #"<GCamera:VideoLength>\s*(\d+)\s*</GCamera:VideoLength>"#,
+        ]
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+            let range = NSRange(xmp.startIndex..<xmp.endIndex, in: xmp)
+            for match in regex.matches(in: xmp, range: range) where match.numberOfRanges >= 2 {
+                if let swiftRange = Range(match.range(at: 1), in: xmp),
+                   let value = Int64(xmp[swiftRange]), value > 0 {
+                    values.append(value)
+                }
+            }
+        }
+        return values.max()
+    }
+
+    private static func extractPresentationTimestamp(from xmp: String) -> Int64? {
+        let names = [
+            "Camera:MotionPhotoPresentationTimestampUs",
+            "GCamera:MotionPhotoPresentationTimestampUs",
+            "MotionPhotoPresentationTimestampUs",
+            "GCamera:MicroVideoPresentationTimestampUs",
+        ]
+        for name in names {
+            let escaped = NSRegularExpression.escapedPattern(for: name)
+            let patterns = [
+                "\(escaped)\\s*=\\s*[\"'](-?\\d+)[\"']",
+                "<\(escaped)>\\s*(-?\\d+)\\s*</\(escaped)>",
+            ]
+            for pattern in patterns {
+                guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+                let range = NSRange(xmp.startIndex..<xmp.endIndex, in: xmp)
+                guard let match = regex.firstMatch(in: xmp, range: range),
+                      match.numberOfRanges >= 2,
+                      let swiftRange = Range(match.range(at: 1), in: xmp),
+                      let value = Int64(xmp[swiftRange]) else { continue }
+                return value == -1 ? nil : value
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoFallbackParser.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoFallbackParser.swift
@@ -82,10 +82,29 @@ public enum OppoMotionPhotoFallbackParser {
         declaredLength: Int64?,
         lpex: OppoMotionPhotoMetadata?
     ) throws -> (range: MotionPhotoByteRange, streamCount: Int)? {
-        // Prefer the vendor-declared length when it resolves exactly to a valid BMFF stream start.
-        // Old OPPO files in the wild can retain stale length metadata after edits, so a bad declared
-        // length is a reason to use the bounded ftyp recovery scan, not a reason to reject an
-        // otherwise OPPO-signed file immediately.
+        let tailStart = max(0, fileSize - maxTailScanBytes)
+        let scanRange = try MotionPhotoByteRange(lowerBound: tailStart, upperBound: fileSize)
+
+        // ColorOS 16 uses an LPEX v1+ layout with two concatenated BMFF streams. Its VideoLength
+        // can legitimately point only to the final (Stream 2) payload, so accepting that length
+        // before looking at topology would discard Stream 1. Resolve the two-stream layout first.
+        if let lpex, lpex.version >= 1 {
+            let offsets = try ISOBaseMediaStreamScanner.ftypBoxOffsets(in: url, range: scanRange)
+            if offsets.count >= 2 {
+                return (
+                    try MotionPhotoByteRange(
+                        lowerBound: offsets[offsets.count - 2],
+                        upperBound: fileSize
+                    ),
+                    2
+                )
+            }
+        }
+
+        // Prefer the vendor-declared length for single-stream files when it resolves exactly to a
+        // valid BMFF stream start. Old OPPO files can retain stale length metadata after edits, so
+        // a bad declared length falls through to the bounded recovery scan instead of rejecting the
+        // otherwise OPPO-signed input.
         if let declaredLength, declaredLength > 0, declaredLength <= fileSize {
             let start = fileSize - declaredLength
             if try ISOBaseMediaStreamScanner.isFTYPBoxStart(
@@ -102,19 +121,8 @@ public enum OppoMotionPhotoFallbackParser {
             }
         }
 
-        let tailStart = max(0, fileSize - maxTailScanBytes)
-        let scanRange = try MotionPhotoByteRange(lowerBound: tailStart, upperBound: fileSize)
         let offsets = try ISOBaseMediaStreamScanner.ftypBoxOffsets(in: url, range: scanRange)
         guard let last = offsets.last else { return nil }
-        if let lpex, lpex.version >= 1, offsets.count >= 2 {
-            return (
-                try MotionPhotoByteRange(
-                    lowerBound: offsets[offsets.count - 2],
-                    upperBound: fileSize
-                ),
-                2
-            )
-        }
         return (
             try MotionPhotoByteRange(lowerBound: last, upperBound: fileSize),
             1

--- a/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoFallbackParser.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoFallbackParser.swift
@@ -24,55 +24,31 @@ public enum OppoMotionPhotoFallbackParser {
 
         let declaredLength = xmp.flatMap(extractVideoLength)
         let presentation = xmp.flatMap(extractPresentationTimestamp)
-        let videoRange: MotionPhotoByteRange
-        var streamCount = 1
-
-        if let declaredLength, declaredLength > 0, declaredLength <= fileSize {
-            let start = fileSize - declaredLength
-            guard try ISOBaseMediaStreamScanner.isFTYPBoxStart(
-                in: url,
-                offset: start,
-                upperBound: fileSize
-            ) else {
-                return nil
-            }
-            videoRange = try MotionPhotoByteRange(lowerBound: start, upperBound: fileSize)
-            streamCount = max(
-                1,
-                try ISOBaseMediaStreamScanner.ftypBoxOffsets(in: url, range: videoRange).count
-            )
-        } else {
-            let tailStart = max(0, fileSize - maxTailScanBytes)
-            let scanRange = try MotionPhotoByteRange(lowerBound: tailStart, upperBound: fileSize)
-            let offsets = try ISOBaseMediaStreamScanner.ftypBoxOffsets(in: url, range: scanRange)
-            guard let last = offsets.last else { return nil }
-            if let lpex, lpex.version >= 1, offsets.count >= 2 {
-                videoRange = try MotionPhotoByteRange(
-                    lowerBound: offsets[offsets.count - 2],
-                    upperBound: fileSize
-                )
-                streamCount = 2
-            } else {
-                videoRange = try MotionPhotoByteRange(lowerBound: last, upperBound: fileSize)
-                streamCount = 1
-            }
-        }
+        let resolved = try resolveVideoRange(
+            url: url,
+            fileSize: fileSize,
+            declaredLength: declaredLength,
+            lpex: lpex
+        )
+        guard let resolved else { return nil }
+        let videoRange = resolved.range
+        let streamCount = resolved.streamCount
 
         let stillRange = try MotionPhotoByteRange(lowerBound: 0, upperBound: videoRange.lowerBound)
-        var metadata = lpex ?? OppoMotionPhotoMetadata()
-        metadata = OppoMotionPhotoMetadata(
-            coverFramePtsUs: metadata.coverFramePtsUs,
-            version: metadata.version,
-            matrixCount: metadata.matrixCount,
-            photoCropMatrix: metadata.photoCropMatrix,
-            photoEisMatrix: metadata.photoEisMatrix,
-            matrices: metadata.matrices,
-            videoWidth: metadata.videoWidth,
-            videoHeight: metadata.videoHeight,
-            originPhotoWidth: metadata.originPhotoWidth,
-            originPhotoHeight: metadata.originPhotoHeight,
-            eisCropFactor: metadata.eisCropFactor,
-            photoCropFactor: metadata.photoCropFactor,
+        let rawMetadata = lpex ?? OppoMotionPhotoMetadata()
+        let metadata = OppoMotionPhotoMetadata(
+            coverFramePtsUs: rawMetadata.coverFramePtsUs,
+            version: rawMetadata.version,
+            matrixCount: rawMetadata.matrixCount,
+            photoCropMatrix: rawMetadata.photoCropMatrix,
+            photoEisMatrix: rawMetadata.photoEisMatrix,
+            matrices: rawMetadata.matrices,
+            videoWidth: rawMetadata.videoWidth,
+            videoHeight: rawMetadata.videoHeight,
+            originPhotoWidth: rawMetadata.originPhotoWidth,
+            originPhotoHeight: rawMetadata.originPhotoHeight,
+            eisCropFactor: rawMetadata.eisCropFactor,
+            photoCropFactor: rawMetadata.photoCropFactor,
             streamCount: streamCount
         )
         let selectedPresentation = presentation ?? metadata.coverFramePtsUs
@@ -100,6 +76,51 @@ public enum OppoMotionPhotoFallbackParser {
         )
     }
 
+    private static func resolveVideoRange(
+        url: URL,
+        fileSize: Int64,
+        declaredLength: Int64?,
+        lpex: OppoMotionPhotoMetadata?
+    ) throws -> (range: MotionPhotoByteRange, streamCount: Int)? {
+        // Prefer the vendor-declared length when it resolves exactly to a valid BMFF stream start.
+        // Old OPPO files in the wild can retain stale length metadata after edits, so a bad declared
+        // length is a reason to use the bounded ftyp recovery scan, not a reason to reject an
+        // otherwise OPPO-signed file immediately.
+        if let declaredLength, declaredLength > 0, declaredLength <= fileSize {
+            let start = fileSize - declaredLength
+            if try ISOBaseMediaStreamScanner.isFTYPBoxStart(
+                in: url,
+                offset: start,
+                upperBound: fileSize
+            ) {
+                let range = try MotionPhotoByteRange(lowerBound: start, upperBound: fileSize)
+                let count = max(
+                    1,
+                    try ISOBaseMediaStreamScanner.ftypBoxOffsets(in: url, range: range).count
+                )
+                return (range, count)
+            }
+        }
+
+        let tailStart = max(0, fileSize - maxTailScanBytes)
+        let scanRange = try MotionPhotoByteRange(lowerBound: tailStart, upperBound: fileSize)
+        let offsets = try ISOBaseMediaStreamScanner.ftypBoxOffsets(in: url, range: scanRange)
+        guard let last = offsets.last else { return nil }
+        if let lpex, lpex.version >= 1, offsets.count >= 2 {
+            return (
+                try MotionPhotoByteRange(
+                    lowerBound: offsets[offsets.count - 2],
+                    upperBound: fileSize
+                ),
+                2
+            )
+        }
+        return (
+            try MotionPhotoByteRange(lowerBound: last, upperBound: fileSize),
+            1
+        )
+    }
+
     private static func readPrefix(url: URL, count: Int64) throws -> Data {
         let handle = try FileHandle(forReadingFrom: url)
         defer { try? handle.close() }
@@ -107,58 +128,89 @@ public enum OppoMotionPhotoFallbackParser {
     }
 
     private static func extractXMPString(from data: Data) -> String? {
-        guard let start = data.range(of: Data("<x:xmpmeta".utf8))?.lowerBound,
-              let endRange = data.range(
-                of: Data("</x:xmpmeta>".utf8),
-                in: start..<data.endIndex
-              ) else { return nil }
-        return String(data: data.subdata(in: start..<endRange.upperBound), encoding: .utf8)
+        let openingCandidates = [Data("<x:xmpmeta".utf8), Data("<xmpmeta".utf8)]
+        let closingCandidates = [Data("</x:xmpmeta>".utf8), Data("</xmpmeta>".utf8)]
+        guard let start = openingCandidates.compactMap({ data.range(of: $0)?.lowerBound }).min() else {
+            return nil
+        }
+        var end: Data.Index?
+        for closing in closingCandidates {
+            if let range = data.range(of: closing, in: start..<data.endIndex) {
+                end = end.map { min($0, range.upperBound) } ?? range.upperBound
+            }
+        }
+        guard let end else { return nil }
+        return String(data: data.subdata(in: start..<end), encoding: .utf8)
     }
 
     private static func extractVideoLength(from xmp: String) -> Int64? {
-        var values: [Int64] = []
-        let patterns = [
-            #"Item:Length\s*=\s*["'](\d+)["']"#,
-            #"OpCamera:VideoLength\s*=\s*["'](\d+)["']"#,
-            #"GCamera:VideoLength\s*=\s*["'](\d+)["']"#,
-            #"<OpCamera:VideoLength>\s*(\d+)\s*</OpCamera:VideoLength>"#,
-            #"<GCamera:VideoLength>\s*(\d+)\s*</GCamera:VideoLength>"#,
+        // Preserve LivePhotoToolbox's successful heuristic for non-standard OPPO files: choose the
+        // largest plausible Item:Length first, then fall back to explicit VideoLength tags. This is
+        // only used after standards-compliant Container:Directory parsing has already failed.
+        var genericLengths: [Int64] = []
+        let genericPatterns = [
+            #"Item:Length\s*=\s*["']?(\d+)"#,
+            #"Item:Length\s*>(\d+)"#,
+            #"Length\s*=\s*["']?(\d+)"#,
         ]
-        for pattern in patterns {
-            guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
-            let range = NSRange(xmp.startIndex..<xmp.endIndex, in: xmp)
-            for match in regex.matches(in: xmp, range: range) where match.numberOfRanges >= 2 {
-                if let swiftRange = Range(match.range(at: 1), in: xmp),
-                   let value = Int64(xmp[swiftRange]), value > 0 {
-                    values.append(value)
-                }
+        for pattern in genericPatterns {
+            genericLengths.append(contentsOf: integerMatches(pattern: pattern, in: xmp))
+        }
+        if let maxLength = genericLengths.max(), maxLength > 100_000 {
+            return maxLength
+        }
+
+        let tags = ["OpCamera:VideoLength", "GCamera:VideoLength", "VideoLength"]
+        for tag in tags {
+            if let value = extractXMPValue(from: xmp, tagName: tag),
+               let length = Int64(value), length > 100_000 {
+                return length
             }
         }
-        return values.max()
+        return nil
     }
 
     private static func extractPresentationTimestamp(from xmp: String) -> Int64? {
-        let names = [
-            "Camera:MotionPhotoPresentationTimestampUs",
+        let tags = [
             "GCamera:MotionPhotoPresentationTimestampUs",
             "MotionPhotoPresentationTimestampUs",
             "GCamera:MicroVideoPresentationTimestampUs",
         ]
-        for name in names {
-            let escaped = NSRegularExpression.escapedPattern(for: name)
-            let patterns = [
-                "\(escaped)\\s*=\\s*[\"'](-?\\d+)[\"']",
-                "<\(escaped)>\\s*(-?\\d+)\\s*</\(escaped)>",
-            ]
-            for pattern in patterns {
-                guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
-                let range = NSRange(xmp.startIndex..<xmp.endIndex, in: xmp)
-                guard let match = regex.firstMatch(in: xmp, range: range),
-                      match.numberOfRanges >= 2,
-                      let swiftRange = Range(match.range(at: 1), in: xmp),
-                      let value = Int64(xmp[swiftRange]) else { continue }
-                return value == -1 ? nil : value
+        for tag in tags {
+            if let value = extractXMPValue(from: xmp, tagName: tag),
+               let timestamp = Int64(value) {
+                return timestamp == -1 ? nil : timestamp
             }
+        }
+        return nil
+    }
+
+    private static func integerMatches(pattern: String, in string: String) -> [Int64] {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(string.startIndex..<string.endIndex, in: string)
+        return regex.matches(in: string, range: range).compactMap { match in
+            guard match.numberOfRanges >= 2,
+                  let valueRange = Range(match.range(at: 1), in: string),
+                  let value = Int64(string[valueRange]), value > 0 else {
+                return nil
+            }
+            return value
+        }
+    }
+
+    private static func extractXMPValue(from xmp: String, tagName: String) -> String? {
+        let escaped = NSRegularExpression.escapedPattern(for: tagName)
+        let patterns = [
+            "<\(escaped)>([^<]+)</\(escaped)>",
+            "\(escaped)=[\"']([^\"']+)[\"']",
+        ]
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+            let range = NSRange(xmp.startIndex..<xmp.endIndex, in: xmp)
+            guard let match = regex.firstMatch(in: xmp, range: range),
+                  match.numberOfRanges >= 2,
+                  let valueRange = Range(match.range(at: 1), in: xmp) else { continue }
+            return String(xmp[valueRange]).trimmingCharacters(in: .whitespacesAndNewlines)
         }
         return nil
     }

--- a/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoParser.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoParser.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+public enum OppoMotionPhotoParser {
+    public static func parse(url: URL) throws -> MotionPhotoAsset? {
+        guard let base = try AndroidMotionPhotoParser.parse(url: url) else { return nil }
+        return try enrichIfPresent(base)
+    }
+
+    public static func enrichIfPresent(_ asset: MotionPhotoAsset) throws -> MotionPhotoAsset {
+        guard let metadata = try OppoLpexParser.parse(from: asset.sourceURL) else { return asset }
+        let offsets = try ISOBaseMediaStreamScanner.ftypBoxOffsets(
+            in: asset.sourceURL,
+            range: asset.videoResourceRange
+        )
+        let enriched = OppoMotionPhotoMetadata(
+            coverFramePtsUs: metadata.coverFramePtsUs,
+            version: metadata.version,
+            matrixCount: metadata.matrixCount,
+            photoCropMatrix: metadata.photoCropMatrix,
+            photoEisMatrix: metadata.photoEisMatrix,
+            matrices: metadata.matrices,
+            videoWidth: metadata.videoWidth,
+            videoHeight: metadata.videoHeight,
+            originPhotoWidth: metadata.originPhotoWidth,
+            originPhotoHeight: metadata.originPhotoHeight,
+            eisCropFactor: metadata.eisCropFactor,
+            photoCropFactor: metadata.photoCropFactor,
+            streamCount: max(1, offsets.count)
+        )
+
+        if asset.presentationTimestampUs == nil, let cover = enriched.coverFramePtsUs {
+            return asset.enrichingWithOppoMetadata(
+                enriched,
+                presentationTimestampUs: cover,
+                presentationSource: .oppoCoverFrame
+            )
+        }
+        return asset.enrichingWithOppoMetadata(enriched)
+    }
+}

--- a/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoParser.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoParser.swift
@@ -2,8 +2,17 @@ import Foundation
 
 public enum OppoMotionPhotoParser {
     public static func parse(url: URL) throws -> MotionPhotoAsset? {
-        guard let base = try AndroidMotionPhotoParser.parse(url: url) else { return nil }
-        return try enrichIfPresent(base)
+        do {
+            if let base = try AndroidMotionPhotoParser.parse(url: url) {
+                return try enrichIfPresent(base)
+            }
+        } catch {
+            if let fallback = try OppoMotionPhotoFallbackParser.parse(url: url) {
+                return fallback
+            }
+            throw error
+        }
+        return try OppoMotionPhotoFallbackParser.parse(url: url)
     }
 
     public static func enrichIfPresent(_ asset: MotionPhotoAsset) throws -> MotionPhotoAsset {
@@ -28,6 +37,8 @@ public enum OppoMotionPhotoParser {
             streamCount: max(1, offsets.count)
         )
 
+        // LivePhotoToolbox selected the XMP presentation timestamp first, then coverFramePts from
+        // LPEX. Keep that behavior while retaining both values for diagnostics.
         if asset.presentationTimestampUs == nil, let cover = enriched.coverFramePtsUs {
             return asset.enrichingWithOppoMetadata(
                 enriched,

--- a/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoParser.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoParser.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 public enum OppoMotionPhotoParser {
+    private static let maxVendorTailScanBytes: Int64 = 512 * 1024 * 1024
+
     public static func parse(url: URL) throws -> MotionPhotoAsset? {
         do {
             if let base = try AndroidMotionPhotoParser.parse(url: url) {
@@ -17,10 +19,39 @@ public enum OppoMotionPhotoParser {
 
     public static func enrichIfPresent(_ asset: MotionPhotoAsset) throws -> MotionPhotoAsset {
         guard let metadata = try OppoLpexParser.parse(from: asset.sourceURL) else { return asset }
-        let offsets = try ISOBaseMediaStreamScanner.ftypBoxOffsets(
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: asset.sourceURL.path)
+        guard let sizeNumber = attributes[.size] as? NSNumber else { return asset }
+        let fileSize = sizeNumber.int64Value
+        let scanStart = max(0, fileSize - maxVendorTailScanBytes)
+        let scanRange = try MotionPhotoByteRange(lowerBound: scanStart, upperBound: fileSize)
+        let allTailOffsets = try ISOBaseMediaStreamScanner.ftypBoxOffsets(
             in: asset.sourceURL,
-            range: asset.videoResourceRange
+            range: scanRange
         )
+
+        // ColorOS 16 OPPO Live Photos can carry two concatenated BMFF streams while the Android
+        // directory / VideoLength metadata describes only the final stream. In that case treating
+        // the directory's videoStart as authoritative incorrectly leaves Stream 1 attached to the
+        // still image and later chooses Stream 2. LPEX version >= 1 is the vendor signal used by the
+        // original toolbox; the last two validated ftyp starts therefore define Stream 1 + Stream 2.
+        let correctedStillRange: MotionPhotoByteRange
+        let correctedVideoRange: MotionPhotoByteRange
+        let streamCount: Int
+        if metadata.version >= 1, allTailOffsets.count >= 2 {
+            let stream1Start = allTailOffsets[allTailOffsets.count - 2]
+            correctedStillRange = try MotionPhotoByteRange(lowerBound: 0, upperBound: stream1Start)
+            correctedVideoRange = try MotionPhotoByteRange(lowerBound: stream1Start, upperBound: fileSize)
+            streamCount = 2
+        } else {
+            correctedStillRange = asset.stillResourceRange
+            correctedVideoRange = asset.videoResourceRange
+            let offsetsInsideDeclaredRange = allTailOffsets.filter {
+                $0 >= asset.videoResourceRange.lowerBound && $0 < asset.videoResourceRange.upperBound
+            }
+            streamCount = max(1, offsetsInsideDeclaredRange.count)
+        }
+
         let enriched = OppoMotionPhotoMetadata(
             coverFramePtsUs: metadata.coverFramePtsUs,
             version: metadata.version,
@@ -34,18 +65,23 @@ public enum OppoMotionPhotoParser {
             originPhotoHeight: metadata.originPhotoHeight,
             eisCropFactor: metadata.eisCropFactor,
             photoCropFactor: metadata.photoCropFactor,
-            streamCount: max(1, offsets.count)
+            streamCount: streamCount
         )
 
-        // LivePhotoToolbox selected the XMP presentation timestamp first, then coverFramePts from
-        // LPEX. Keep that behavior while retaining both values for diagnostics.
-        if asset.presentationTimestampUs == nil, let cover = enriched.coverFramePtsUs {
-            return asset.enrichingWithOppoMetadata(
-                enriched,
-                presentationTimestampUs: cover,
-                presentationSource: .oppoCoverFrame
-            )
-        }
-        return asset.enrichingWithOppoMetadata(enriched)
+        let selectedPresentation = asset.presentationTimestampUs ?? enriched.coverFramePtsUs
+        let selectedSource: MotionPhotoPresentationSource? = asset.presentationTimestampUs != nil
+            ? asset.presentationSource
+            : (enriched.coverFramePtsUs != nil ? .oppoCoverFrame : nil)
+
+        return MotionPhotoAsset(
+            sourceURL: asset.sourceURL,
+            sourceKind: .oppoLivePhoto,
+            items: asset.items,
+            stillResourceRange: correctedStillRange,
+            videoResourceRange: correctedVideoRange,
+            presentationTimestampUs: selectedPresentation,
+            presentationSource: selectedSource,
+            vendorMetadata: enriched
+        )
     }
 }

--- a/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoStreamResolver.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoStreamResolver.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public enum OppoMotionPhotoStreamResolver {
+    /// Returns the primary OPPO Live Photo video stream. ColorOS 16 commonly stores two
+    /// concatenated BMFF streams; the penultimate ftyp starts Stream 1 and the last starts Stream 2.
+    /// This preserves the behavior of LivePhotoToolbox without making generic Android parsing
+    /// depend on OPPO's dual-stream convention.
+    public static func primaryVideoRange(for asset: MotionPhotoAsset) throws -> MotionPhotoByteRange {
+        guard asset.sourceKind == .oppoLivePhoto,
+              (asset.vendorMetadata?.streamCount ?? 1) >= 2 else {
+            return asset.videoResourceRange
+        }
+        let offsets = try ISOBaseMediaStreamScanner.ftypBoxOffsets(
+            in: asset.sourceURL,
+            range: asset.videoResourceRange
+        )
+        guard offsets.count >= 2 else { return asset.videoResourceRange }
+        let stream1Start = offsets[offsets.count - 2]
+        let stream2Start = offsets[offsets.count - 1]
+        guard stream1Start >= asset.videoResourceRange.lowerBound,
+              stream2Start > stream1Start,
+              stream2Start <= asset.videoResourceRange.upperBound else {
+            throw MotionPhotoParsingError.invalidVideoPayload
+        }
+        return try MotionPhotoByteRange(lowerBound: stream1Start, upperBound: stream2Start)
+    }
+}

--- a/Tests/XDRemuxAppleFeaturesTests/LivePhotoAudioPassthroughTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/LivePhotoAudioPassthroughTests.swift
@@ -24,8 +24,10 @@ final class LivePhotoAudioPassthroughTests: XCTestCase {
         try await createH264AACVideo(at: sourceMP4)
 
         let sourceAsset = AVURLAsset(url: sourceMP4)
-        XCTAssertEqual(try await sourceAsset.loadTracks(withMediaType: .video).count, 1)
-        XCTAssertEqual(try await sourceAsset.loadTracks(withMediaType: .audio).count, 1)
+        let sourceVideoTracks = try await sourceAsset.loadTracks(withMediaType: .video)
+        let sourceAudioTracks = try await sourceAsset.loadTracks(withMediaType: .audio)
+        XCTAssertEqual(sourceVideoTracks.count, 1)
+        XCTAssertEqual(sourceAudioTracks.count, 1)
 
         let identifier = UUID().uuidString
         let stillTime = CMTime(value: 3, timescale: 30)

--- a/Tests/XDRemuxAppleFeaturesTests/LivePhotoAudioPassthroughTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/LivePhotoAudioPassthroughTests.swift
@@ -1,0 +1,274 @@
+import Foundation
+import AudioToolbox
+@preconcurrency import AVFoundation
+import CoreGraphics
+import CoreMedia
+import CoreVideo
+import ImageIO
+import UniformTypeIdentifiers
+import XCTest
+@testable import XDRemuxAppleFeatures
+
+final class LivePhotoAudioPassthroughTests: XCTestCase {
+    func testAACAudioTrackSurvivesLivePhotoRemux() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-livephoto-audio-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let sourceJPEG = directory.appendingPathComponent("source.jpg")
+        let sourceMP4 = directory.appendingPathComponent("source-with-audio.mp4")
+        let outputHEIC = directory.appendingPathComponent("output.heic")
+        let outputMOV = directory.appendingPathComponent("output.mov")
+        try createJPEG(at: sourceJPEG)
+        try await createH264AACVideo(at: sourceMP4)
+
+        let sourceAsset = AVURLAsset(url: sourceMP4)
+        XCTAssertEqual(try await sourceAsset.loadTracks(withMediaType: .video).count, 1)
+        XCTAssertEqual(try await sourceAsset.loadTracks(withMediaType: .audio).count, 1)
+
+        let identifier = UUID().uuidString
+        let stillTime = CMTime(value: 3, timescale: 30)
+        try AppleLivePhotoStillWriter.write(
+            stillInputURL: sourceJPEG,
+            outputURL: outputHEIC,
+            assetIdentifier: identifier
+        )
+        try await AppleLivePhotoVideoWriter.write(
+            videoInputURL: sourceMP4,
+            outputURL: outputMOV,
+            assetIdentifier: identifier,
+            stillImageTime: stillTime
+        )
+
+        let report = try await AppleLivePhotoValidator.validate(
+            imageURL: outputHEIC,
+            videoURL: outputMOV,
+            expectedAssetIdentifier: identifier,
+            expectedStillImageTime: stillTime,
+            sourceStillURL: sourceJPEG,
+            sourceVideoURL: sourceMP4,
+            sourceHadAudio: true,
+            sourceHadGainMap: false,
+            requirePhotoKitLoad: true
+        )
+        XCTAssertTrue(report.hasAudio)
+    }
+
+    private func createJPEG(at url: URL) throws {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: nil,
+            width: 64,
+            height: 48,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ),
+        let destination = CGImageDestinationCreateWithURL(
+            url as CFURL,
+            UTType.jpeg.identifier as CFString,
+            1,
+            nil
+        ) else {
+            XCTFail("could not create JPEG fixture")
+            return
+        }
+        context.setFillColor(CGColor(red: 0.4, green: 0.3, blue: 0.2, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: 64, height: 48))
+        guard let image = context.makeImage() else {
+            XCTFail("could not create JPEG fixture image")
+            return
+        }
+        CGImageDestinationAddImage(destination, image, nil)
+        XCTAssertTrue(CGImageDestinationFinalize(destination))
+    }
+
+    private func createH264AACVideo(at url: URL) async throws {
+        let width = 64
+        let height = 48
+        let frameCount = 10
+        let audioSampleRate = 44_100
+        let audioFramesPerBuffer = 1_024
+        let audioBufferCount = 15
+
+        let writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
+        let videoInput = AVAssetWriterInput(
+            mediaType: .video,
+            outputSettings: [
+                AVVideoCodecKey: AVVideoCodecType.h264,
+                AVVideoWidthKey: width,
+                AVVideoHeightKey: height,
+            ]
+        )
+        let videoAdaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: videoInput,
+            sourcePixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA),
+                kCVPixelBufferWidthKey as String: width,
+                kCVPixelBufferHeightKey as String: height,
+            ]
+        )
+        let audioInput = AVAssetWriterInput(
+            mediaType: .audio,
+            outputSettings: [
+                AVFormatIDKey: kAudioFormatMPEG4AAC,
+                AVSampleRateKey: audioSampleRate,
+                AVNumberOfChannelsKey: 1,
+                AVEncoderBitRateKey: 64_000,
+            ]
+        )
+        guard writer.canAdd(videoInput), writer.canAdd(audioInput) else {
+            throw XCTSkip("H.264/AAC encoder inputs are unavailable on this macOS runner")
+        }
+        writer.add(videoInput)
+        writer.add(audioInput)
+        guard writer.startWriting() else {
+            throw writer.error ?? AppleLivePhotoError.videoWriteFailed("test H.264/AAC writer did not start")
+        }
+        writer.startSession(atSourceTime: .zero)
+
+        for index in 0..<frameCount {
+            while !videoInput.isReadyForMoreMediaData {
+                try await Task.sleep(nanoseconds: 1_000_000)
+            }
+            var pixelBuffer: CVPixelBuffer?
+            let status = CVPixelBufferCreate(
+                kCFAllocatorDefault,
+                width,
+                height,
+                kCVPixelFormatType_32BGRA,
+                [kCVPixelBufferIOSurfacePropertiesKey as String: [:]] as CFDictionary,
+                &pixelBuffer
+            )
+            XCTAssertEqual(status, kCVReturnSuccess)
+            guard let pixelBuffer else {
+                XCTFail("could not allocate source video pixel buffer")
+                return
+            }
+            CVPixelBufferLockBaseAddress(pixelBuffer, [])
+            if let base = CVPixelBufferGetBaseAddress(pixelBuffer) {
+                memset(base, Int32(64 + index), CVPixelBufferGetBytesPerRow(pixelBuffer) * height)
+            }
+            CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
+            XCTAssertTrue(
+                videoAdaptor.append(
+                    pixelBuffer,
+                    withPresentationTime: CMTime(value: CMTimeValue(index), timescale: 30)
+                )
+            )
+        }
+        videoInput.markAsFinished()
+
+        var asbd = AudioStreamBasicDescription(
+            mSampleRate: Double(audioSampleRate),
+            mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kLinearPCMFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked,
+            mBytesPerPacket: 2,
+            mFramesPerPacket: 1,
+            mBytesPerFrame: 2,
+            mChannelsPerFrame: 1,
+            mBitsPerChannel: 16,
+            mReserved: 0
+        )
+        var audioFormatDescription: CMAudioFormatDescription?
+        let formatStatus = CMAudioFormatDescriptionCreate(
+            allocator: kCFAllocatorDefault,
+            asbd: &asbd,
+            layoutSize: 0,
+            layout: nil,
+            magicCookieSize: 0,
+            magicCookie: nil,
+            extensions: nil,
+            formatDescriptionOut: &audioFormatDescription
+        )
+        XCTAssertEqual(formatStatus, noErr)
+        guard let audioFormatDescription else {
+            XCTFail("could not create PCM audio format description")
+            return
+        }
+
+        for bufferIndex in 0..<audioBufferCount {
+            while !audioInput.isReadyForMoreMediaData {
+                try await Task.sleep(nanoseconds: 1_000_000)
+            }
+            let sampleBuffer = try makeSilentPCMSampleBuffer(
+                formatDescription: audioFormatDescription,
+                frameCount: audioFramesPerBuffer,
+                frameOffset: bufferIndex * audioFramesPerBuffer,
+                sampleRate: audioSampleRate
+            )
+            XCTAssertTrue(audioInput.append(sampleBuffer))
+        }
+        audioInput.markAsFinished()
+
+        await writer.finishWriting()
+        guard writer.status == .completed else {
+            throw writer.error ?? AppleLivePhotoError.videoWriteFailed("test H.264/AAC writer failed")
+        }
+    }
+
+    private func makeSilentPCMSampleBuffer(
+        formatDescription: CMAudioFormatDescription,
+        frameCount: Int,
+        frameOffset: Int,
+        sampleRate: Int
+    ) throws -> CMSampleBuffer {
+        let bytesPerSample = MemoryLayout<Int16>.size
+        let byteCount = frameCount * bytesPerSample
+        var blockBuffer: CMBlockBuffer?
+        let blockStatus = CMBlockBufferCreateWithMemoryBlock(
+            allocator: kCFAllocatorDefault,
+            memoryBlock: nil,
+            blockLength: byteCount,
+            blockAllocator: kCFAllocatorDefault,
+            customBlockSource: nil,
+            offsetToData: 0,
+            dataLength: byteCount,
+            flags: 0,
+            blockBufferOut: &blockBuffer
+        )
+        guard blockStatus == kCMBlockBufferNoErr, let blockBuffer else {
+            throw AppleLivePhotoError.videoWriteFailed("could not allocate PCM block buffer")
+        }
+        let silence = Data(count: byteCount)
+        let replaceStatus = silence.withUnsafeBytes { rawBuffer in
+            CMBlockBufferReplaceDataBytes(
+                with: rawBuffer.baseAddress!,
+                blockBuffer: blockBuffer,
+                offsetIntoDestination: 0,
+                dataLength: byteCount
+            )
+        }
+        guard replaceStatus == kCMBlockBufferNoErr else {
+            throw AppleLivePhotoError.videoWriteFailed("could not fill PCM block buffer")
+        }
+
+        var timing = CMSampleTimingInfo(
+            duration: CMTime(value: 1, timescale: CMTimeScale(sampleRate)),
+            presentationTimeStamp: CMTime(
+                value: CMTimeValue(frameOffset),
+                timescale: CMTimeScale(sampleRate)
+            ),
+            decodeTimeStamp: .invalid
+        )
+        var sampleSize = bytesPerSample
+        var sampleBuffer: CMSampleBuffer?
+        let sampleStatus = CMSampleBufferCreateReady(
+            allocator: kCFAllocatorDefault,
+            dataBuffer: blockBuffer,
+            formatDescription: formatDescription,
+            sampleCount: frameCount,
+            sampleTimingEntryCount: 1,
+            sampleTimingArray: &timing,
+            sampleSizeEntryCount: 1,
+            sampleSizeArray: &sampleSize,
+            sampleBufferOut: &sampleBuffer
+        )
+        guard sampleStatus == noErr, let sampleBuffer else {
+            throw AppleLivePhotoError.videoWriteFailed("could not create PCM sample buffer")
+        }
+        return sampleBuffer
+    }
+}

--- a/Tests/XDRemuxAppleFeaturesTests/LivePhotoStillWriterMetadataTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/LivePhotoStillWriterMetadataTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
+import XCTest
+@testable import XDRemuxAppleFeatures
+
+final class LivePhotoStillWriterMetadataTests: XCTestCase {
+    func testMotionPhotoXMPIsExcludedAndEXIFIsPreserved() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-livephoto-metadata-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let cleanJPEG = directory.appendingPathComponent("clean.jpg")
+        let sourceJPEG = directory.appendingPathComponent("motion-xmp.jpg")
+        let outputHEIC = directory.appendingPathComponent("output.heic")
+        let exifDate = "2026:08:11 12:34:56"
+        try createJPEG(at: cleanJPEG, exifDate: exifDate)
+        try injectMotionPhotoXMP(into: cleanJPEG, outputURL: sourceJPEG)
+
+        let sourceXMP = try XCTUnwrap(xmpPacket(at: sourceJPEG))
+        XCTAssertTrue(sourceXMP.contains("MotionPhoto"))
+
+        let identifier = UUID().uuidString
+        try AppleLivePhotoStillWriter.write(
+            stillInputURL: sourceJPEG,
+            outputURL: outputHEIC,
+            assetIdentifier: identifier
+        )
+
+        let outputXMP = xmpPacket(at: outputHEIC) ?? ""
+        XCTAssertFalse(outputXMP.contains("MotionPhoto"))
+        XCTAssertFalse(outputXMP.contains("GContainer"))
+        XCTAssertEqual(AppleLivePhotoStillWriter.assetIdentifier(in: outputHEIC), identifier)
+
+        guard let source = CGImageSourceCreateWithURL(outputHEIC as CFURL, nil),
+              let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+              let exif = properties[kCGImagePropertyExifDictionary] as? [CFString: Any] else {
+            XCTFail("could not read output EXIF")
+            return
+        }
+        XCTAssertEqual(exif[kCGImagePropertyExifDateTimeOriginal] as? String, exifDate)
+    }
+
+    private func createJPEG(at url: URL, exifDate: String) throws {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: nil,
+            width: 48,
+            height: 32,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ),
+        let destination = CGImageDestinationCreateWithURL(
+            url as CFURL,
+            UTType.jpeg.identifier as CFString,
+            1,
+            nil
+        ) else {
+            XCTFail("could not create source JPEG")
+            return
+        }
+        context.setFillColor(CGColor(red: 0.35, green: 0.25, blue: 0.15, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: 48, height: 32))
+        guard let image = context.makeImage() else {
+            XCTFail("could not create source image")
+            return
+        }
+        let properties: [CFString: Any] = [
+            kCGImagePropertyExifDictionary: [
+                kCGImagePropertyExifDateTimeOriginal: exifDate,
+            ] as CFDictionary,
+        ]
+        CGImageDestinationAddImage(destination, image, properties as CFDictionary)
+        XCTAssertTrue(CGImageDestinationFinalize(destination))
+    }
+
+    private func injectMotionPhotoXMP(into inputURL: URL, outputURL: URL) throws {
+        let original = try Data(contentsOf: inputURL)
+        guard original.count >= 2, original[0] == 0xff, original[1] == 0xd8 else {
+            XCTFail("generated fixture is not JPEG")
+            return
+        }
+        let xmp = """
+        <x:xmpmeta xmlns:x="adobe:ns:meta/">
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <rdf:Description xmlns:GCamera="http://ns.google.com/photos/1.0/camera/"
+                             xmlns:GContainer="http://ns.google.com/photos/1.0/container/"
+                             GCamera:MotionPhoto="1" GCamera:MotionPhotoVersion="1"/>
+          </rdf:RDF>
+        </x:xmpmeta>
+        """
+        var payload = Data("http://ns.adobe.com/xap/1.0/".utf8)
+        payload.append(0)
+        payload.append(Data(xmp.utf8))
+        let segmentLength = payload.count + 2
+        guard segmentLength <= Int(UInt16.max) else {
+            XCTFail("test XMP APP1 segment is too large")
+            return
+        }
+        var segment = Data([0xff, 0xe1])
+        segment.append(UInt8((segmentLength >> 8) & 0xff))
+        segment.append(UInt8(segmentLength & 0xff))
+        segment.append(payload)
+
+        var output = Data(original.prefix(2))
+        output.append(segment)
+        output.append(original.dropFirst(2))
+        try output.write(to: outputURL, options: .atomic)
+    }
+
+    private func xmpPacket(at url: URL) -> String? {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+              let metadata = CGImageSourceCopyMetadataAtIndex(source, 0, nil),
+              let data = CGImageMetadataCreateXMPData(metadata, nil) else {
+            return nil
+        }
+        return String(data: data as Data, encoding: .utf8)
+    }
+}

--- a/Tests/XDRemuxAppleFeaturesTests/LivePhotoWriterIntegrationTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/LivePhotoWriterIntegrationTests.swift
@@ -9,18 +9,32 @@ import XCTest
 @testable import XDRemuxAppleFeatures
 
 final class LivePhotoWriterIntegrationTests: XCTestCase {
-    func testSyntheticPairLoadsInPhotoKitAndPreservesCompressedVideo() async throws {
+    func testSyntheticH264PairLoadsInPhotoKitAndPreservesCompressedVideo() async throws {
+        try await assertSyntheticPair(codec: .h264, filename: "h264.mp4")
+    }
+
+    func testSyntheticHEVCPairLoadsInPhotoKitAndPreservesCompressedVideo() async throws {
+        try await assertSyntheticPair(codec: .hevc, filename: "hevc.mp4")
+    }
+
+    private func assertSyntheticPair(codec: AVVideoCodecType, filename: String) async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("xdremux-livephoto-integration-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
 
         let sourceJPEG = directory.appendingPathComponent("source.jpg")
-        let sourceMP4 = directory.appendingPathComponent("source.mp4")
+        let sourceMP4 = directory.appendingPathComponent(filename)
         let outputHEIC = directory.appendingPathComponent("output.heic")
         let outputMOV = directory.appendingPathComponent("output.mov")
         try createJPEG(at: sourceJPEG, width: 64, height: 48)
-        try await createH264Video(at: sourceMP4, width: 64, height: 48, frameCount: 8)
+        try await createCompressedVideo(
+            at: sourceMP4,
+            codec: codec,
+            width: 64,
+            height: 48,
+            frameCount: 8
+        )
 
         let identifier = UUID().uuidString
         let stillTime = CMTime(value: 2, timescale: 30)
@@ -82,8 +96,9 @@ final class LivePhotoWriterIntegrationTests: XCTestCase {
         XCTAssertTrue(CGImageDestinationFinalize(destination))
     }
 
-    private func createH264Video(
+    private func createCompressedVideo(
         at url: URL,
+        codec: AVVideoCodecType,
         width: Int,
         height: Int,
         frameCount: Int
@@ -92,7 +107,7 @@ final class LivePhotoWriterIntegrationTests: XCTestCase {
         let input = AVAssetWriterInput(
             mediaType: .video,
             outputSettings: [
-                AVVideoCodecKey: AVVideoCodecType.h264,
+                AVVideoCodecKey: codec,
                 AVVideoWidthKey: width,
                 AVVideoHeightKey: height,
             ]
@@ -107,12 +122,14 @@ final class LivePhotoWriterIntegrationTests: XCTestCase {
             ]
         )
         guard writer.canAdd(input) else {
-            XCTFail("H.264 writer input unavailable")
-            return
+            throw XCTSkip("\(codec.rawValue) encoder is unavailable on this macOS runner")
         }
         writer.add(input)
         guard writer.startWriting() else {
-            throw writer.error ?? AppleLivePhotoError.videoWriteFailed("synthetic H.264 writer did not start")
+            if codec == .hevc {
+                throw XCTSkip("HEVC encoder could not start on this macOS runner: \(writer.error?.localizedDescription ?? "unknown error")")
+            }
+            throw writer.error ?? AppleLivePhotoError.videoWriteFailed("synthetic compressed writer did not start")
         }
         writer.startSession(atSourceTime: .zero)
 
@@ -151,7 +168,10 @@ final class LivePhotoWriterIntegrationTests: XCTestCase {
         input.markAsFinished()
         await writer.finishWriting()
         guard writer.status == .completed else {
-            throw writer.error ?? AppleLivePhotoError.videoWriteFailed("synthetic H.264 writer failed")
+            if codec == .hevc {
+                throw XCTSkip("HEVC encoder failed on this macOS runner: \(writer.error?.localizedDescription ?? "unknown error")")
+            }
+            throw writer.error ?? AppleLivePhotoError.videoWriteFailed("synthetic compressed writer failed")
         }
     }
 }

--- a/Tests/XDRemuxAppleFeaturesTests/LivePhotoWriterIntegrationTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/LivePhotoWriterIntegrationTests.swift
@@ -18,6 +18,15 @@ final class LivePhotoWriterIntegrationTests: XCTestCase {
         try await assertSyntheticPair(codec: .hevc, filename: "hevc.mp4")
     }
 
+    func testHighPrecisionStillImageTimeValidatesAtStoredMetadataPrecision() async throws {
+        try await assertSyntheticPair(
+            codec: .h264,
+            filename: "high-precision.mp4",
+            stillTime: CMTime(value: 3_038, timescale: 30_000),
+            requireExactStoredTime: false
+        )
+    }
+
     func testColorOS16AlignmentMetadataStillLoadsInPhotoKit() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("xdremux-livephoto-oppo-transform-\(UUID().uuidString)", isDirectory: true)
@@ -79,7 +88,12 @@ final class LivePhotoWriterIntegrationTests: XCTestCase {
         XCTAssertTrue(report.hasTransformReferenceDimensions)
     }
 
-    private func assertSyntheticPair(codec: AVVideoCodecType, filename: String) async throws {
+    private func assertSyntheticPair(
+        codec: AVVideoCodecType,
+        filename: String,
+        stillTime: CMTime = CMTime(value: 2, timescale: 30),
+        requireExactStoredTime: Bool = true
+    ) async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("xdremux-livephoto-integration-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -99,7 +113,6 @@ final class LivePhotoWriterIntegrationTests: XCTestCase {
         )
 
         let identifier = UUID().uuidString
-        let stillTime = CMTime(value: 2, timescale: 30)
         try AppleLivePhotoStillWriter.write(
             stillInputURL: sourceJPEG,
             outputURL: outputHEIC,
@@ -124,7 +137,19 @@ final class LivePhotoWriterIntegrationTests: XCTestCase {
             requirePhotoKitLoad: true
         )
         XCTAssertEqual(report.assetIdentifier, identifier)
-        XCTAssertEqual(CMTimeCompare(report.stillImageTime, stillTime), 0)
+        if requireExactStoredTime {
+            XCTAssertEqual(CMTimeCompare(report.stillImageTime, stillTime), 0)
+        } else {
+            XCTAssertGreaterThan(report.stillImageTime.timescale, 0)
+            let delta = abs(
+                CMTimeGetSeconds(report.stillImageTime)
+                    - CMTimeGetSeconds(stillTime)
+            )
+            XCTAssertLessThanOrEqual(
+                delta,
+                1.0 / Double(report.stillImageTime.timescale) + 1e-9
+            )
+        }
         XCTAssertFalse(report.hasAudio)
     }
 

--- a/Tests/XDRemuxAppleFeaturesTests/LivePhotoWriterIntegrationTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/LivePhotoWriterIntegrationTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+@preconcurrency import AVFoundation
+import CoreGraphics
+import CoreMedia
+import CoreVideo
+import ImageIO
+import UniformTypeIdentifiers
+import XCTest
+@testable import XDRemuxAppleFeatures
+
+final class LivePhotoWriterIntegrationTests: XCTestCase {
+    func testSyntheticPairLoadsInPhotoKitAndPreservesCompressedVideo() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-livephoto-integration-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let sourceJPEG = directory.appendingPathComponent("source.jpg")
+        let sourceMP4 = directory.appendingPathComponent("source.mp4")
+        let outputHEIC = directory.appendingPathComponent("output.heic")
+        let outputMOV = directory.appendingPathComponent("output.mov")
+        try createJPEG(at: sourceJPEG, width: 64, height: 48)
+        try await createH264Video(at: sourceMP4, width: 64, height: 48, frameCount: 8)
+
+        let identifier = UUID().uuidString
+        let stillTime = CMTime(value: 2, timescale: 30)
+        try AppleLivePhotoStillWriter.write(
+            stillInputURL: sourceJPEG,
+            outputURL: outputHEIC,
+            assetIdentifier: identifier
+        )
+        try await AppleLivePhotoVideoWriter.write(
+            videoInputURL: sourceMP4,
+            outputURL: outputMOV,
+            assetIdentifier: identifier,
+            stillImageTime: stillTime
+        )
+
+        let report = try await AppleLivePhotoValidator.validate(
+            imageURL: outputHEIC,
+            videoURL: outputMOV,
+            expectedAssetIdentifier: identifier,
+            expectedStillImageTime: stillTime,
+            sourceStillURL: sourceJPEG,
+            sourceVideoURL: sourceMP4,
+            sourceHadAudio: false,
+            sourceHadGainMap: false,
+            requirePhotoKitLoad: true
+        )
+        XCTAssertEqual(report.assetIdentifier, identifier)
+        XCTAssertEqual(CMTimeCompare(report.stillImageTime, stillTime), 0)
+        XCTAssertFalse(report.hasAudio)
+    }
+
+    private func createJPEG(at url: URL, width: Int, height: Int) throws {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            XCTFail("could not create CGContext")
+            return
+        }
+        context.setFillColor(CGColor(red: 0.2, green: 0.4, blue: 0.6, alpha: 1.0))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        guard let image = context.makeImage(),
+              let destination = CGImageDestinationCreateWithURL(
+                url as CFURL,
+                UTType.jpeg.identifier as CFString,
+                1,
+                nil
+              ) else {
+            XCTFail("could not create JPEG destination")
+            return
+        }
+        CGImageDestinationAddImage(destination, image, nil)
+        XCTAssertTrue(CGImageDestinationFinalize(destination))
+    }
+
+    private func createH264Video(
+        at url: URL,
+        width: Int,
+        height: Int,
+        frameCount: Int
+    ) async throws {
+        let writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
+        let input = AVAssetWriterInput(
+            mediaType: .video,
+            outputSettings: [
+                AVVideoCodecKey: AVVideoCodecType.h264,
+                AVVideoWidthKey: width,
+                AVVideoHeightKey: height,
+            ]
+        )
+        input.expectsMediaDataInRealTime = false
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA),
+                kCVPixelBufferWidthKey as String: width,
+                kCVPixelBufferHeightKey as String: height,
+            ]
+        )
+        guard writer.canAdd(input) else {
+            XCTFail("H.264 writer input unavailable")
+            return
+        }
+        writer.add(input)
+        guard writer.startWriting() else {
+            throw writer.error ?? AppleLivePhotoError.videoWriteFailed("synthetic H.264 writer did not start")
+        }
+        writer.startSession(atSourceTime: .zero)
+
+        for index in 0..<frameCount {
+            while !input.isReadyForMoreMediaData {
+                try await Task.sleep(nanoseconds: 1_000_000)
+            }
+            var pixelBuffer: CVPixelBuffer?
+            let status = CVPixelBufferCreate(
+                kCFAllocatorDefault,
+                width,
+                height,
+                kCVPixelFormatType_32BGRA,
+                [kCVPixelBufferIOSurfacePropertiesKey as String: [:]] as CFDictionary,
+                &pixelBuffer
+            )
+            XCTAssertEqual(status, kCVReturnSuccess)
+            guard let pixelBuffer else {
+                XCTFail("could not allocate synthetic video pixel buffer")
+                return
+            }
+            CVPixelBufferLockBaseAddress(pixelBuffer, [])
+            if let base = CVPixelBufferGetBaseAddress(pixelBuffer) {
+                let byteCount = CVPixelBufferGetBytesPerRow(pixelBuffer) * height
+                memset(base, Int32(24 + index * 8), byteCount)
+            }
+            CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
+            XCTAssertTrue(
+                adaptor.append(
+                    pixelBuffer,
+                    withPresentationTime: CMTime(value: CMTimeValue(index), timescale: 30)
+                )
+            )
+        }
+
+        input.markAsFinished()
+        await writer.finishWriting()
+        guard writer.status == .completed else {
+            throw writer.error ?? AppleLivePhotoError.videoWriteFailed("synthetic H.264 writer failed")
+        }
+    }
+}

--- a/Tests/XDRemuxAppleFeaturesTests/LivePhotoWriterIntegrationTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/LivePhotoWriterIntegrationTests.swift
@@ -6,6 +6,7 @@ import CoreVideo
 import ImageIO
 import UniformTypeIdentifiers
 import XCTest
+import XDRemuxCore
 @testable import XDRemuxAppleFeatures
 
 final class LivePhotoWriterIntegrationTests: XCTestCase {
@@ -15,6 +16,67 @@ final class LivePhotoWriterIntegrationTests: XCTestCase {
 
     func testSyntheticHEVCPairLoadsInPhotoKitAndPreservesCompressedVideo() async throws {
         try await assertSyntheticPair(codec: .hevc, filename: "hevc.mp4")
+    }
+
+    func testColorOS16AlignmentMetadataStillLoadsInPhotoKit() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-livephoto-oppo-transform-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let sourceJPEG = directory.appendingPathComponent("source.jpg")
+        let sourceMP4 = directory.appendingPathComponent("source.mp4")
+        let outputHEIC = directory.appendingPathComponent("output.heic")
+        let outputMOV = directory.appendingPathComponent("output.mov")
+        try createJPEG(at: sourceJPEG, width: 64, height: 48)
+        try await createCompressedVideo(
+            at: sourceMP4,
+            codec: .hevc,
+            width: 64,
+            height: 48,
+            frameCount: 8
+        )
+
+        let identifier = UUID().uuidString
+        let stillTime = CMTime(value: 2, timescale: 30)
+        let metadata = OppoMotionPhotoMetadata(
+            coverFramePtsUs: 66_667,
+            version: 1,
+            matrixCount: 0,
+            photoCropMatrix: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+            photoEisMatrix: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+            videoWidth: 64,
+            videoHeight: 48
+        )
+        XCTAssertNotNil(OppoLivePhotoAlignment.transformMatrix(for: metadata))
+
+        try AppleLivePhotoStillWriter.write(
+            stillInputURL: sourceJPEG,
+            outputURL: outputHEIC,
+            assetIdentifier: identifier
+        )
+        try await AppleLivePhotoVideoWriter.write(
+            videoInputURL: sourceMP4,
+            outputURL: outputMOV,
+            assetIdentifier: identifier,
+            stillImageTime: stillTime,
+            oppoMetadata: metadata
+        )
+
+        let report = try await AppleLivePhotoValidator.validate(
+            imageURL: outputHEIC,
+            videoURL: outputMOV,
+            expectedAssetIdentifier: identifier,
+            expectedStillImageTime: stillTime,
+            sourceStillURL: sourceJPEG,
+            sourceVideoURL: sourceMP4,
+            sourceHadAudio: false,
+            sourceHadGainMap: false,
+            expectsOppoTransform: true,
+            requirePhotoKitLoad: true
+        )
+        XCTAssertTrue(report.hasTransform)
+        XCTAssertTrue(report.hasTransformReferenceDimensions)
     }
 
     private func assertSyntheticPair(codec: AVVideoCodecType, filename: String) async throws {

--- a/Tests/XDRemuxAppleFeaturesTests/OppoLivePhotoAlignmentTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/OppoLivePhotoAlignmentTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+import XDRemuxCore
+@testable import XDRemuxAppleFeatures
+
+final class OppoLivePhotoAlignmentTests: XCTestCase {
+    func testColorOS16AppliesEISCompensationAfterIdentityVendorMatrices() throws {
+        let identity: [Double] = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+        let metadata = OppoMotionPhotoMetadata(
+            coverFramePtsUs: 1_000_000,
+            version: 1,
+            matrixCount: 0,
+            photoCropMatrix: identity,
+            photoEisMatrix: identity,
+            videoWidth: 1728,
+            videoHeight: 1296
+        )
+        let matrix = try XCTUnwrap(OppoLivePhotoAlignment.transformMatrix(for: metadata))
+        XCTAssertEqual(matrix[0], 0.90, accuracy: 1e-12)
+        XCTAssertEqual(matrix[4], 0.90, accuracy: 1e-12)
+        XCTAssertEqual(matrix[8], 1.0, accuracy: 1e-12)
+        XCTAssertEqual(OppoLivePhotoAlignment.referenceDimensions(for: metadata), [1728, 1296])
+    }
+
+    func testColorOS15UsesClosestCoverFrameAndInvertsMatrix() throws {
+        let metadata = OppoMotionPhotoMetadata(
+            coverFramePtsUs: 1_100,
+            version: 0,
+            matrixCount: 2,
+            matrices: [
+                "1000": [2, 0, 0, 0, 2, 0, 0, 0, 1],
+                "2000": [4, 0, 0, 0, 4, 0, 0, 0, 1],
+            ]
+        )
+        let matrix = try XCTUnwrap(OppoLivePhotoAlignment.transformMatrix(for: metadata))
+        XCTAssertEqual(matrix[0], 0.5, accuracy: 1e-12)
+        XCTAssertEqual(matrix[4], 0.5, accuracy: 1e-12)
+        XCTAssertEqual(matrix[8], 1.0, accuracy: 1e-12)
+    }
+
+    func testColorOS15WithNoMatricesNeedsNoTransform() {
+        let metadata = OppoMotionPhotoMetadata(coverFramePtsUs: 1_000, version: 0, matrixCount: 0)
+        XCTAssertNil(OppoLivePhotoAlignment.transformMatrix(for: metadata))
+    }
+}

--- a/Tests/XDRemuxAppleFeaturesTests/RealMotionPhotoFixtureTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/RealMotionPhotoFixtureTests.swift
@@ -58,10 +58,8 @@ final class RealMotionPhotoFixtureTests: XCTestCase {
             AppleLivePhotoStillWriter.assetIdentifier(in: result.imageURL),
             result.assetIdentifier
         )
-        XCTAssertEqual(
-            await AppleLivePhotoVideoWriter.contentIdentifier(in: result.videoURL),
-            result.assetIdentifier
-        )
+        let videoIdentifier = await AppleLivePhotoVideoWriter.contentIdentifier(in: result.videoURL)
+        XCTAssertEqual(videoIdentifier, result.assetIdentifier)
     }
 
     private func requireFixture(named filename: String) throws -> URL {

--- a/Tests/XDRemuxAppleFeaturesTests/RealMotionPhotoFixtureTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/RealMotionPhotoFixtureTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import XCTest
+import XDRemuxCore
+@testable import XDRemuxAppleFeatures
+
+/// Optional characterization + end-to-end gates for the real OPPO samples used while developing
+/// LivePhotoToolbox. CI runs these after unpacking the private fixture archive when the files are
+/// present. Normal open-source test runs skip them rather than depending on private media.
+final class RealMotionPhotoFixtureTests: XCTestCase {
+    func testColorOS15RealFixture() async throws {
+        let source = try requireFixture(named: "IMG20250425184722.jpg")
+        let asset = try XCTUnwrap(OppoMotionPhotoParser.parse(url: source))
+
+        XCTAssertEqual(asset.sourceKind, .oppoLivePhoto)
+        XCTAssertEqual(asset.stillResourceRange.upperBound, 1_905_360)
+        XCTAssertEqual(asset.videoResourceRange.lowerBound, 1_905_360)
+        XCTAssertEqual(asset.presentationTimestampUs, 1_265_580)
+        XCTAssertEqual(asset.presentationSource, .androidXMP)
+        XCTAssertEqual(asset.vendorMetadata?.streamCount, 1)
+
+        try await assertEndToEndConversion(source: source)
+    }
+
+    func testColorOS16RealFixture() async throws {
+        let source = try requireFixture(named: "IMG20250901181353.jpg")
+        let asset = try XCTUnwrap(OppoMotionPhotoParser.parse(url: source))
+
+        XCTAssertEqual(asset.sourceKind, .oppoLivePhoto)
+        XCTAssertEqual(asset.stillResourceRange.upperBound, 8_273_274)
+        XCTAssertEqual(asset.videoResourceRange.lowerBound, 8_273_274)
+        XCTAssertEqual(asset.presentationTimestampUs, 1_634_640)
+        XCTAssertEqual(asset.presentationSource, .androidXMP)
+        XCTAssertGreaterThanOrEqual(asset.vendorMetadata?.streamCount ?? 0, 2)
+
+        let primary = try OppoMotionPhotoStreamResolver.primaryVideoRange(for: asset)
+        XCTAssertEqual(primary.lowerBound, 8_273_274)
+        XCTAssertEqual(primary.upperBound, 15_283_688)
+
+        try await assertEndToEndConversion(source: source)
+    }
+
+    private func assertEndToEndConversion(source: URL) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-real-motion-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let output = directory.appendingPathComponent(source.deletingPathExtension().lastPathComponent)
+            .appendingPathExtension("heic")
+        let result = try await AppleLivePhotoConversionEngine.convertAsync(
+            inputURL: source,
+            outputImageURL: output,
+            requirePhotoKitValidation: true
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.imageURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.videoURL.path))
+        XCTAssertEqual(
+            AppleLivePhotoStillWriter.assetIdentifier(in: result.imageURL),
+            result.assetIdentifier
+        )
+        XCTAssertEqual(
+            await AppleLivePhotoVideoWriter.contentIdentifier(in: result.videoURL),
+            result.assetIdentifier
+        )
+    }
+
+    private func requireFixture(named filename: String) throws -> URL {
+        guard let rootPath = ProcessInfo.processInfo.environment["XDREMUX_MOTION_PHOTO_FIXTURE_ROOT"],
+              !rootPath.isEmpty else {
+            throw XCTSkip("XDREMUX_MOTION_PHOTO_FIXTURE_ROOT is not configured")
+        }
+        let root = URL(fileURLWithPath: rootPath).standardizedFileURL
+        if root.lastPathComponent == filename,
+           FileManager.default.fileExists(atPath: root.path) {
+            return root
+        }
+        let keys: [URLResourceKey] = [.isRegularFileKey]
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: keys,
+            options: [.skipsHiddenFiles]
+        ) else {
+            throw XCTSkip("cannot enumerate private Motion Photo fixture root")
+        }
+        for case let url as URL in enumerator where url.lastPathComponent == filename {
+            if (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true {
+                return url
+            }
+        }
+        throw XCTSkip("private Motion Photo fixture \(filename) is not present")
+    }
+}

--- a/Tests/XDRemuxAppleFeaturesTests/UploadedMotionPhotoFixtureGateTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/UploadedMotionPhotoFixtureGateTests.swift
@@ -1,0 +1,348 @@
+import Foundation
+@preconcurrency import AVFoundation
+import CoreMedia
+import CryptoKit
+import ImageIO
+import XCTest
+import XDRemuxCore
+@testable import XDRemuxAppleFeatures
+
+/// Production gate for the real samples supplied for the Motion Photo implementation review.
+///
+/// The test is intentionally skipped when no private fixture root is configured. Once
+/// `XDREMUX_MOTION_PHOTO_FIXTURE_ROOT` is present, every named fixture is mandatory and the gate
+/// performs both characterization and full HEIC+MOV -> PHLivePhoto validation on macOS.
+final class UploadedMotionPhotoFixtureGateTests: XCTestCase {
+    private struct FixtureSpec: Sendable {
+        let filename: String
+        let sha256: String
+        let sourceKind: MotionPhotoSourceKind
+        let stillEnd: Int64
+        let videoStart: Int64
+        let videoEnd: Int64
+        let presentationTimestampUs: Int64
+        let streamCount: Int
+        let primaryVideoEnd: Int64?
+        let expectsGainMap: Bool
+    }
+
+    private let fixtures: [FixtureSpec] = [
+        // OPPO ColorOS 15 — one embedded HEVC Motion Photo stream, Ultra HDR still.
+        .init(
+            filename: "IMG20250502131605.jpg",
+            sha256: "83a4f9f3c978f541e1255bff3bd89cffe0da182aef5558c1d9d081c41f4cdb01",
+            sourceKind: .oppoLivePhoto,
+            stillEnd: 5_212_915,
+            videoStart: 5_212_915,
+            videoEnd: 15_165_684,
+            presentationTimestampUs: 1_469_600,
+            streamCount: 1,
+            primaryVideoEnd: nil,
+            expectsGainMap: true
+        ),
+        .init(
+            filename: "IMG20250502131608.jpg",
+            sha256: "3f5cc79c1cf26f18acf22522964e7b8e009bf35b36c4c509d7618b1fd7cd6707",
+            sourceKind: .oppoLivePhoto,
+            stillEnd: 4_610_334,
+            videoStart: 4_610_334,
+            videoEnd: 13_359_471,
+            presentationTimestampUs: 1_433_190,
+            streamCount: 1,
+            primaryVideoEnd: nil,
+            expectsGainMap: true
+        ),
+        .init(
+            filename: "IMG20250819170327.jpg",
+            sha256: "20afbcfb3f6fbcd7ea7b2ca306b8208dbfd10eaeb7a9fb91cf86a5a9b21c3920",
+            sourceKind: .oppoLivePhoto,
+            stillEnd: 19_365_654,
+            videoStart: 19_365_654,
+            videoEnd: 30_680_658,
+            presentationTimestampUs: 1_666_600,
+            streamCount: 1,
+            primaryVideoEnd: nil,
+            expectsGainMap: true
+        ),
+
+        // OPPO ColorOS 16 — the Android MotionPhoto resource contains two concatenated BMFF
+        // streams. Stream 1 is the Apple paired video; Stream 2 is vendor preview data.
+        .init(
+            filename: "IMG20260710191114_ColorOS_16.jpg",
+            sha256: "5b555b0fffcec9ffb64a082a0532822431b59fc0490b677cc557e9810b764e70",
+            sourceKind: .oppoLivePhoto,
+            stillEnd: 6_809_684,
+            videoStart: 6_809_684,
+            videoEnd: 24_929_781,
+            presentationTimestampUs: 1_533_287,
+            streamCount: 2,
+            primaryVideoEnd: 23_211_122,
+            expectsGainMap: true
+        ),
+        .init(
+            filename: "IMG20260801190843_ColorOS_16.jpg",
+            sha256: "15c19972c3328da9c4bfb8ad9134f92764c6c51827853f8118d5d2d986e967ff",
+            sourceKind: .oppoLivePhoto,
+            stillEnd: 13_591_436,
+            videoStart: 13_591_436,
+            videoEnd: 29_199_130,
+            presentationTimestampUs: 1_298_732,
+            streamCount: 2,
+            primaryVideoEnd: 27_234_826,
+            expectsGainMap: true
+        ),
+
+        // Xiaomi Android Motion Photo V1, Ultra HDR JPEG static resource.
+        .init(
+            filename: "MVIMG_20260419_151324_2_3..jpg",
+            sha256: "18f5d5b9243dec290626b446f6812d7bf41399bdc66d7feb794e562a9ffca4dc",
+            sourceKind: .androidMotionPhotoV1,
+            stillEnd: 9_541_876,
+            videoStart: 9_541_876,
+            videoEnd: 10_550_148,
+            presentationTimestampUs: 430_574,
+            streamCount: 1,
+            primaryVideoEnd: nil,
+            expectsGainMap: true
+        ),
+
+        // Samsung JPEG Motion Photo V1. Samsung keeps another BMFF-looking vendor region inside
+        // the static resource; the semantic Container directory selects the later true video start.
+        .init(
+            filename: "20260312_135625..jpg",
+            sha256: "d95c3bfe772d681c3b7b4c33ab39f6a9da46517b3e88209fe263843dfa49cfa4",
+            sourceKind: .androidMotionPhotoV1,
+            stillEnd: 2_689_001,
+            videoStart: 2_689_001,
+            videoEnd: 6_842_570,
+            presentationTimestampUs: 1_573_888,
+            streamCount: 1,
+            primaryVideoEnd: nil,
+            expectsGainMap: true
+        ),
+        .init(
+            filename: "20260312_135627..jpg",
+            sha256: "c9e97669689fcc975f3d511cc15274b047c6b340d12c434fd04ceaa249bfee9b",
+            sourceKind: .androidMotionPhotoV1,
+            stillEnd: 2_690_459,
+            videoStart: 2_690_459,
+            videoEnd: 3_752_096,
+            presentationTimestampUs: 1_585_246,
+            streamCount: 1,
+            primaryVideoEnd: nil,
+            expectsGainMap: true
+        ),
+
+        // Samsung HEIF Motion Photo V1. The video is the mpvd payload only; trailing sefd is vendor
+        // data and must never be copied into the Apple paired MOV. R002/R003 are byte-identical
+        // duplicates supplied in the same archive and are retained in the gate deliberately.
+        .init(
+            filename: "20260312_135609..heic",
+            sha256: "06eb244bc69ae464bd7b0a60b769f4fc3429dc543451481f5331586a7536b8d0",
+            sourceKind: .androidHeifMotionPhotoV1,
+            stillEnd: 1_232_154,
+            videoStart: 1_232_162,
+            videoEnd: 5_181_667,
+            presentationTimestampUs: 1_540_401,
+            streamCount: 1,
+            primaryVideoEnd: nil,
+            expectsGainMap: true
+        ),
+        .init(
+            filename: "R002_20260312_135609..heic",
+            sha256: "06eb244bc69ae464bd7b0a60b769f4fc3429dc543451481f5331586a7536b8d0",
+            sourceKind: .androidHeifMotionPhotoV1,
+            stillEnd: 1_232_154,
+            videoStart: 1_232_162,
+            videoEnd: 5_181_667,
+            presentationTimestampUs: 1_540_401,
+            streamCount: 1,
+            primaryVideoEnd: nil,
+            expectsGainMap: true
+        ),
+        .init(
+            filename: "20260312_135610..heic",
+            sha256: "d33f502276f0d8e8a0f49c9f5674ed1728812f7432f355a5a3325007fc780f1f",
+            sourceKind: .androidHeifMotionPhotoV1,
+            stillEnd: 1_217_171,
+            videoStart: 1_217_179,
+            videoEnd: 5_586_957,
+            presentationTimestampUs: 2_518_658,
+            streamCount: 1,
+            primaryVideoEnd: nil,
+            expectsGainMap: true
+        ),
+        .init(
+            filename: "R003_20260312_135610..heic",
+            sha256: "d33f502276f0d8e8a0f49c9f5674ed1728812f7432f355a5a3325007fc780f1f",
+            sourceKind: .androidHeifMotionPhotoV1,
+            stillEnd: 1_217_171,
+            videoStart: 1_217_179,
+            videoEnd: 5_586_957,
+            presentationTimestampUs: 2_518_658,
+            streamCount: 1,
+            primaryVideoEnd: nil,
+            expectsGainMap: true
+        ),
+
+        // vivo standard Motion Photo V1. These two supplied samples are SDR still resources rather
+        // than Ultra HDR; they still exercise HEVC + AAC passthrough and generic vendor neutrality.
+        .init(
+            filename: "IMG_20260620_160335..jpg",
+            sha256: "f71104787d3ce236e5543a71cfc50f8208fd9acbaeef057178350dfbacecd277",
+            sourceKind: .androidMotionPhotoV1,
+            stillEnd: 3_307_962,
+            videoStart: 3_307_962,
+            videoEnd: 6_031_584,
+            presentationTimestampUs: 1_333_944,
+            streamCount: 1,
+            primaryVideoEnd: nil,
+            expectsGainMap: false
+        ),
+        .init(
+            filename: "IMG_20260620_160410..jpg",
+            sha256: "7a00f4a63b51abfde5d1a93bc08053b3f4f28222b2234212da030ab8ed12d321",
+            sourceKind: .androidMotionPhotoV1,
+            stillEnd: 3_036_474,
+            videoStart: 3_036_474,
+            videoEnd: 9_638_904,
+            presentationTimestampUs: 838_055,
+            streamCount: 1,
+            primaryVideoEnd: nil,
+            expectsGainMap: false
+        ),
+    ]
+
+    func testAllSuppliedFixturesCharacterizeAndLoadAsAppleLivePhotos() async throws {
+        let root = try fixtureRoot()
+        let index = try fixtureIndex(root: root)
+        let outputRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-uploaded-motion-gate-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: outputRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outputRoot) }
+
+        for spec in fixtures {
+            guard let source = index[spec.filename] else {
+                XCTFail("required private Motion Photo fixture is missing: \(spec.filename)")
+                continue
+            }
+            let beforeHash = try sha256(source)
+            XCTAssertEqual(beforeHash, spec.sha256, "fixture identity changed: \(spec.filename)")
+
+            let asset = try XCTUnwrap(
+                OppoMotionPhotoParser.parse(url: source),
+                "parser rejected \(spec.filename)"
+            )
+            XCTAssertEqual(asset.sourceKind, spec.sourceKind, spec.filename)
+            XCTAssertEqual(asset.stillResourceRange.lowerBound, 0, spec.filename)
+            XCTAssertEqual(asset.stillResourceRange.upperBound, spec.stillEnd, spec.filename)
+            XCTAssertEqual(asset.videoResourceRange.lowerBound, spec.videoStart, spec.filename)
+            XCTAssertEqual(asset.videoResourceRange.upperBound, spec.videoEnd, spec.filename)
+            XCTAssertEqual(asset.presentationTimestampUs, spec.presentationTimestampUs, spec.filename)
+            XCTAssertEqual(asset.vendorMetadata?.streamCount ?? 1, spec.streamCount, spec.filename)
+
+            let primaryVideo = try OppoMotionPhotoStreamResolver.primaryVideoRange(for: asset)
+            XCTAssertEqual(primaryVideo.lowerBound, spec.videoStart, spec.filename)
+            XCTAssertEqual(
+                primaryVideo.upperBound,
+                spec.primaryVideoEnd ?? spec.videoEnd,
+                spec.filename
+            )
+
+            let output = outputRoot
+                .appendingPathComponent(sanitizedStem(spec.filename))
+                .appendingPathExtension("heic")
+            let result = try await AppleLivePhotoConversionEngine.convertAsync(
+                inputURL: source,
+                outputImageURL: output,
+                requirePhotoKitValidation: true
+            )
+
+            XCTAssertEqual(result.sourceKind, spec.sourceKind, spec.filename)
+            XCTAssertTrue(FileManager.default.fileExists(atPath: result.imageURL.path), spec.filename)
+            XCTAssertTrue(FileManager.default.fileExists(atPath: result.videoURL.path), spec.filename)
+            XCTAssertEqual(
+                AppleLivePhotoStillWriter.hasGainMap(result.imageURL),
+                spec.expectsGainMap,
+                "gain-map state changed: \(spec.filename)"
+            )
+            XCTAssertTrue(
+                AppleLivePhotoValidator.isValidPair(
+                    imageURL: result.imageURL,
+                    videoURL: result.videoURL
+                ),
+                "structural Live Photo validation failed: \(spec.filename)"
+            )
+            XCTAssertFalse(
+                outputContainsStaleMotionPhotoXMP(result.imageURL),
+                "stale Android Motion Photo XMP survived conversion: \(spec.filename)"
+            )
+
+            let afterHash = try sha256(source)
+            XCTAssertEqual(afterHash, beforeHash, "conversion modified source fixture: \(spec.filename)")
+        }
+    }
+
+    private func fixtureRoot() throws -> URL {
+        guard let path = ProcessInfo.processInfo.environment["XDREMUX_MOTION_PHOTO_FIXTURE_ROOT"],
+              !path.isEmpty else {
+            throw XCTSkip("XDREMUX_MOTION_PHOTO_FIXTURE_ROOT is not configured")
+        }
+        let root = URL(fileURLWithPath: path).standardizedFileURL
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: root.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            XCTFail("XDREMUX_MOTION_PHOTO_FIXTURE_ROOT is not a readable directory")
+            throw AppleLivePhotoError.pairValidationFailed("private fixture root is invalid")
+        }
+        return root
+    }
+
+    private func fixtureIndex(root: URL) throws -> [String: URL] {
+        let expectedNames = Set(fixtures.map(\.filename))
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return [:]
+        }
+        var result: [String: URL] = [:]
+        for case let url as URL in enumerator where expectedNames.contains(url.lastPathComponent) {
+            if (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true {
+                result[url.lastPathComponent] = url
+            }
+        }
+        return result
+    }
+
+    private func sha256(_ url: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        while let data = try handle.read(upToCount: 1 << 20), !data.isEmpty {
+            hasher.update(data: data)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func sanitizedStem(_ filename: String) -> String {
+        filename.replacingOccurrences(of: "/", with: "_")
+    }
+
+    private func outputContainsStaleMotionPhotoXMP(_ imageURL: URL) -> Bool {
+        guard let source = CGImageSourceCreateWithURL(
+            imageURL as CFURL,
+            [kCGImageSourceShouldCache: false] as CFDictionary
+        ),
+        let metadata = CGImageSourceCopyMetadataAtIndex(source, 0, nil),
+        let xmp = CGImageMetadataCreateXMPData(metadata, nil),
+        let text = String(data: xmp as Data, encoding: .utf8) else {
+            return false
+        }
+        return text.contains("MotionPhoto")
+            || text.contains("MicroVideo")
+            || text.contains("GContainer")
+            || text.contains("Container:Directory")
+    }
+}

--- a/Tests/XDRemuxCLITests/MixedMotionPhotoBatchRoutingTests.swift
+++ b/Tests/XDRemuxCLITests/MixedMotionPhotoBatchRoutingTests.swift
@@ -1,5 +1,12 @@
 import Foundation
+@preconcurrency import AVFoundation
+import CoreGraphics
+import CoreMedia
+import CoreVideo
+import ImageIO
+import UniformTypeIdentifiers
 import XCTest
+import XDRemuxAppleFeatures
 @testable import XDRemuxCLI
 
 final class MixedMotionPhotoBatchRoutingTests: XCTestCase {
@@ -36,6 +43,59 @@ final class MixedMotionPhotoBatchRoutingTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: motionOutput.path))
     }
 
+    func testRerunWithExistingLivePhotoStillNeverFallsThroughToLegacyHEICEnumerator() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-mixed-motion-rerun-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let sourceJPEG = directory.appendingPathComponent("live-source.jpg")
+        let sourceMP4 = directory.appendingPathComponent("live-source.mp4")
+        let liveHEIC = directory.appendingPathComponent("already-converted.heic")
+        let liveMOV = directory.appendingPathComponent("already-converted.mov")
+        try createJPEG(at: sourceJPEG, width: 32, height: 24)
+        try await createH264Video(at: sourceMP4, width: 32, height: 24, frameCount: 5)
+        let identifier = UUID().uuidString
+        let stillTime = CMTime(value: 1, timescale: 30)
+        try AppleLivePhotoStillWriter.write(
+            stillInputURL: sourceJPEG,
+            outputURL: liveHEIC,
+            assetIdentifier: identifier
+        )
+        try await AppleLivePhotoVideoWriter.write(
+            videoInputURL: sourceMP4,
+            outputURL: liveMOV,
+            assetIdentifier: identifier,
+            stillImageTime: stillTime
+        )
+        _ = try await AppleLivePhotoValidator.validate(
+            imageURL: liveHEIC,
+            videoURL: liveMOV,
+            expectedAssetIdentifier: identifier,
+            expectedStillImageTime: stillTime,
+            requirePhotoKitLoad: true
+        )
+
+        let motionURL = directory.appendingPathComponent("motion.jpg")
+        try syntheticMotionPhoto().write(to: motionURL, options: .atomic)
+
+        // A repeated batch sees the valid paired HEIC as an output, not as a source HEIC. Because
+        // the synthetic Motion Photo video intentionally has no playable AV track, the classified
+        // Motion Photo pass fails immediately. If routing had fallen through to XDRemuxCommand's
+        // legacy `*.heic` enumerator this call would return false instead of throwing here.
+        XCTAssertThrowsError(
+            try MotionPhotoCLIIntegration.handleIfNeeded([
+                "batch",
+                "--input-dir", directory.path,
+            ])
+        )
+        XCTAssertNoThrow(try MotionPhotoCLIIntegration.finishPendingBatchIfNeeded())
+        XCTAssertTrue(
+            AppleLivePhotoValidator.isValidPair(imageURL: liveHEIC, videoURL: liveMOV),
+            "the pre-existing Live Photo pair must remain untouched"
+        )
+    }
+
     private func syntheticMotionPhoto() -> Data {
         let video = fakeBMFF()
         let xmp = """
@@ -63,5 +123,105 @@ final class MixedMotionPhotoBatchRoutingTests: XCTestCase {
         data.append(contentsOf: [0, 0, 0, 8])
         data.append(Data("mdat".utf8))
         return data
+    }
+
+    private func createJPEG(at url: URL, width: Int, height: Int) throws {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ),
+        let destination = CGImageDestinationCreateWithURL(
+            url as CFURL,
+            UTType.jpeg.identifier as CFString,
+            1,
+            nil
+        ) else {
+            XCTFail("could not create JPEG fixture")
+            return
+        }
+        context.setFillColor(CGColor(red: 0.25, green: 0.5, blue: 0.75, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        guard let image = context.makeImage() else {
+            XCTFail("could not make JPEG fixture image")
+            return
+        }
+        CGImageDestinationAddImage(destination, image, nil)
+        XCTAssertTrue(CGImageDestinationFinalize(destination))
+    }
+
+    private func createH264Video(
+        at url: URL,
+        width: Int,
+        height: Int,
+        frameCount: Int
+    ) async throws {
+        let writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
+        let input = AVAssetWriterInput(
+            mediaType: .video,
+            outputSettings: [
+                AVVideoCodecKey: AVVideoCodecType.h264,
+                AVVideoWidthKey: width,
+                AVVideoHeightKey: height,
+            ]
+        )
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA),
+                kCVPixelBufferWidthKey as String: width,
+                kCVPixelBufferHeightKey as String: height,
+            ]
+        )
+        guard writer.canAdd(input) else {
+            XCTFail("could not add H.264 writer input")
+            return
+        }
+        writer.add(input)
+        guard writer.startWriting() else {
+            throw writer.error ?? AppleLivePhotoError.videoWriteFailed("test H.264 writer did not start")
+        }
+        writer.startSession(atSourceTime: .zero)
+
+        for index in 0..<frameCount {
+            while !input.isReadyForMoreMediaData {
+                try await Task.sleep(nanoseconds: 1_000_000)
+            }
+            var pixelBuffer: CVPixelBuffer?
+            let status = CVPixelBufferCreate(
+                kCFAllocatorDefault,
+                width,
+                height,
+                kCVPixelFormatType_32BGRA,
+                [kCVPixelBufferIOSurfacePropertiesKey as String: [:]] as CFDictionary,
+                &pixelBuffer
+            )
+            XCTAssertEqual(status, kCVReturnSuccess)
+            guard let pixelBuffer else {
+                XCTFail("could not allocate test pixel buffer")
+                return
+            }
+            CVPixelBufferLockBaseAddress(pixelBuffer, [])
+            if let base = CVPixelBufferGetBaseAddress(pixelBuffer) {
+                memset(base, Int32(32 + index), CVPixelBufferGetBytesPerRow(pixelBuffer) * height)
+            }
+            CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
+            XCTAssertTrue(
+                adaptor.append(
+                    pixelBuffer,
+                    withPresentationTime: CMTime(value: CMTimeValue(index), timescale: 30)
+                )
+            )
+        }
+        input.markAsFinished()
+        await writer.finishWriting()
+        guard writer.status == .completed else {
+            throw writer.error ?? AppleLivePhotoError.videoWriteFailed("test H.264 writer failed")
+        }
     }
 }

--- a/Tests/XDRemuxCLITests/MixedMotionPhotoBatchRoutingTests.swift
+++ b/Tests/XDRemuxCLITests/MixedMotionPhotoBatchRoutingTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import XCTest
+@testable import XDRemuxCLI
+
+final class MixedMotionPhotoBatchRoutingTests: XCTestCase {
+    func testMixedHEICAndMotionPhotoDefersMotionOutputUntilAfterLegacyBatch() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-mixed-motion-batch-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // Only the filename/extension matters for planning the unchanged HEIC pass.
+        try Data("not-a-real-heic".utf8).write(
+            to: directory.appendingPathComponent("existing.heic"),
+            options: .atomic
+        )
+
+        let motionURL = directory.appendingPathComponent("motion.jpg")
+        try syntheticMotionPhoto().write(to: motionURL, options: .atomic)
+        let motionOutput = directory.appendingPathComponent("motion.heic")
+
+        let handled = try MotionPhotoCLIIntegration.handleIfNeeded([
+            "batch",
+            "--input-dir", directory.path,
+        ])
+
+        // False means XDRemuxCommand.main() must run the existing HEIC pass first. Crucially the
+        // Motion Photo HEIC has not been written yet, so that pass cannot enumerate it as an input.
+        XCTAssertFalse(handled)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: motionOutput.path))
+
+        // Clear the queued plan. The deliberately minimal fake MP4 has no playable video track, so
+        // the actual conversion is expected to fail after planning; the routing assertion above is
+        // the behavior under test.
+        XCTAssertThrowsError(try MotionPhotoCLIIntegration.finishPendingBatchIfNeeded())
+        XCTAssertFalse(FileManager.default.fileExists(atPath: motionOutput.path))
+    }
+
+    private func syntheticMotionPhoto() -> Data {
+        let video = fakeBMFF()
+        let xmp = """
+        <x:xmpmeta xmlns:x="adobe:ns:meta/">
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <rdf:Description xmlns:Camera="http://ns.google.com/photos/1.0/camera/"
+                             xmlns:Container="http://ns.google.com/photos/1.0/container/"
+                             xmlns:Item="http://ns.google.com/photos/1.0/container/item/"
+                             Camera:MotionPhoto="1" Camera:MotionPhotoVersion="1">
+              <Container:Directory><rdf:Seq>
+                <rdf:li rdf:parseType="Resource"><Container:Item Item:Mime="image/jpeg" Item:Semantic="Primary" Item:Length="0" Item:Padding="0"/></rdf:li>
+                <rdf:li rdf:parseType="Resource"><Container:Item Item:Mime="video/mp4" Item:Semantic="MotionPhoto" Item:Length="\(video.count)" Item:Padding="0"/></rdf:li>
+              </rdf:Seq></Container:Directory>
+            </rdf:Description>
+          </rdf:RDF>
+        </x:xmpmeta>
+        """
+        return Data([0xff, 0xd8]) + Data(xmp.utf8) + Data([0xff, 0xd9]) + video
+    }
+
+    private func fakeBMFF() -> Data {
+        var data = Data([0, 0, 0, 16])
+        data.append(Data("ftypisom".utf8))
+        data.append(contentsOf: [0, 0, 0, 0])
+        data.append(contentsOf: [0, 0, 0, 8])
+        data.append(Data("mdat".utf8))
+        return data
+    }
+}

--- a/Tests/XDRemuxCLITests/MotionPhotoBatchCheckpointTests.swift
+++ b/Tests/XDRemuxCLITests/MotionPhotoBatchCheckpointTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import XCTest
+@testable import XDRemuxCLI
+
+final class MotionPhotoBatchCheckpointTests: XCTestCase {
+    func testRoundTripsPairOutputsAndInputSignature() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-motion-checkpoint-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let input = directory.appendingPathComponent("source.jpg")
+        try Data("source".utf8).write(to: input)
+        let image = directory.appendingPathComponent("source.heic")
+        let video = directory.appendingPathComponent("source.mov")
+        let checkpoint = directory.appendingPathComponent("checkpoint.jsonl")
+        let signature = try MotionPhotoBatchCheckpoint.signature(for: input)
+
+        let writer = try MotionPhotoBatchCheckpoint.Writer(url: checkpoint)
+        try writer.append(
+            inputURL: input,
+            outputImageURL: image,
+            outputVideoURL: video,
+            status: .success,
+            signature: signature
+        )
+        try writer.close()
+
+        let state = try MotionPhotoBatchCheckpoint.load(url: checkpoint)
+        let item = try XCTUnwrap(state[input.standardizedFileURL.path])
+        XCTAssertEqual(item.status, .success)
+        XCTAssertTrue(item.matchesSignature(signature))
+        XCTAssertTrue(item.matchesOutputs(imageURL: image, videoURL: video))
+    }
+
+    func testChangedInputSignatureDoesNotResumeAsDone() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-motion-checkpoint-change-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let input = directory.appendingPathComponent("source.jpg")
+        try Data("before".utf8).write(to: input)
+        let image = directory.appendingPathComponent("source.heic")
+        let video = directory.appendingPathComponent("source.mov")
+        let checkpoint = directory.appendingPathComponent("checkpoint.jsonl")
+        let before = try MotionPhotoBatchCheckpoint.signature(for: input)
+
+        let writer = try MotionPhotoBatchCheckpoint.Writer(url: checkpoint)
+        try writer.append(
+            inputURL: input,
+            outputImageURL: image,
+            outputVideoURL: video,
+            status: .success,
+            signature: before
+        )
+        try writer.close()
+
+        try Data("after-with-different-size".utf8).write(to: input, options: .atomic)
+        let after = try MotionPhotoBatchCheckpoint.signature(for: input)
+        let state = try MotionPhotoBatchCheckpoint.load(url: checkpoint)
+        let item = try XCTUnwrap(state[input.standardizedFileURL.path])
+        XCTAssertFalse(item.matchesSignature(after))
+    }
+}

--- a/Tests/XDRemuxCLITests/MotionPhotoConvertIntegrationTests.swift
+++ b/Tests/XDRemuxCLITests/MotionPhotoConvertIntegrationTests.swift
@@ -1,0 +1,209 @@
+import Foundation
+@preconcurrency import AVFoundation
+import CoreGraphics
+import CoreMedia
+import CoreVideo
+import CryptoKit
+import ImageIO
+import UniformTypeIdentifiers
+import XCTest
+import XDRemuxAppleFeatures
+@testable import XDRemuxCLI
+
+final class MotionPhotoConvertIntegrationTests: XCTestCase {
+    func testConvertAutoRoutesStandardMotionPhotoAndPreservesSourceJPEG() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-motion-convert-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let cleanJPEG = directory.appendingPathComponent("clean.jpg")
+        let sourceMP4 = directory.appendingPathComponent("motion.mp4")
+        let motionJPEG = directory.appendingPathComponent("IMG_0001.jpg")
+        try createJPEG(at: cleanJPEG, width: 64, height: 48)
+        try await createH264Video(at: sourceMP4, width: 64, height: 48, frameCount: 8)
+        let video = try Data(contentsOf: sourceMP4)
+        try makeMotionPhoto(
+            cleanJPEG: cleanJPEG,
+            video: video,
+            presentationTimestampUs: 100_000,
+            outputURL: motionJPEG
+        )
+        let sourceDigest = SHA256.hash(data: try Data(contentsOf: motionJPEG))
+
+        let handled = try MotionPhotoCLIIntegration.handleIfNeeded([
+            "convert",
+            "--input", motionJPEG.path,
+        ])
+        XCTAssertTrue(handled)
+
+        let outputHEIC = directory.appendingPathComponent("IMG_0001.heic")
+        let outputMOV = directory.appendingPathComponent("IMG_0001.mov")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: motionJPEG.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: outputHEIC.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: outputMOV.path))
+        XCTAssertEqual(
+            SHA256.hash(data: try Data(contentsOf: motionJPEG)),
+            sourceDigest,
+            "Motion Photo convert must never modify the source JPEG"
+        )
+
+        let report = try await AppleLivePhotoValidator.validate(
+            imageURL: outputHEIC,
+            videoURL: outputMOV,
+            expectedStillImageTime: CMTime(value: 3, timescale: 30),
+            sourceVideoURL: sourceMP4,
+            sourceHadAudio: false,
+            sourceHadGainMap: false,
+            requirePhotoKitLoad: true
+        )
+        XCTAssertEqual(CMTimeCompare(report.stillImageTime, CMTime(value: 3, timescale: 30)), 0)
+    }
+
+    private func makeMotionPhoto(
+        cleanJPEG: URL,
+        video: Data,
+        presentationTimestampUs: Int64,
+        outputURL: URL
+    ) throws {
+        let original = try Data(contentsOf: cleanJPEG)
+        guard original.count >= 2, original[0] == 0xff, original[1] == 0xd8 else {
+            XCTFail("source fixture is not JPEG")
+            return
+        }
+        let xmp = """
+        <x:xmpmeta xmlns:x="adobe:ns:meta/">
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <rdf:Description xmlns:Camera="http://ns.google.com/photos/1.0/camera/"
+                             xmlns:Container="http://ns.google.com/photos/1.0/container/"
+                             xmlns:Item="http://ns.google.com/photos/1.0/container/item/"
+                             Camera:MotionPhoto="1"
+                             Camera:MotionPhotoVersion="1"
+                             Camera:MotionPhotoPresentationTimestampUs="\(presentationTimestampUs)">
+              <Container:Directory><rdf:Seq>
+                <rdf:li rdf:parseType="Resource"><Container:Item Item:Mime="image/jpeg" Item:Semantic="Primary" Item:Length="0" Item:Padding="0"/></rdf:li>
+                <rdf:li rdf:parseType="Resource"><Container:Item Item:Mime="video/mp4" Item:Semantic="MotionPhoto" Item:Length="\(video.count)" Item:Padding="0"/></rdf:li>
+              </rdf:Seq></Container:Directory>
+            </rdf:Description>
+          </rdf:RDF>
+        </x:xmpmeta>
+        """
+        var payload = Data("http://ns.adobe.com/xap/1.0/".utf8)
+        payload.append(0)
+        payload.append(Data(xmp.utf8))
+        let segmentLength = payload.count + 2
+        guard segmentLength <= Int(UInt16.max) else {
+            XCTFail("Motion Photo test XMP is too large")
+            return
+        }
+        var app1 = Data([0xff, 0xe1])
+        app1.append(UInt8((segmentLength >> 8) & 0xff))
+        app1.append(UInt8(segmentLength & 0xff))
+        app1.append(payload)
+
+        var output = Data(original.prefix(2))
+        output.append(app1)
+        output.append(original.dropFirst(2))
+        output.append(video)
+        try output.write(to: outputURL, options: .atomic)
+    }
+
+    private func createJPEG(at url: URL, width: Int, height: Int) throws {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ),
+        let destination = CGImageDestinationCreateWithURL(
+            url as CFURL,
+            UTType.jpeg.identifier as CFString,
+            1,
+            nil
+        ) else {
+            XCTFail("could not create JPEG fixture")
+            return
+        }
+        context.setFillColor(CGColor(red: 0.2, green: 0.4, blue: 0.6, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        guard let image = context.makeImage() else {
+            XCTFail("could not create JPEG image")
+            return
+        }
+        CGImageDestinationAddImage(destination, image, nil)
+        XCTAssertTrue(CGImageDestinationFinalize(destination))
+    }
+
+    private func createH264Video(
+        at url: URL,
+        width: Int,
+        height: Int,
+        frameCount: Int
+    ) async throws {
+        let writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
+        let input = AVAssetWriterInput(
+            mediaType: .video,
+            outputSettings: [
+                AVVideoCodecKey: AVVideoCodecType.h264,
+                AVVideoWidthKey: width,
+                AVVideoHeightKey: height,
+            ]
+        )
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA),
+                kCVPixelBufferWidthKey as String: width,
+                kCVPixelBufferHeightKey as String: height,
+            ]
+        )
+        guard writer.canAdd(input) else {
+            XCTFail("H.264 encoder unavailable")
+            return
+        }
+        writer.add(input)
+        guard writer.startWriting() else {
+            throw writer.error ?? AppleLivePhotoError.videoWriteFailed("test H.264 writer did not start")
+        }
+        writer.startSession(atSourceTime: .zero)
+        for index in 0..<frameCount {
+            while !input.isReadyForMoreMediaData {
+                try await Task.sleep(nanoseconds: 1_000_000)
+            }
+            var pixelBuffer: CVPixelBuffer?
+            let status = CVPixelBufferCreate(
+                kCFAllocatorDefault,
+                width,
+                height,
+                kCVPixelFormatType_32BGRA,
+                [kCVPixelBufferIOSurfacePropertiesKey as String: [:]] as CFDictionary,
+                &pixelBuffer
+            )
+            XCTAssertEqual(status, kCVReturnSuccess)
+            guard let pixelBuffer else {
+                XCTFail("could not allocate video pixel buffer")
+                return
+            }
+            CVPixelBufferLockBaseAddress(pixelBuffer, [])
+            if let base = CVPixelBufferGetBaseAddress(pixelBuffer) {
+                memset(base, Int32(48 + index), CVPixelBufferGetBytesPerRow(pixelBuffer) * height)
+            }
+            CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
+            XCTAssertTrue(
+                adaptor.append(
+                    pixelBuffer,
+                    withPresentationTime: CMTime(value: CMTimeValue(index), timescale: 30)
+                )
+            )
+        }
+        input.markAsFinished()
+        await writer.finishWriting()
+        guard writer.status == .completed else {
+            throw writer.error ?? AppleLivePhotoError.videoWriteFailed("test H.264 writer failed")
+        }
+    }
+}

--- a/Tests/XDRemuxCoreTests/HEIFMotionPhotoParserTests.swift
+++ b/Tests/XDRemuxCoreTests/HEIFMotionPhotoParserTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import XCTest
+@testable import XDRemuxCore
+
+final class HEIFMotionPhotoParserTests: XCTestCase {
+    func testHEIFMotionPhotoExtractsOnlyMPVDPayloadWithTrailingVendorBox() throws {
+        let videoPayload = fakeMP4Payload()
+        let trailingSEFD = bmffBox(type: "sefd", payload: Data(repeating: 0x5a, count: 24))
+        let xmp = xmpPacket(
+            primaryPadding: 8,
+            motionLength: Int64(videoPayload.count + trailingSEFD.count),
+            timestampUs: 1_540_401
+        )
+        let prefix = bmffBox(type: "ftyp", payload: Data("heic\0\0\0\0heicmif1".utf8))
+            + bmffBox(type: "free", payload: Data(xmp.utf8))
+        let mpvdOffset = Int64(prefix.count)
+        let mpvd = bmffBox(type: "mpvd", payload: videoPayload)
+        let payloadStart = mpvdOffset + 8
+        let payloadEnd = payloadStart + Int64(videoPayload.count)
+        let data = prefix + mpvd + trailingSEFD
+        let url = try writeTemporary(data, extension: "heic")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let asset = try XCTUnwrap(AndroidMotionPhotoParser.parse(url: url))
+        XCTAssertEqual(asset.sourceKind, .androidHeifMotionPhotoV1)
+        XCTAssertEqual(asset.presentationTimestampUs, 1_540_401)
+        XCTAssertEqual(asset.stillResourceRange.lowerBound, 0)
+        XCTAssertEqual(asset.stillResourceRange.upperBound, mpvdOffset)
+        XCTAssertEqual(asset.videoResourceRange.lowerBound, payloadStart)
+        XCTAssertEqual(asset.videoResourceRange.upperBound, payloadEnd)
+        XCTAssertLessThan(asset.videoResourceRange.upperBound, Int64(data.count))
+    }
+
+    func testHEIFMotionPhotoRejectsNonEightBytePrimaryPadding() throws {
+        let videoPayload = fakeMP4Payload()
+        let xmp = xmpPacket(
+            primaryPadding: 0,
+            motionLength: Int64(videoPayload.count),
+            timestampUs: 1_000_000
+        )
+        let prefix = bmffBox(type: "ftyp", payload: Data("heic\0\0\0\0heicmif1".utf8))
+            + bmffBox(type: "free", payload: Data(xmp.utf8))
+        let data = prefix + bmffBox(type: "mpvd", payload: videoPayload)
+        let url = try writeTemporary(data, extension: "heic")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertThrowsError(try AndroidMotionPhotoParser.parse(url: url)) { error in
+            XCTAssertEqual(error as? MotionPhotoParsingError, .invalidItemLength)
+        }
+    }
+
+    func testHEIFMotionPhotoRejectsDirectoryStartThatDoesNotMatchMPVDPayload() throws {
+        let videoPayload = fakeMP4Payload()
+        let xmp = xmpPacket(
+            primaryPadding: 8,
+            motionLength: Int64(videoPayload.count - 1),
+            timestampUs: 1_000_000
+        )
+        let prefix = bmffBox(type: "ftyp", payload: Data("heic\0\0\0\0heicmif1".utf8))
+            + bmffBox(type: "free", payload: Data(xmp.utf8))
+        let data = prefix + bmffBox(type: "mpvd", payload: videoPayload)
+        let url = try writeTemporary(data, extension: "heic")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertThrowsError(try AndroidMotionPhotoParser.parse(url: url)) { error in
+            XCTAssertEqual(error as? MotionPhotoParsingError, .invalidByteRange)
+        }
+    }
+
+    private func xmpPacket(
+        primaryPadding: Int64,
+        motionLength: Int64,
+        timestampUs: Int64
+    ) -> String {
+        """
+        <x:xmpmeta xmlns:x="adobe:ns:meta/">
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <rdf:Description xmlns:GCamera="http://ns.google.com/photos/1.0/camera/"
+                             xmlns:GContainer="http://ns.google.com/photos/1.0/container/"
+                             xmlns:GContainerItem="http://ns.google.com/photos/1.0/container/item/"
+                             GCamera:MotionPhoto="1"
+                             GCamera:MotionPhotoVersion="1"
+                             GCamera:MotionPhotoPresentationTimestampUs="\(timestampUs)">
+              <GContainer:Directory><rdf:Seq>
+                <rdf:li rdf:parseType="Resource"><GContainer:Item GContainerItem:Mime="image/heic" GContainerItem:Semantic="Primary" GContainerItem:Length="0" GContainerItem:Padding="\(primaryPadding)"/></rdf:li>
+                <rdf:li rdf:parseType="Resource"><GContainer:Item GContainerItem:Mime="image/heic" GContainerItem:Semantic="GainMap" GContainerItem:Length="0" GContainerItem:Padding="0"/></rdf:li>
+                <rdf:li rdf:parseType="Resource"><GContainer:Item GContainerItem:Mime="video/mp4" GContainerItem:Semantic="MotionPhoto" GContainerItem:Length="\(motionLength)" GContainerItem:Padding="0"/></rdf:li>
+              </rdf:Seq></GContainer:Directory>
+            </rdf:Description>
+          </rdf:RDF>
+        </x:xmpmeta>
+        """
+    }
+
+    private func fakeMP4Payload() -> Data {
+        bmffBox(type: "ftyp", payload: Data("isom\0\0\0\0isommp42".utf8))
+            + bmffBox(type: "mdat", payload: Data(repeating: 0x11, count: 16))
+    }
+
+    private func bmffBox(type: String, payload: Data) -> Data {
+        precondition(type.utf8.count == 4)
+        let size = UInt32(8 + payload.count)
+        var data = Data([
+            UInt8((size >> 24) & 0xff),
+            UInt8((size >> 16) & 0xff),
+            UInt8((size >> 8) & 0xff),
+            UInt8(size & 0xff),
+        ])
+        data.append(Data(type.utf8))
+        data.append(payload)
+        return data
+    }
+
+    private func writeTemporary(_ data: Data, extension ext: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-heif-motion-\(UUID().uuidString).\(ext)")
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+}

--- a/Tests/XDRemuxCoreTests/MotionPhotoNamespaceTests.swift
+++ b/Tests/XDRemuxCoreTests/MotionPhotoNamespaceTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import XCTest
+@testable import XDRemuxCore
+
+final class MotionPhotoNamespaceTests: XCTestCase {
+    func testParsesGContainerMotionPhotoV1() throws {
+        let video = fakeMP4()
+        let xmp = """
+        <x:xmpmeta xmlns:x="adobe:ns:meta/">
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <rdf:Description xmlns:GCamera="http://ns.google.com/photos/1.0/camera/"
+                             xmlns:GContainer="http://ns.google.com/photos/1.0/container/"
+                             xmlns:GContainerItem="http://ns.google.com/photos/1.0/container/item/"
+                             GCamera:MotionPhoto="1"
+                             GCamera:MotionPhotoVersion="1"
+                             GCamera:MotionPhotoPresentationTimestampUs="500000">
+              <GContainer:Directory><rdf:Seq>
+                <rdf:li rdf:parseType="Resource"><GContainer:Item GContainerItem:Mime="image/jpeg" GContainerItem:Semantic="Primary" GContainerItem:Length="0" GContainerItem:Padding="0"/></rdf:li>
+                <rdf:li rdf:parseType="Resource"><GContainer:Item GContainerItem:Mime="video/mp4" GContainerItem:Semantic="MotionPhoto" GContainerItem:Length="\(video.count)" GContainerItem:Padding="0"/></rdf:li>
+              </rdf:Seq></GContainer:Directory>
+            </rdf:Description>
+          </rdf:RDF>
+        </x:xmpmeta>
+        """
+        let still = Data([0xFF, 0xD8]) + Data(xmp.utf8) + Data([0xFF, 0xD9])
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-gcontainer-\(UUID().uuidString).jpg")
+        try (still + video).write(to: url, options: .atomic)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let asset = try XCTUnwrap(AndroidMotionPhotoParser.parse(url: url))
+        XCTAssertEqual(asset.sourceKind, .androidMotionPhotoV1)
+        XCTAssertEqual(asset.presentationTimestampUs, 500_000)
+        XCTAssertEqual(asset.videoResourceRange.lowerBound, Int64(still.count))
+    }
+
+    private func fakeMP4() -> Data {
+        var data = Data([0, 0, 0, 16])
+        data.append(Data("ftypisom".utf8))
+        data.append(contentsOf: [0, 0, 2, 0])
+        data.append(contentsOf: [0, 0, 0, 8])
+        data.append(Data("mdat".utf8))
+        return data
+    }
+}

--- a/Tests/XDRemuxCoreTests/MotionPhotoParserTests.swift
+++ b/Tests/XDRemuxCoreTests/MotionPhotoParserTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import XCTest
+@testable import XDRemuxCore
+
+final class MotionPhotoParserTests: XCTestCase {
+    func testParsesAndroidMotionPhotoV1Directory() throws {
+        let video = fakeMP4()
+        let xmp = motionPhotoXMP(videoLength: video.count, timestampUs: 1_417_000)
+        let still = Data([0xFF, 0xD8]) + Data(xmp.utf8) + Data([0xFF, 0xD9])
+        let url = try writeTemporary(still + video)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let asset = try XCTUnwrap(AndroidMotionPhotoParser.parse(url: url))
+        XCTAssertEqual(asset.sourceKind, .androidMotionPhotoV1)
+        XCTAssertEqual(asset.presentationTimestampUs, 1_417_000)
+        XCTAssertEqual(asset.presentationSource, .androidXMP)
+        XCTAssertEqual(asset.stillResourceRange.lowerBound, 0)
+        XCTAssertEqual(asset.stillResourceRange.upperBound, Int64(still.count))
+        XCTAssertEqual(asset.videoResourceRange.lowerBound, Int64(still.count))
+        XCTAssertEqual(asset.videoResourceRange.upperBound, Int64(still.count + video.count))
+        XCTAssertEqual(asset.items.map(\.semantic), ["Primary", "MotionPhoto"])
+    }
+
+    func testParsesLegacyMicroVideoOffsetIntoNormalizedModel() throws {
+        let video = fakeMP4()
+        let xmp = legacyMicroVideoXMP(videoLength: video.count, timestampUs: 900_000)
+        let still = Data([0xFF, 0xD8]) + Data(xmp.utf8) + Data([0xFF, 0xD9])
+        let url = try writeTemporary(still + video)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let asset = try XCTUnwrap(AndroidMotionPhotoParser.parse(url: url))
+        XCTAssertEqual(asset.sourceKind, .legacyMicroVideoV1b)
+        XCTAssertEqual(asset.presentationTimestampUs, 900_000)
+        XCTAssertEqual(asset.presentationSource, .legacyMicroVideoXMP)
+        XCTAssertEqual(asset.videoResourceRange.length, Int64(video.count))
+    }
+
+    func testKeepsZeroLengthGainMapInsidePrimaryStaticResource() throws {
+        let video = fakeMP4()
+        let xmp = motionPhotoXMP(videoLength: video.count, timestampUs: nil, includeGainMap: true)
+        let still = Data([0xFF, 0xD8]) + Data(xmp.utf8) + Data([0xFF, 0xD9]) + Data(repeating: 0xAB, count: 64)
+        let url = try writeTemporary(still + video)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let asset = try XCTUnwrap(AndroidMotionPhotoParser.parse(url: url))
+        XCTAssertEqual(asset.items.map(\.semantic), ["Primary", "GainMap", "MotionPhoto"])
+        XCTAssertEqual(asset.stillResourceRange.upperBound, Int64(still.count))
+        XCTAssertNil(asset.presentationTimestampUs)
+    }
+
+    func testRejectsMissingVersionForMotionPhotoV1() throws {
+        let video = fakeMP4()
+        let xmp = motionPhotoXMP(videoLength: video.count, timestampUs: nil, version: nil)
+        let url = try writeTemporary(Data([0xFF, 0xD8]) + Data(xmp.utf8) + Data([0xFF, 0xD9]) + video)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertThrowsError(try AndroidMotionPhotoParser.parse(url: url)) { error in
+            XCTAssertEqual(error as? MotionPhotoParsingError, .unsupportedVersion(nil))
+        }
+    }
+
+    func testRejectsStaleMotionPhotoXMPWithoutVideoPayload() throws {
+        let xmp = motionPhotoXMP(videoLength: 32, timestampUs: nil)
+        let url = try writeTemporary(Data([0xFF, 0xD8]) + Data(xmp.utf8) + Data([0xFF, 0xD9]) + Data(repeating: 0, count: 32))
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertThrowsError(try AndroidMotionPhotoParser.parse(url: url)) { error in
+            XCTAssertEqual(error as? MotionPhotoParsingError, .invalidVideoPayload)
+        }
+    }
+
+    func testRejectsMotionPhotoItemThatIsNotLast() throws {
+        let video = fakeMP4()
+        let xmp = motionPhotoXMP(videoLength: video.count, timestampUs: nil, trailingAuxItem: true)
+        let url = try writeTemporary(Data([0xFF, 0xD8]) + Data(xmp.utf8) + Data([0xFF, 0xD9]) + video)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertThrowsError(try AndroidMotionPhotoParser.parse(url: url)) { error in
+            XCTAssertEqual(error as? MotionPhotoParsingError, .invalidMotionPhotoItem)
+        }
+    }
+
+    func testRejectsOversizedDeclaredVideoLengthWithoutOverflow() throws {
+        let video = fakeMP4()
+        let xmp = motionPhotoXMP(videoLengthLiteral: String(Int64.max), timestampUs: nil)
+        let url = try writeTemporary(Data([0xFF, 0xD8]) + Data(xmp.utf8) + Data([0xFF, 0xD9]) + video)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertThrowsError(try AndroidMotionPhotoParser.parse(url: url)) { error in
+            XCTAssertTrue(
+                error as? MotionPhotoParsingError == .arithmeticOverflow
+                    || error as? MotionPhotoParsingError == .invalidByteRange
+            )
+        }
+    }
+
+    private func fakeMP4() -> Data {
+        var data = Data()
+        data.append(contentsOf: [0x00, 0x00, 0x00, 0x10])
+        data.append(Data("ftyp".utf8))
+        data.append(Data("isom".utf8))
+        data.append(contentsOf: [0x00, 0x00, 0x02, 0x00])
+        data.append(contentsOf: [0x00, 0x00, 0x00, 0x08])
+        data.append(Data("mdat".utf8))
+        return data
+    }
+
+    private func writeTemporary(_ data: Data) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-motion-photo-\(UUID().uuidString).jpg")
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+
+    private func motionPhotoXMP(
+        videoLength: Int,
+        timestampUs: Int64?,
+        version: Int? = 1,
+        includeGainMap: Bool = false,
+        trailingAuxItem: Bool = false
+    ) -> String {
+        motionPhotoXMP(
+            videoLengthLiteral: String(videoLength),
+            timestampUs: timestampUs,
+            version: version,
+            includeGainMap: includeGainMap,
+            trailingAuxItem: trailingAuxItem
+        )
+    }
+
+    private func motionPhotoXMP(
+        videoLengthLiteral: String,
+        timestampUs: Int64?,
+        version: Int? = 1,
+        includeGainMap: Bool = false,
+        trailingAuxItem: Bool = false
+    ) -> String {
+        let versionAttribute = version.map { " Camera:MotionPhotoVersion=\"\($0)\"" } ?? ""
+        let timestampAttribute = timestampUs.map { " Camera:MotionPhotoPresentationTimestampUs=\"\($0)\"" } ?? ""
+        let gainMap = includeGainMap
+            ? "<rdf:li rdf:parseType=\"Resource\"><Container:Item Item:Mime=\"image/jpeg\" Item:Semantic=\"GainMap\" Item:Length=\"0\" Item:Padding=\"0\"/></rdf:li>"
+            : ""
+        let trailing = trailingAuxItem
+            ? "<rdf:li rdf:parseType=\"Resource\"><Container:Item Item:Mime=\"application/octet-stream\" Item:Semantic=\"Auxiliary\" Item:Length=\"0\" Item:Padding=\"0\"/></rdf:li>"
+            : ""
+        return """
+        <x:xmpmeta xmlns:x="adobe:ns:meta/">
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <rdf:Description xmlns:Camera="http://ns.google.com/photos/1.0/camera/" xmlns:Container="http://ns.google.com/photos/1.0/container/" xmlns:Item="http://ns.google.com/photos/1.0/container/item/" Camera:MotionPhoto="1"\(versionAttribute)\(timestampAttribute)>
+              <Container:Directory><rdf:Seq>
+                <rdf:li rdf:parseType="Resource"><Container:Item Item:Mime="image/jpeg" Item:Semantic="Primary" Item:Length="0" Item:Padding="0"/></rdf:li>
+                \(gainMap)
+                <rdf:li rdf:parseType="Resource"><Container:Item Item:Mime="video/mp4" Item:Semantic="MotionPhoto" Item:Length="\(videoLengthLiteral)" Item:Padding="0"/></rdf:li>
+                \(trailing)
+              </rdf:Seq></Container:Directory>
+            </rdf:Description>
+          </rdf:RDF>
+        </x:xmpmeta>
+        """
+    }
+
+    private func legacyMicroVideoXMP(videoLength: Int, timestampUs: Int64) -> String {
+        """
+        <x:xmpmeta xmlns:x="adobe:ns:meta/">
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <rdf:Description xmlns:GCamera="http://ns.google.com/photos/1.0/camera/" GCamera:MicroVideo="1" GCamera:MicroVideoOffset="\(videoLength)" GCamera:MicroVideoPresentationTimestampUs="\(timestampUs)"/>
+          </rdf:RDF>
+        </x:xmpmeta>
+        """
+    }
+}

--- a/Tests/XDRemuxCoreTests/MotionPhotoParserTests.swift
+++ b/Tests/XDRemuxCoreTests/MotionPhotoParserTests.swift
@@ -35,16 +35,24 @@ final class MotionPhotoParserTests: XCTestCase {
         XCTAssertEqual(asset.videoResourceRange.length, Int64(video.count))
     }
 
-    func testKeepsZeroLengthGainMapInsidePrimaryStaticResource() throws {
+    func testKeepsPositiveLengthUltraHDRGainMapInsideStaticResource() throws {
         let video = fakeMP4()
-        let xmp = motionPhotoXMP(videoLength: video.count, timestampUs: nil, includeGainMap: true)
-        let still = Data([0xFF, 0xD8]) + Data(xmp.utf8) + Data([0xFF, 0xD9]) + Data(repeating: 0xAB, count: 64)
-        let url = try writeTemporary(still + video)
+        let gainMap = Data(repeating: 0xAB, count: 64)
+        let xmp = motionPhotoXMP(
+            videoLength: video.count,
+            timestampUs: nil,
+            gainMapLength: gainMap.count
+        )
+        let primaryJPEG = Data([0xFF, 0xD8]) + Data(xmp.utf8) + Data([0xFF, 0xD9])
+        let stillContainer = primaryJPEG + gainMap
+        let url = try writeTemporary(stillContainer + video)
         defer { try? FileManager.default.removeItem(at: url) }
 
         let asset = try XCTUnwrap(AndroidMotionPhotoParser.parse(url: url))
         XCTAssertEqual(asset.items.map(\.semantic), ["Primary", "GainMap", "MotionPhoto"])
-        XCTAssertEqual(asset.stillResourceRange.upperBound, Int64(still.count))
+        XCTAssertEqual(asset.items[1].length, Int64(gainMap.count))
+        XCTAssertEqual(asset.stillResourceRange.upperBound, Int64(stillContainer.count))
+        XCTAssertEqual(asset.videoResourceRange.lowerBound, Int64(stillContainer.count))
         XCTAssertNil(asset.presentationTimestampUs)
     }
 
@@ -116,14 +124,14 @@ final class MotionPhotoParserTests: XCTestCase {
         videoLength: Int,
         timestampUs: Int64?,
         version: Int? = 1,
-        includeGainMap: Bool = false,
+        gainMapLength: Int? = nil,
         trailingAuxItem: Bool = false
     ) -> String {
         motionPhotoXMP(
             videoLengthLiteral: String(videoLength),
             timestampUs: timestampUs,
             version: version,
-            includeGainMap: includeGainMap,
+            gainMapLength: gainMapLength,
             trailingAuxItem: trailingAuxItem
         )
     }
@@ -132,14 +140,14 @@ final class MotionPhotoParserTests: XCTestCase {
         videoLengthLiteral: String,
         timestampUs: Int64?,
         version: Int? = 1,
-        includeGainMap: Bool = false,
+        gainMapLength: Int? = nil,
         trailingAuxItem: Bool = false
     ) -> String {
         let versionAttribute = version.map { " Camera:MotionPhotoVersion=\"\($0)\"" } ?? ""
         let timestampAttribute = timestampUs.map { " Camera:MotionPhotoPresentationTimestampUs=\"\($0)\"" } ?? ""
-        let gainMap = includeGainMap
-            ? "<rdf:li rdf:parseType=\"Resource\"><Container:Item Item:Mime=\"image/jpeg\" Item:Semantic=\"GainMap\" Item:Length=\"0\" Item:Padding=\"0\"/></rdf:li>"
-            : ""
+        let gainMap = gainMapLength.map {
+            "<rdf:li rdf:parseType=\"Resource\"><Container:Item Item:Mime=\"image/jpeg\" Item:Semantic=\"GainMap\" Item:Length=\"\($0)\" Item:Padding=\"0\"/></rdf:li>"
+        } ?? ""
         let trailing = trailingAuxItem
             ? "<rdf:li rdf:parseType=\"Resource\"><Container:Item Item:Mime=\"application/octet-stream\" Item:Semantic=\"Auxiliary\" Item:Length=\"0\" Item:Padding=\"0\"/></rdf:li>"
             : ""

--- a/Tests/XDRemuxCoreTests/MotionPhotoSecurityTests.swift
+++ b/Tests/XDRemuxCoreTests/MotionPhotoSecurityTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import XCTest
+@testable import XDRemuxCore
+
+final class MotionPhotoSecurityTests: XCTestCase {
+    func testRejectsDTDAndEntityDeclarations() throws {
+        let video = fakeMP4()
+        let xmp = """
+        <x:xmpmeta xmlns:x="adobe:ns:meta/">
+          <!DOCTYPE rdf:RDF [<!ENTITY injected "MotionPhoto">]>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <rdf:Description xmlns:Camera="http://ns.google.com/photos/1.0/camera/"
+                             xmlns:Container="http://ns.google.com/photos/1.0/container/"
+                             xmlns:Item="http://ns.google.com/photos/1.0/container/item/"
+                             Camera:MotionPhoto="1" Camera:MotionPhotoVersion="1">
+              <Container:Directory><rdf:Seq>
+                <rdf:li rdf:parseType="Resource"><Container:Item Item:Mime="image/jpeg" Item:Semantic="Primary" Item:Length="0" Item:Padding="0"/></rdf:li>
+                <rdf:li rdf:parseType="Resource"><Container:Item Item:Mime="video/mp4" Item:Semantic="&injected;" Item:Length="\(video.count)" Item:Padding="0"/></rdf:li>
+              </rdf:Seq></Container:Directory>
+            </rdf:Description>
+          </rdf:RDF>
+        </x:xmpmeta>
+        """
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-motion-dtd-\(UUID().uuidString).jpg")
+        let jpeg = Data([0xff, 0xd8]) + Data(xmp.utf8) + Data([0xff, 0xd9])
+        try (jpeg + video).write(to: url, options: .atomic)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertThrowsError(try AndroidMotionPhotoParser.parse(url: url)) { error in
+            XCTAssertEqual(error as? MotionPhotoParsingError, .malformedXMP)
+        }
+    }
+
+    private func fakeMP4() -> Data {
+        var data = Data([0, 0, 0, 16])
+        data.append(Data("ftypisom".utf8))
+        data.append(contentsOf: [0, 0, 2, 0])
+        data.append(contentsOf: [0, 0, 0, 8])
+        data.append(Data("mdat".utf8))
+        return data
+    }
+}

--- a/Tests/XDRemuxCoreTests/OppoDualStreamMotionPhotoTests.swift
+++ b/Tests/XDRemuxCoreTests/OppoDualStreamMotionPhotoTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import XDRemuxCore
 
 final class OppoDualStreamMotionPhotoTests: XCTestCase {
-    func testColorOS16VideoLengthMayPointToStream2ButParserKeepsBothStreams() throws {
+    func testColorOS16VideoLengthMayPointToStream2ButFallbackKeepsBothStreams() throws {
         let stream1 = fakeMP4(brand: "isom", payloadByte: 0x11)
         let stream2 = fakeMP4(brand: "mp42", payloadByte: 0x22)
         let xmp = """
@@ -25,15 +25,76 @@ final class OppoDualStreamMotionPhotoTests: XCTestCase {
         let url = try writeTemporary(still + stream1 + stream2)
         defer { try? FileManager.default.removeItem(at: url) }
 
+        try assertDualStreamAsset(
+            url: url,
+            stream1Start: stream1Start,
+            stream2Start: stream2Start,
+            expectedTimestamp: 1_634_640
+        )
+    }
+
+    func testColorOS16LpexOverridesStandardDirectoryThatDescribesOnlyFinalStream() throws {
+        let stream1 = fakeMP4(brand: "isom", payloadByte: 0x33)
+        let stream2 = fakeMP4(brand: "mp42", payloadByte: 0x44)
+        let xmp = """
+        <x:xmpmeta xmlns:x="adobe:ns:meta/">
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <rdf:Description xmlns:Camera="http://ns.google.com/photos/1.0/camera/"
+                             xmlns:Container="http://ns.google.com/photos/1.0/container/"
+                             xmlns:Item="http://ns.google.com/photos/1.0/container/item/"
+                             Camera:MotionPhoto="1"
+                             Camera:MotionPhotoVersion="1"
+                             Camera:MotionPhotoPresentationTimestampUs="1634640">
+              <Container:Directory><rdf:Seq>
+                <rdf:li rdf:parseType="Resource"><Container:Item Item:Mime="image/jpeg" Item:Semantic="Primary" Item:Length="0" Item:Padding="0"/></rdf:li>
+                <rdf:li rdf:parseType="Resource"><Container:Item Item:Mime="video/mp4" Item:Semantic="MotionPhoto" Item:Length="\(stream2.count)" Item:Padding="0"/></rdf:li>
+              </rdf:Seq></Container:Directory>
+            </rdf:Description>
+          </rdf:RDF>
+        </x:xmpmeta>
+        """
+        let lpex = """
+        lpexLivePhotoExtension {"version":1,"coverFramePts":1666666,"matrixCount":0,"videoSize":[1920,1080]}
+        """
+        let still = Data([0xff, 0xd8]) + Data(xmp.utf8) + Data(lpex.utf8) + Data([0xff, 0xd9])
+        let stream1Start = Int64(still.count)
+        let stream2Start = stream1Start + Int64(stream1.count)
+        let url = try writeTemporary(still + stream1 + stream2)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        // The generic Android parser necessarily interprets bytes before Stream 2 as part of the
+        // static resource because the standard directory only declares the final stream.
+        let generic = try XCTUnwrap(AndroidMotionPhotoParser.parse(url: url))
+        XCTAssertEqual(generic.videoResourceRange.lowerBound, stream2Start)
+        XCTAssertEqual(generic.stillResourceRange.upperBound, stream2Start)
+
+        // The OPPO vendor layer must correct that topology before ImageIO sees the still resource.
+        try assertDualStreamAsset(
+            url: url,
+            stream1Start: stream1Start,
+            stream2Start: stream2Start,
+            expectedTimestamp: 1_634_640
+        )
+    }
+
+    private func assertDualStreamAsset(
+        url: URL,
+        stream1Start: Int64,
+        stream2Start: Int64,
+        expectedTimestamp: Int64
+    ) throws {
         let asset = try XCTUnwrap(OppoMotionPhotoParser.parse(url: url))
         XCTAssertEqual(asset.sourceKind, .oppoLivePhoto)
-        XCTAssertEqual(asset.presentationTimestampUs, 1_634_640)
+        XCTAssertEqual(asset.presentationTimestampUs, expectedTimestamp)
         XCTAssertEqual(asset.presentationSource, .androidXMP)
         XCTAssertEqual(asset.vendorMetadata?.coverFramePtsUs, 1_666_666)
         XCTAssertEqual(asset.vendorMetadata?.streamCount, 2)
         XCTAssertEqual(asset.stillResourceRange.upperBound, stream1Start)
         XCTAssertEqual(asset.videoResourceRange.lowerBound, stream1Start)
-        XCTAssertEqual(asset.videoResourceRange.upperBound, Int64(still.count + stream1.count + stream2.count))
+        XCTAssertEqual(
+            asset.videoResourceRange.upperBound,
+            Int64((try? Data(contentsOf: url).count) ?? 0)
+        )
 
         let primary = try OppoMotionPhotoStreamResolver.primaryVideoRange(for: asset)
         XCTAssertEqual(primary.lowerBound, stream1Start)

--- a/Tests/XDRemuxCoreTests/OppoDualStreamMotionPhotoTests.swift
+++ b/Tests/XDRemuxCoreTests/OppoDualStreamMotionPhotoTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import XCTest
+@testable import XDRemuxCore
+
+final class OppoDualStreamMotionPhotoTests: XCTestCase {
+    func testColorOS16VideoLengthMayPointToStream2ButParserKeepsBothStreams() throws {
+        let stream1 = fakeMP4(brand: "isom", payloadByte: 0x11)
+        let stream2 = fakeMP4(brand: "mp42", payloadByte: 0x22)
+        let xmp = """
+        <x:xmpmeta xmlns:x="adobe:ns:meta/">
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <rdf:Description xmlns:OpCamera="http://ns.oppo.com/photos/1.0/camera/"
+                             OpCamera:VideoLength="\(stream2.count)"
+                             GCamera:MotionPhotoPresentationTimestampUs="1634640"
+                             xmlns:GCamera="http://ns.google.com/photos/1.0/camera/"/>
+          </rdf:RDF>
+        </x:xmpmeta>
+        """
+        let lpex = """
+        lpexLivePhotoExtension {"version":1,"coverFramePts":1666666,"matrixCount":0,"videoSize":[1920,1080]}
+        """
+        let still = Data([0xff, 0xd8]) + Data(xmp.utf8) + Data(lpex.utf8) + Data([0xff, 0xd9])
+        let stream1Start = Int64(still.count)
+        let stream2Start = stream1Start + Int64(stream1.count)
+        let url = try writeTemporary(still + stream1 + stream2)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let asset = try XCTUnwrap(OppoMotionPhotoParser.parse(url: url))
+        XCTAssertEqual(asset.sourceKind, .oppoLivePhoto)
+        XCTAssertEqual(asset.presentationTimestampUs, 1_634_640)
+        XCTAssertEqual(asset.presentationSource, .androidXMP)
+        XCTAssertEqual(asset.vendorMetadata?.coverFramePtsUs, 1_666_666)
+        XCTAssertEqual(asset.vendorMetadata?.streamCount, 2)
+        XCTAssertEqual(asset.stillResourceRange.upperBound, stream1Start)
+        XCTAssertEqual(asset.videoResourceRange.lowerBound, stream1Start)
+        XCTAssertEqual(asset.videoResourceRange.upperBound, Int64(still.count + stream1.count + stream2.count))
+
+        let primary = try OppoMotionPhotoStreamResolver.primaryVideoRange(for: asset)
+        XCTAssertEqual(primary.lowerBound, stream1Start)
+        XCTAssertEqual(primary.upperBound, stream2Start)
+    }
+
+    private func fakeMP4(brand: String, payloadByte: UInt8) -> Data {
+        precondition(brand.utf8.count == 4)
+        var data = Data([0, 0, 0, 16])
+        data.append(Data("ftyp".utf8))
+        data.append(Data(brand.utf8))
+        data.append(contentsOf: [0, 0, 0, 0])
+        data.append(contentsOf: [0, 0, 0, 12])
+        data.append(Data("mdat".utf8))
+        data.append(contentsOf: [payloadByte, payloadByte, payloadByte, payloadByte])
+        return data
+    }
+
+    private func writeTemporary(_ data: Data) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-oppo-dual-\(UUID().uuidString).jpg")
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+}

--- a/Tests/XDRemuxCoreTests/OppoMotionPhotoMetadataTests.swift
+++ b/Tests/XDRemuxCoreTests/OppoMotionPhotoMetadataTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import XCTest
+@testable import XDRemuxCore
+
+final class OppoMotionPhotoMetadataTests: XCTestCase {
+    func testParsesLpexTransformFields() throws {
+        let json = """
+        {"version":1,"matrixCount":2,"coverFramePts":1433000,
+         "photoCropMatrix":[1,0,0,0,1,0,0,0,1],
+         "photoEisMatrix":[1,0,0,0,1,0,0,0,1],
+         "matrices":{"1433000":[1,0,0,0,1,0,0,0,1]},
+         "videoSize":[1728,1296],"originPhotoSize":[4096,3072],
+         "photoCropFactor":0.9,"eisCropFactor":[0.9,0.9]}
+        """
+        let payload = Data("prefix lpexLivePhotoExtension \(json) suffix".utf8)
+        let metadata = try XCTUnwrap(OppoLpexParser.parseFirstObject(in: payload))
+        XCTAssertEqual(metadata.version, 1)
+        XCTAssertEqual(metadata.matrixCount, 2)
+        XCTAssertEqual(metadata.coverFramePtsUs, 1_433_000)
+        XCTAssertEqual(metadata.photoCropMatrix?.count, 9)
+        XCTAssertEqual(metadata.photoEisMatrix?.count, 9)
+        XCTAssertEqual(metadata.videoWidth, 1728)
+        XCTAssertEqual(metadata.videoHeight, 1296)
+        XCTAssertEqual(metadata.originPhotoWidth, 4096)
+        XCTAssertEqual(metadata.originPhotoHeight, 3072)
+        XCTAssertEqual(metadata.photoCropFactor, 0.9)
+    }
+
+    func testRejectsNonFiniteMatrix() throws {
+        let json = """
+        {"version":1,"coverFramePts":1000,
+         "photoCropMatrix":["nan",0,0,0,1,0,0,0,1]}
+        """
+        let payload = Data("lpexLivePhotoExtension \(json)".utf8)
+        let metadata = try XCTUnwrap(OppoLpexParser.parseFirstObject(in: payload))
+        XCTAssertNil(metadata.photoCropMatrix)
+    }
+}


### PR DESCRIPTION
## Scope

Implements Android Motion Photo / OPPO Live Photo → Apple Live Photo resource pairs (`.heic` still + `.mov` paired video) without changing the existing ProXDR / ISO HDR / OPPO-compatible / Portrait / Photographic Styles conversion core.

The supplied real-fixture gate is now green on GitHub's `macos-26-arm64` runner, and the ordinary XDRemux CI + policy checks are also green on the current head.

## Real sample coverage

The supplied archives contain 14 files:

- OPPO ColorOS 15: 3 JPEG Live Photos
- OPPO ColorOS 16: 2 JPEG Live Photos, both dual-BMFF-stream inputs
- Samsung: 2 JPEG Motion Photos + 4 HEIC Motion Photos (two duplicate pairs)
- Xiaomi: 1 JPEG Motion Photo
- vivo: 2 JPEG Motion Photos

Every file in the first archive contains Ultra HDR gain-map metadata. The two vivo samples are standard SDR Motion Photos.

The real samples exposed and now lock down several format details:

- Samsung JPEG Motion Photos can contain an earlier BMFF-looking vendor region inside the static resource; semantic `Container:Directory` ranges select the real MotionPhoto payload.
- Samsung HEIC Motion Photo V1 stores video in top-level `mpvd`; the declared MotionPhoto length may also cover trailing Samsung `sefd`, so only `mpvd` payload becomes the Apple MOV.
- Xiaomi uses a positive-length Ultra HDR `GainMap` resource before the trailing MotionPhoto video.
- ColorOS 16 uses two concatenated BMFF streams; Stream 1 is selected for the Apple paired video.
- OPPO/Samsung/Xiaomi/vivo samples cover HEVC variants and AAC layouts; compressed media payloads are verified byte-for-byte across MP4 → MOV remux.

Exact fixture SHA-256 values, byte ranges, presentation timestamps, stream counts and expected gain-map state are locked in `UploadedMotionPhotoFixtureGateTests`.

## Architecture

### `XDRemuxCore/MotionPhoto`

- normalized `MotionPhotoAsset` / item / checked byte-range model
- Android Motion Photo V1 parser (`Camera`/`GCamera`, `Container`/`GContainer`)
- legacy MicroVideo V1b compatibility
- JPEG + HEIC/HEIF Motion Photo inputs
- HEIF top-level `mpvd` parser with Samsung trailing-`sefd` handling
- strict directory/range/EOF validation and bounded BMFF scanning
- positive-length Ultra HDR GainMap resources remain inside the still resource passed to ImageIO
- bounded `FileHandle` payload extraction
- DTD/entity rejection, checked integer arithmetic and parser limits
- OPPO LPEX parser + ColorOS 15/16 vendor extension
- ColorOS 16 dual-stream topology correction and Stream 1 selection

### `XDRemuxAppleFeatures/LivePhoto`

- ImageIO HEIC still writer with `kCGImageDestinationPreserveGainMap = true`
- stale Android Motion Photo XMP excluded while EXIF/TIFF/etc. metadata is preserved
- Apple MakerNote key 17 shared identifier
- compressed video/audio passthrough into MOV; no silent H.264 fallback
- canonical QuickTime content identifier + exactly one `still-image-time` timed metadata sample
- OPPO Live Photo transform/reference-dimension metadata
- source timeline resolver using actual sample PTS
- still-image-time validation at the actual MOV metadata timebase precision
- pair validator checks identifier, still time, audio, gain-map state, geometry/orientation, transform metadata and PhotoKit loadability
- compressed passthrough validator hashes encoded sample storage ranges before/after remux
- transactional HEIC+MOV commit with rollback

### CLI / batch

- `xdremux convert --input <motion.jpg>` auto-routes without a new command/flag
- JPEG source remains untouched and produces sibling `.heic` + `.mov`
- HEIC Motion Photo source remains untouched and defaults to `.live.heic` + `.live.mov`
- explicit output requires `.heic`/`.heif`
- default batch discovers JPEG Motion Photos and classifies HEIF Motion Photos before the existing ProXDR HEIC path
- pair-aware collision/skip/resume checkpointing
- generated Apple Live Photo stills cannot fall back into the legacy ProXDR `*.heic` scan

## Validation

Current head: `571d0a886f67a88ba68aa0984cb29ba265c1a03e`

All three pull-request checks are green:

- `XDRemux Policy` — success
- `XDRemux CI` — success
- `Motion Photo Real Fixture Gate` — success

The strict real-fixture gate ran on macOS 26.5.2 / build 25F84 / arm64 and successfully:

1. downloaded the private fixture archive from `XDREMUX_FIXTURE_ARCHIVE_URL`;
2. verified all 14 supplied filenames;
3. verified exact fixture identities and parser characterization;
4. converted every supplied Samsung / Xiaomi / OPPO / vivo sample to HEIC+MOV;
5. verified source files remained unchanged;
6. verified expected gain-map state and removal of stale Android Motion Photo XMP;
7. verified compressed video/audio passthrough;
8. verified HEIC/MOV identifier and still-image-time metadata;
9. required `PHLivePhoto.request` to construct a real Apple `PHLivePhoto` for every generated pair.

`UploadedMotionPhotoFixtureGateTests` completed in 173.748 seconds with 0 failures.

The first strict run exposed a real QuickTime metadata timebase quantization case (~1.27 ms). The validator was corrected to compare the resolved source timestamp at the stored MOV metadata timescale rather than using an arbitrary 1 ms threshold; the real-fixture gate then passed in full. A synthetic regression test now covers this behavior.

The Motion Photo fixture archive is intentionally isolated from the pre-existing ProXDR/Apple-feature regression fixture bundle; ordinary CI now uses `XDREMUX_REGRESSION_FIXTURE_ARCHIVE_URL` for that older optional bundle, while `XDREMUX_FIXTURE_ARCHIVE_URL` is reserved for the dedicated Motion Photo gate.

## Deliberately deferred

- AVIF Motion Photo input support
- ColorOS 16 blur-fill/content re-render path; current scope preserves the source still/HDR data and compressed motion/audio and uses alignment metadata rather than modifying image/video content
