### PR TITLE
Harden Live Photo batch provenance and crash recovery

### DIFF
--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoConversionEngine.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoConversionEngine.swift
@@ -68,10 +68,14 @@ public enum AppleLivePhotoConversionEngine {
         }
 
         let outputVideoURL = companionVideoURL(for: outputImageURL)
+        let outputDirectory = outputImageURL.deletingLastPathComponent()
         try FileManager.default.createDirectory(
-            at: outputImageURL.deletingLastPathComponent(),
+            at: outputDirectory,
             withIntermediateDirectories: true
         )
+        // A prior process may have died between the two resource renames. Recover that transaction
+        // before generating another pair in the same destination directory.
+        try LivePhotoPairTransaction.recover(in: outputDirectory)
 
         let scratch = FileManager.default.temporaryDirectory
             .appendingPathComponent("xdremux-livephoto-\(UUID().uuidString)", isDirectory: true)
@@ -140,7 +144,7 @@ public enum AppleLivePhotoConversionEngine {
             requirePhotoKitLoad: requirePhotoKitValidation
         )
 
-        try commitPair(
+        try LivePhotoPairTransaction.commit(
             temporaryImageURL: temporaryImageURL,
             temporaryVideoURL: temporaryVideoURL,
             finalImageURL: outputImageURL,
@@ -170,45 +174,6 @@ public enum AppleLivePhotoConversionEngine {
             sourceKind: asset.sourceKind,
             diagnostics: diagnostics
         )
-    }
-
-    private static func commitPair(
-        temporaryImageURL: URL,
-        temporaryVideoURL: URL,
-        finalImageURL: URL,
-        finalVideoURL: URL
-    ) throws {
-        let fileManager = FileManager.default
-        let backupID = UUID().uuidString
-        let imageBackup = finalImageURL.deletingLastPathComponent()
-            .appendingPathComponent(".\(finalImageURL.lastPathComponent).\(backupID).backup")
-        let videoBackup = finalVideoURL.deletingLastPathComponent()
-            .appendingPathComponent(".\(finalVideoURL.lastPathComponent).\(backupID).backup")
-        let hadImage = fileManager.fileExists(atPath: finalImageURL.path)
-        let hadVideo = fileManager.fileExists(atPath: finalVideoURL.path)
-        var newImageInstalled = false
-
-        do {
-            if hadImage { try fileManager.moveItem(at: finalImageURL, to: imageBackup) }
-            if hadVideo { try fileManager.moveItem(at: finalVideoURL, to: videoBackup) }
-            try fileManager.moveItem(at: temporaryImageURL, to: finalImageURL)
-            newImageInstalled = true
-            try fileManager.moveItem(at: temporaryVideoURL, to: finalVideoURL)
-            if hadImage { try? fileManager.removeItem(at: imageBackup) }
-            if hadVideo { try? fileManager.removeItem(at: videoBackup) }
-        } catch {
-            if newImageInstalled { try? fileManager.removeItem(at: finalImageURL) }
-            // A throwing move of the temporary video cannot have installed it successfully, and
-            // there are no throwing operations after the successful video move. Therefore no
-            // separate newVideoInstalled state is needed here.
-            if hadImage, fileManager.fileExists(atPath: imageBackup.path) {
-                try? fileManager.moveItem(at: imageBackup, to: finalImageURL)
-            }
-            if hadVideo, fileManager.fileExists(atPath: videoBackup.path) {
-                try? fileManager.moveItem(at: videoBackup, to: finalVideoURL)
-            }
-            throw AppleLivePhotoError.transactionFailed(error.localizedDescription)
-        }
     }
 
     private static func formatMicroseconds(_ value: Int64) -> String {

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/LivePhotoPairTransaction.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/LivePhotoPairTransaction.swift
@@ -132,11 +132,14 @@ enum LivePhotoPairTransaction {
                     )
                 }
 
-                // This durable marker is the commit point. Backup cleanup happens only afterwards.
-                // If cleanup itself is interrupted, recovery must continue cleanup and never roll
-                // one resource back independently of the other.
-                manifest.state = .committed
-                journalURL = try writeManifest(manifest, in: directory)
+                // This durable marker is the commit point. Do not update the in-memory state until
+                // the journal write returns successfully; otherwise a failed journal publication
+                // could make the catch path clean backups instead of rolling the transaction back.
+                var committedManifest = manifest
+                committedManifest.state = .committed
+                let committedJournalURL = try writeManifest(committedManifest, in: directory)
+                manifest = committedManifest
+                journalURL = committedJournalURL
                 try cleanupCommitted(manifest, journalURL: journalURL, in: directory)
             } catch {
                 do {
@@ -189,8 +192,10 @@ enum LivePhotoPairTransaction {
                FileManager.default.fileExists(atPath: finalVideo.path),
                let validatePair,
                validatePair(finalImage, finalVideo) {
-                manifest.state = .committed
-                let committedJournalURL = try writeManifest(manifest, in: directory)
+                var committedManifest = manifest
+                committedManifest.state = .committed
+                let committedJournalURL = try writeManifest(committedManifest, in: directory)
+                manifest = committedManifest
                 try cleanupCommitted(manifest, journalURL: committedJournalURL, in: directory)
                 continue
             }

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/LivePhotoPairTransaction.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/LivePhotoPairTransaction.swift
@@ -281,10 +281,10 @@ enum LivePhotoPairTransaction {
             throw AppleLivePhotoError.transactionFailed("could not open Live Photo transaction lock")
         }
         defer { Darwin.close(descriptor) }
-        guard Darwin.flock(descriptor, LOCK_EX) == 0 else {
+        guard Darwin.lockf(descriptor, F_LOCK, 0) == 0 else {
             throw AppleLivePhotoError.transactionFailed("could not acquire Live Photo transaction lock")
         }
-        defer { _ = Darwin.flock(descriptor, LOCK_UN) }
+        defer { _ = Darwin.lockf(descriptor, F_ULOCK, 0) }
         return try body()
     }
 }

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/LivePhotoPairTransaction.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/LivePhotoPairTransaction.swift
@@ -1,0 +1,290 @@
+import Darwin
+import Foundation
+
+/// Crash-recoverable commit protocol for the HEIC+MOV resources that form one Live Photo.
+///
+/// A filesystem cannot atomically rename two independent files as one operation. This transaction
+/// therefore keeps a durable, same-volume journal and can either finish a fully installed valid pair
+/// or restore the previous pair after SIGKILL, power loss, or another abrupt process termination.
+enum LivePhotoPairTransaction {
+    static let journalDirectoryName = ".xdremux-live-photo-transactions"
+    static let lockFileName = ".xdremux-live-photo-transactions.lock"
+    static let schemaVersion = 1
+
+    enum State: String, Codable {
+        case prepared
+        case originalsBackedUp = "originals_backed_up"
+        case imageInstalled = "image_installed"
+        case pairInstalled = "pair_installed"
+    }
+
+    struct Manifest: Codable {
+        let schemaVersion: Int
+        let transactionID: String
+        var state: State
+        let finalImage: String
+        let finalVideo: String
+        let temporaryImage: String
+        let temporaryVideo: String
+        let backupImage: String
+        let backupVideo: String
+        let hadImage: Bool
+        let hadVideo: Bool
+    }
+
+    typealias PairValidator = (URL, URL) -> Bool
+
+    static func recover(
+        in directoryURL: URL,
+        validatePair: PairValidator? = nil
+    ) throws {
+        let directory = directoryURL.standardizedFileURL
+        guard FileManager.default.fileExists(atPath: directory.path) else { return }
+        try withDirectoryLock(directory) {
+            try recoverLocked(in: directory, validatePair: validatePair)
+        }
+    }
+
+    static func commit(
+        temporaryImageURL: URL,
+        temporaryVideoURL: URL,
+        finalImageURL: URL,
+        finalVideoURL: URL,
+        validatePair: PairValidator? = nil
+    ) throws {
+        let temporaryImage = temporaryImageURL.standardizedFileURL
+        let temporaryVideo = temporaryVideoURL.standardizedFileURL
+        let finalImage = finalImageURL.standardizedFileURL
+        let finalVideo = finalVideoURL.standardizedFileURL
+        let directory = finalImage.deletingLastPathComponent()
+        let directoryPath = directory.path
+
+        guard finalVideo.deletingLastPathComponent().path == directoryPath,
+              temporaryImage.deletingLastPathComponent().path == directoryPath,
+              temporaryVideo.deletingLastPathComponent().path == directoryPath else {
+            throw AppleLivePhotoError.transactionFailed(
+                "Live Photo transaction resources must be on the destination directory/filesystem"
+            )
+        }
+        guard FileManager.default.fileExists(atPath: temporaryImage.path),
+              FileManager.default.fileExists(atPath: temporaryVideo.path) else {
+            throw AppleLivePhotoError.transactionFailed("validated Live Photo temporary pair is incomplete")
+        }
+
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try withDirectoryLock(directory) {
+            try recoverLocked(in: directory, validatePair: validatePair)
+
+            let transactionID = UUID().uuidString.lowercased()
+            let imageBackupName = ".\(finalImage.lastPathComponent).\(transactionID).backup"
+            let videoBackupName = ".\(finalVideo.lastPathComponent).\(transactionID).backup"
+            var manifest = Manifest(
+                schemaVersion: schemaVersion,
+                transactionID: transactionID,
+                state: .prepared,
+                finalImage: finalImage.lastPathComponent,
+                finalVideo: finalVideo.lastPathComponent,
+                temporaryImage: temporaryImage.lastPathComponent,
+                temporaryVideo: temporaryVideo.lastPathComponent,
+                backupImage: imageBackupName,
+                backupVideo: videoBackupName,
+                hadImage: FileManager.default.fileExists(atPath: finalImage.path),
+                hadVideo: FileManager.default.fileExists(atPath: finalVideo.path)
+            )
+
+            try synchronizeFile(temporaryImage)
+            try synchronizeFile(temporaryVideo)
+            var journalURL = try writeManifest(manifest, in: directory)
+
+            do {
+                if manifest.hadImage {
+                    try FileManager.default.moveItem(
+                        at: finalImage,
+                        to: directory.appendingPathComponent(imageBackupName)
+                    )
+                }
+                if manifest.hadVideo {
+                    try FileManager.default.moveItem(
+                        at: finalVideo,
+                        to: directory.appendingPathComponent(videoBackupName)
+                    )
+                }
+                manifest.state = .originalsBackedUp
+                journalURL = try writeManifest(manifest, in: directory)
+
+                try FileManager.default.moveItem(at: temporaryImage, to: finalImage)
+                manifest.state = .imageInstalled
+                journalURL = try writeManifest(manifest, in: directory)
+
+                try FileManager.default.moveItem(at: temporaryVideo, to: finalVideo)
+                manifest.state = .pairInstalled
+                journalURL = try writeManifest(manifest, in: directory)
+
+                let validator = validatePair ?? { image, video in
+                    AppleLivePhotoValidator.isValidPair(imageURL: image, videoURL: video)
+                }
+                guard validator(finalImage, finalVideo) else {
+                    throw AppleLivePhotoError.transactionFailed(
+                        "installed Live Photo pair failed final validation"
+                    )
+                }
+                try finalize(manifest, journalURL: journalURL, in: directory)
+            } catch {
+                do {
+                    try rollback(manifest, journalURL: journalURL, in: directory)
+                } catch {
+                    // Keep the durable journal when rollback itself cannot finish. The next run can
+                    // retry recovery from filesystem truth plus the last persisted state.
+                }
+                throw error
+            }
+        }
+    }
+
+    private static func recoverLocked(
+        in directory: URL,
+        validatePair: PairValidator?
+    ) throws {
+        let journalDirectory = directory.appendingPathComponent(journalDirectoryName, isDirectory: true)
+        guard FileManager.default.fileExists(atPath: journalDirectory.path) else { return }
+        let journals = try FileManager.default.contentsOfDirectory(
+            at: journalDirectory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )
+        .filter { $0.pathExtension.lowercased() == "json" }
+        .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+        for journalURL in journals {
+            let data = try Data(contentsOf: journalURL)
+            let manifest = try JSONDecoder().decode(Manifest.self, from: data)
+            guard manifest.schemaVersion == schemaVersion else {
+                throw AppleLivePhotoError.transactionFailed(
+                    "unsupported Live Photo transaction schema \(manifest.schemaVersion)"
+                )
+            }
+            let finalImage = try safeChild(manifest.finalImage, of: directory)
+            let finalVideo = try safeChild(manifest.finalVideo, of: directory)
+            if manifest.state == .pairInstalled,
+               FileManager.default.fileExists(atPath: finalImage.path),
+               FileManager.default.fileExists(atPath: finalVideo.path) {
+                let validator = validatePair ?? { image, video in
+                    AppleLivePhotoValidator.isValidPair(imageURL: image, videoURL: video)
+                }
+                if validator(finalImage, finalVideo) {
+                    try finalize(manifest, journalURL: journalURL, in: directory)
+                    continue
+                }
+            }
+            try rollback(manifest, journalURL: journalURL, in: directory)
+        }
+    }
+
+    private static func rollback(
+        _ manifest: Manifest,
+        journalURL: URL,
+        in directory: URL
+    ) throws {
+        let manager = FileManager.default
+        let finalImage = try safeChild(manifest.finalImage, of: directory)
+        let finalVideo = try safeChild(manifest.finalVideo, of: directory)
+        let temporaryImage = try safeChild(manifest.temporaryImage, of: directory)
+        let temporaryVideo = try safeChild(manifest.temporaryVideo, of: directory)
+        let imageBackup = try safeChild(manifest.backupImage, of: directory)
+        let videoBackup = try safeChild(manifest.backupVideo, of: directory)
+
+        if manager.fileExists(atPath: imageBackup.path) {
+            try removeIfPresent(finalImage)
+            try manager.moveItem(at: imageBackup, to: finalImage)
+        } else if !manifest.hadImage,
+                  !manager.fileExists(atPath: temporaryImage.path),
+                  manager.fileExists(atPath: finalImage.path) {
+            // A crash can occur after the temp->final rename and before its state update.
+            try removeIfPresent(finalImage)
+        }
+
+        if manager.fileExists(atPath: videoBackup.path) {
+            try removeIfPresent(finalVideo)
+            try manager.moveItem(at: videoBackup, to: finalVideo)
+        } else if !manifest.hadVideo,
+                  !manager.fileExists(atPath: temporaryVideo.path),
+                  manager.fileExists(atPath: finalVideo.path) {
+            try removeIfPresent(finalVideo)
+        }
+
+        try removeIfPresent(temporaryImage)
+        try removeIfPresent(temporaryVideo)
+        try removeIfPresent(imageBackup)
+        try removeIfPresent(videoBackup)
+        try removeIfPresent(journalURL)
+    }
+
+    private static func finalize(
+        _ manifest: Manifest,
+        journalURL: URL,
+        in directory: URL
+    ) throws {
+        try removeIfPresent(try safeChild(manifest.backupImage, of: directory))
+        try removeIfPresent(try safeChild(manifest.backupVideo, of: directory))
+        try removeIfPresent(try safeChild(manifest.temporaryImage, of: directory))
+        try removeIfPresent(try safeChild(manifest.temporaryVideo, of: directory))
+        try removeIfPresent(journalURL)
+    }
+
+    @discardableResult
+    static func writeManifest(_ manifest: Manifest, in directory: URL) throws -> URL {
+        let journalDirectory = directory.appendingPathComponent(journalDirectoryName, isDirectory: true)
+        try FileManager.default.createDirectory(at: journalDirectory, withIntermediateDirectories: true)
+        let journalURL = journalDirectory
+            .appendingPathComponent(manifest.transactionID)
+            .appendingPathExtension("json")
+        let data = try JSONEncoder().encode(manifest)
+        // Foundation's atomic write creates the replacement in the destination directory, so the
+        // manifest transition itself never depends on a cross-volume rename.
+        try data.write(to: journalURL, options: [.atomic])
+        try synchronizeFile(journalURL)
+        return journalURL
+    }
+
+    private static func safeChild(_ name: String, of directory: URL) throws -> URL {
+        guard !name.isEmpty,
+              name != ".",
+              name != "..",
+              !name.contains("/"),
+              !name.contains(":") else {
+            throw AppleLivePhotoError.transactionFailed("unsafe Live Photo transaction path")
+        }
+        return directory.appendingPathComponent(name)
+    }
+
+    private static func removeIfPresent(_ url: URL) throws {
+        if FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.removeItem(at: url)
+        }
+    }
+
+    private static func synchronizeFile(_ url: URL) throws {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        try handle.synchronize()
+    }
+
+    private static func withDirectoryLock<T>(
+        _ directory: URL,
+        _ body: () throws -> T
+    ) throws -> T {
+        let lockURL = directory.appendingPathComponent(lockFileName)
+        let descriptor = lockURL.path.withCString { path in
+            Darwin.open(path, O_CREAT | O_RDWR, mode_t(0o600))
+        }
+        guard descriptor >= 0 else {
+            throw AppleLivePhotoError.transactionFailed("could not open Live Photo transaction lock")
+        }
+        defer { Darwin.close(descriptor) }
+        guard Darwin.flock(descriptor, LOCK_EX) == 0 else {
+            throw AppleLivePhotoError.transactionFailed("could not acquire Live Photo transaction lock")
+        }
+        defer { _ = Darwin.flock(descriptor, LOCK_UN) }
+        return try body()
+    }
+}

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/LivePhotoPairTransaction.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/LivePhotoPairTransaction.swift
@@ -16,6 +16,7 @@ enum LivePhotoPairTransaction {
         case originalsBackedUp = "originals_backed_up"
         case imageInstalled = "image_installed"
         case pairInstalled = "pair_installed"
+        case committed
     }
 
     struct Manifest: Codable {
@@ -119,24 +120,34 @@ enum LivePhotoPairTransaction {
                 try FileManager.default.moveItem(at: temporaryVideo, to: finalVideo)
                 manifest.state = .pairInstalled
                 journalURL = try writeManifest(manifest, in: directory)
+                // Ensure the installed resource names are durable before publishing the commit point.
+                try synchronizeDirectory(directory)
 
                 // AppleLivePhotoConversionEngine fully validates the temporary pair before commit.
                 // A same-directory rename does not mutate file contents. Keep this transaction layer
-                // synchronous: invoking AppleLivePhotoValidator.isValidPair here would nest an async
-                // AVFoundation validation behind a blocking semaphore while the transaction lock is
-                // held. Callers that have a genuinely synchronous validator can still supply one.
+                // synchronous: callers may provide a genuinely synchronous validator when useful.
                 if let validatePair, !validatePair(finalImage, finalVideo) {
                     throw AppleLivePhotoError.transactionFailed(
                         "installed Live Photo pair failed final validation"
                     )
                 }
-                try finalize(manifest, journalURL: journalURL, in: directory)
+
+                // This durable marker is the commit point. Backup cleanup happens only afterwards.
+                // If cleanup itself is interrupted, recovery must continue cleanup and never roll
+                // one resource back independently of the other.
+                manifest.state = .committed
+                journalURL = try writeManifest(manifest, in: directory)
+                try cleanupCommitted(manifest, journalURL: journalURL, in: directory)
             } catch {
                 do {
-                    try rollback(manifest, journalURL: journalURL, in: directory)
+                    if manifest.state == .committed {
+                        try cleanupCommitted(manifest, journalURL: journalURL, in: directory)
+                    } else {
+                        try rollback(manifest, journalURL: journalURL, in: directory)
+                    }
                 } catch {
-                    // Keep the durable journal when rollback itself cannot finish. The next run can
-                    // retry recovery from filesystem truth plus the last persisted state.
+                    // Keep the durable journal when cleanup/rollback itself cannot finish. The next
+                    // run can retry from the last persisted transaction state.
                 }
                 throw error
             }
@@ -159,12 +170,18 @@ enum LivePhotoPairTransaction {
 
         for journalURL in journals {
             let data = try Data(contentsOf: journalURL)
-            let manifest = try JSONDecoder().decode(Manifest.self, from: data)
+            var manifest = try JSONDecoder().decode(Manifest.self, from: data)
             guard manifest.schemaVersion == schemaVersion else {
                 throw AppleLivePhotoError.transactionFailed(
                     "unsupported Live Photo transaction schema \(manifest.schemaVersion)"
                 )
             }
+
+            if manifest.state == .committed {
+                try cleanupCommitted(manifest, journalURL: journalURL, in: directory)
+                continue
+            }
+
             let finalImage = try safeChild(manifest.finalImage, of: directory)
             let finalVideo = try safeChild(manifest.finalVideo, of: directory)
             if manifest.state == .pairInstalled,
@@ -172,13 +189,14 @@ enum LivePhotoPairTransaction {
                FileManager.default.fileExists(atPath: finalVideo.path),
                let validatePair,
                validatePair(finalImage, finalVideo) {
-                try finalize(manifest, journalURL: journalURL, in: directory)
+                manifest.state = .committed
+                let committedJournalURL = try writeManifest(manifest, in: directory)
+                try cleanupCommitted(manifest, journalURL: committedJournalURL, in: directory)
                 continue
             }
 
             // No synchronous validator means fail closed. A pair-installed journal is still an
-            // uncommitted transaction until the journal is removed; restoring the prior pair is the
-            // conservative atomicity rule and avoids accepting an unverified cross-resource state.
+            // uncommitted transaction until the committed marker is durable.
             try rollback(manifest, journalURL: journalURL, in: directory)
         }
     }
@@ -219,19 +237,25 @@ enum LivePhotoPairTransaction {
         try removeIfPresent(temporaryVideo)
         try removeIfPresent(imageBackup)
         try removeIfPresent(videoBackup)
+        try synchronizeDirectory(directory)
         try removeIfPresent(journalURL)
+        try synchronizeDirectory(journalURL.deletingLastPathComponent())
     }
 
-    private static func finalize(
+    private static func cleanupCommitted(
         _ manifest: Manifest,
         journalURL: URL,
         in directory: URL
     ) throws {
+        // Cleanup is idempotent. The committed journal is deliberately removed last so any crash
+        // in the middle can only re-enter cleanup; it can never trigger rollback of half the pair.
         try removeIfPresent(try safeChild(manifest.backupImage, of: directory))
         try removeIfPresent(try safeChild(manifest.backupVideo, of: directory))
         try removeIfPresent(try safeChild(manifest.temporaryImage, of: directory))
         try removeIfPresent(try safeChild(manifest.temporaryVideo, of: directory))
+        try synchronizeDirectory(directory)
         try removeIfPresent(journalURL)
+        try synchronizeDirectory(journalURL.deletingLastPathComponent())
     }
 
     @discardableResult
@@ -246,6 +270,7 @@ enum LivePhotoPairTransaction {
         // manifest transition itself never depends on a cross-volume rename.
         try data.write(to: journalURL, options: [.atomic])
         try synchronizeFile(journalURL)
+        try synchronizeDirectory(journalDirectory)
         return journalURL
     }
 
@@ -270,6 +295,19 @@ enum LivePhotoPairTransaction {
         let handle = try FileHandle(forReadingFrom: url)
         defer { try? handle.close() }
         try handle.synchronize()
+    }
+
+    private static func synchronizeDirectory(_ url: URL) throws {
+        let descriptor = url.path.withCString { path in
+            Darwin.open(path, O_RDONLY)
+        }
+        guard descriptor >= 0 else {
+            throw AppleLivePhotoError.transactionFailed("could not open Live Photo transaction directory for sync")
+        }
+        defer { Darwin.close(descriptor) }
+        guard Darwin.fsync(descriptor) == 0 else {
+            throw AppleLivePhotoError.transactionFailed("could not synchronize Live Photo transaction directory")
+        }
     }
 
     private static func withDirectoryLock<T>(

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/LivePhotoPairTransaction.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/LivePhotoPairTransaction.swift
@@ -120,10 +120,12 @@ enum LivePhotoPairTransaction {
                 manifest.state = .pairInstalled
                 journalURL = try writeManifest(manifest, in: directory)
 
-                let validator = validatePair ?? { image, video in
-                    AppleLivePhotoValidator.isValidPair(imageURL: image, videoURL: video)
-                }
-                guard validator(finalImage, finalVideo) else {
+                // AppleLivePhotoConversionEngine fully validates the temporary pair before commit.
+                // A same-directory rename does not mutate file contents. Keep this transaction layer
+                // synchronous: invoking AppleLivePhotoValidator.isValidPair here would nest an async
+                // AVFoundation validation behind a blocking semaphore while the transaction lock is
+                // held. Callers that have a genuinely synchronous validator can still supply one.
+                if let validatePair, !validatePair(finalImage, finalVideo) {
                     throw AppleLivePhotoError.transactionFailed(
                         "installed Live Photo pair failed final validation"
                     )
@@ -167,15 +169,16 @@ enum LivePhotoPairTransaction {
             let finalVideo = try safeChild(manifest.finalVideo, of: directory)
             if manifest.state == .pairInstalled,
                FileManager.default.fileExists(atPath: finalImage.path),
-               FileManager.default.fileExists(atPath: finalVideo.path) {
-                let validator = validatePair ?? { image, video in
-                    AppleLivePhotoValidator.isValidPair(imageURL: image, videoURL: video)
-                }
-                if validator(finalImage, finalVideo) {
-                    try finalize(manifest, journalURL: journalURL, in: directory)
-                    continue
-                }
+               FileManager.default.fileExists(atPath: finalVideo.path),
+               let validatePair,
+               validatePair(finalImage, finalVideo) {
+                try finalize(manifest, journalURL: journalURL, in: directory)
+                continue
             }
+
+            // No synchronous validator means fail closed. A pair-installed journal is still an
+            // uncommitted transaction until the journal is removed; restoring the prior pair is the
+            // conservative atomicity rule and avoids accepting an unverified cross-resource state.
             try rollback(manifest, journalURL: journalURL, in: directory)
         }
     }

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoBatchCheckpoint.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoBatchCheckpoint.swift
@@ -1,8 +1,8 @@
+import CryptoKit
 import Foundation
 
-/// Independent sidecar checkpoint for the Motion Photo pre-pass. It intentionally does not share
-/// the existing HEIC checkpoint file because the two passes can run in the same `batch` invocation
-/// and have different output cardinality (one file versus HEIC+MOV pair).
+/// Durable sidecar state for the Motion Photo pre-pass. Besides retry status, this is the
+/// provenance record that proves a specific source produced a specific HEIC+MOV pair.
 enum MotionPhotoBatchCheckpoint {
     enum Status: String, Codable {
         case success
@@ -13,23 +13,29 @@ enum MotionPhotoBatchCheckpoint {
     struct FileSignature: Equatable {
         let size: Int64
         let mtimeNs: Int64
+        let sha256: String
     }
 
     struct Item: Codable {
         let kind: String
         let inputPath: String
+        let sourceRelativePath: String?
         let outputImagePath: String
         let outputVideoPath: String
         let status: Status
         let inputSize: Int64?
         let inputMtimeNs: Int64?
+        let inputSHA256: String?
+        let assetIdentifier: String?
         let error: String?
 
+        /// Old schema-1 entries intentionally fail this check: size/mtime alone are not strong
+        /// enough provenance to allow --skip-existing to claim a pair for the current source.
         func matchesSignature(_ signature: FileSignature?) -> Bool {
-            guard let signature else { return true }
-            if let inputSize, inputSize != signature.size { return false }
-            if let inputMtimeNs, inputMtimeNs != signature.mtimeNs { return false }
-            return true
+            guard let signature,
+                  let inputSize,
+                  let inputSHA256 else { return false }
+            return inputSize == signature.size && inputSHA256 == signature.sha256
         }
 
         func matchesOutputs(imageURL: URL, videoURL: URL) -> Bool {
@@ -45,7 +51,7 @@ enum MotionPhotoBatchCheckpoint {
 
         init(createdAt: String) {
             self.kind = "header"
-            self.schemaVersion = 1
+            self.schemaVersion = 2
             self.createdAt = createdAt
         }
     }
@@ -63,10 +69,29 @@ enum MotionPhotoBatchCheckpoint {
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
         let size = (attributes[.size] as? NSNumber)?.int64Value ?? 0
         let modified = (attributes[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        while let data = try handle.read(upToCount: 1024 * 1024), !data.isEmpty {
+            hasher.update(data: data)
+        }
+        let digest = hasher.finalize().map { String(format: "%02x", $0) }.joined()
         return FileSignature(
             size: size,
-            mtimeNs: Int64(modified * 1_000_000_000)
+            mtimeNs: Int64(modified * 1_000_000_000),
+            sha256: digest
         )
+    }
+
+    static func relativeSourcePath(inputURL: URL, inputRootURL: URL) -> String {
+        let input = inputURL.standardizedFileURL.path
+        let root = inputRootURL.standardizedFileURL.path
+        let prefix = root.hasSuffix("/") ? root : root + "/"
+        if input.hasPrefix(prefix) {
+            return String(input.dropFirst(prefix.count)).precomposedStringWithCanonicalMapping
+        }
+        return input.precomposedStringWithCanonicalMapping
     }
 
     static func load(url: URL) throws -> [String: Item] {
@@ -121,21 +146,31 @@ enum MotionPhotoBatchCheckpoint {
 
         func append(
             inputURL: URL,
+            inputRootURL: URL? = nil,
             outputImageURL: URL,
             outputVideoURL: URL,
             status: Status,
             signature: FileSignature?,
+            assetIdentifier: String? = nil,
             error: String? = nil
         ) throws {
             try appendEncodable(
                 Item(
                     kind: "item",
                     inputPath: inputURL.standardizedFileURL.path,
+                    sourceRelativePath: inputRootURL.map {
+                        MotionPhotoBatchCheckpoint.relativeSourcePath(
+                            inputURL: inputURL,
+                            inputRootURL: $0
+                        )
+                    },
                     outputImagePath: outputImageURL.standardizedFileURL.path,
                     outputVideoPath: outputVideoURL.standardizedFileURL.path,
                     status: status,
                     inputSize: signature?.size,
                     inputMtimeNs: signature?.mtimeNs,
+                    inputSHA256: signature?.sha256,
+                    assetIdentifier: assetIdentifier,
                     error: error
                 )
             )

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoBatchCheckpoint.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoBatchCheckpoint.swift
@@ -3,6 +3,7 @@ import Foundation
 
 /// Durable sidecar state for the Motion Photo pre-pass. Besides retry status, this is the
 /// provenance record that proves a specific source produced a specific HEIC+MOV pair.
+/// The wire format intentionally matches xdremux_py.live_photo_batch.
 enum MotionPhotoBatchCheckpoint {
     enum Status: String, Codable {
         case success
@@ -103,9 +104,16 @@ enum MotionPhotoBatchCheckpoint {
         for line in data.split(separator: 0x0a) where !line.isEmpty {
             guard let object = try? JSONSerialization.jsonObject(with: Data(line)) as? [String: Any],
                   object["kind"] as? String == "item" else {
+                // A crash can leave a truncated final JSONL record. Ignoring it is fail-closed:
+                // the input will be rebuilt rather than incorrectly authorized for reuse.
                 continue
             }
-            let item = try decoder.decode(Item.self, from: Data(line))
+            guard let item = try? decoder.decode(Item.self, from: Data(line)) else {
+                // Foreign/unsupported item schemas also cannot authorize reuse. This makes the
+                // checkpoint robust to mixed runtime versions without turning corruption into a
+                // batch-wide availability failure.
+                continue
+            }
             state[item.inputPath] = item
         }
         return state

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoBatchPlanner.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoBatchPlanner.swift
@@ -1,17 +1,18 @@
 import CryptoKit
 import Foundation
 
-/// Stable Motion Photo batch naming. A destination is a pure function of the source path relative
-/// to the batch root, so adding/removing another input cannot remap an existing source onto a
-/// different Live Photo pair.
+/// Stable Motion Photo batch naming. A destination is a pure function of the canonical batch root
+/// plus the source path relative to that root, so batch membership/order cannot remap a source and
+/// two different input roots cannot silently target the same persisted Live Photo name.
 enum MotionPhotoBatchPlanner {
     static func outputImageURL(
         for inputURL: URL,
         inputRootURL: URL,
         outputDirectoryURL: URL
     ) -> URL {
-        let source = inputURL.standardizedFileURL
-        let root = inputRootURL.standardizedFileURL
+        let source = inputURL.resolvingSymlinksInPath().standardizedFileURL
+        let root = inputRootURL.resolvingSymlinksInPath().standardizedFileURL
+        let rootIdentity = root.path.precomposedStringWithCanonicalMapping
         let relativePath: String
         let prefix = root.path.hasSuffix("/") ? root.path : root.path + "/"
         if source.path.hasPrefix(prefix) {
@@ -20,7 +21,11 @@ enum MotionPhotoBatchPlanner {
             relativePath = source.path.precomposedStringWithCanonicalMapping
         }
 
-        let digest = SHA256.hash(data: Data(relativePath.utf8))
+        // Root namespace + relative path is equivalent to a canonical source identity while keeping
+        // the intent explicit. This prevents two independent input trees with the same A/IMG.jpg
+        // layout from overwriting each other when they share an output directory.
+        let identity = rootIdentity + "\u{0}" + relativePath
+        let digest = SHA256.hash(data: Data(identity.utf8))
         // 128 bits keeps the filename compact while making accidental persisted-name collisions
         // negligible. validateUnique() still fails closed if a collision is ever observed.
         let token = digest.prefix(16).map { String(format: "%02x", $0) }.joined()
@@ -36,7 +41,7 @@ enum MotionPhotoBatchPlanner {
         var owners: [String: String] = [:]
         for item in items {
             let outputPath = item.output.standardizedFileURL.path
-            let inputPath = item.input.standardizedFileURL.path
+            let inputPath = item.input.resolvingSymlinksInPath().standardizedFileURL.path
             if let prior = owners[outputPath], prior != inputPath {
                 throw PlannerError.collision(first: prior, second: inputPath, output: outputPath)
             }

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoBatchPlanner.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoBatchPlanner.swift
@@ -21,7 +21,9 @@ enum MotionPhotoBatchPlanner {
         }
 
         let digest = SHA256.hash(data: Data(relativePath.utf8))
-        let token = digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+        // 128 bits keeps the filename compact while making accidental persisted-name collisions
+        // negligible. validateUnique() still fails closed if a collision is ever observed.
+        let token = digest.prefix(16).map { String(format: "%02x", $0) }.joined()
         let ext = source.pathExtension.lowercased()
         let sourceStem = source.deletingPathExtension().lastPathComponent
         let stem = (ext == "heic" || ext == "heif") ? "\(sourceStem).live" : sourceStem

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoBatchPlanner.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoBatchPlanner.swift
@@ -1,0 +1,55 @@
+import CryptoKit
+import Foundation
+
+/// Stable Motion Photo batch naming. A destination is a pure function of the source path relative
+/// to the batch root, so adding/removing another input cannot remap an existing source onto a
+/// different Live Photo pair.
+enum MotionPhotoBatchPlanner {
+    static func outputImageURL(
+        for inputURL: URL,
+        inputRootURL: URL,
+        outputDirectoryURL: URL
+    ) -> URL {
+        let source = inputURL.standardizedFileURL
+        let root = inputRootURL.standardizedFileURL
+        let relativePath: String
+        let prefix = root.path.hasSuffix("/") ? root.path : root.path + "/"
+        if source.path.hasPrefix(prefix) {
+            relativePath = String(source.path.dropFirst(prefix.count)).precomposedStringWithCanonicalMapping
+        } else {
+            relativePath = source.path.precomposedStringWithCanonicalMapping
+        }
+
+        let digest = SHA256.hash(data: Data(relativePath.utf8))
+        let token = digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+        let ext = source.pathExtension.lowercased()
+        let sourceStem = source.deletingPathExtension().lastPathComponent
+        let stem = (ext == "heic" || ext == "heif") ? "\(sourceStem).live" : sourceStem
+        return outputDirectoryURL
+            .appendingPathComponent("\(stem)~\(token)")
+            .appendingPathExtension("heic")
+    }
+
+    static func validateUnique(_ items: [(input: URL, output: URL)]) throws {
+        var owners: [String: String] = [:]
+        for item in items {
+            let outputPath = item.output.standardizedFileURL.path
+            let inputPath = item.input.standardizedFileURL.path
+            if let prior = owners[outputPath], prior != inputPath {
+                throw PlannerError.collision(first: prior, second: inputPath, output: outputPath)
+            }
+            owners[outputPath] = inputPath
+        }
+    }
+
+    enum PlannerError: LocalizedError {
+        case collision(first: String, second: String, output: String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .collision(first, second, output):
+                return "stable Motion Photo output collision: \(first) and \(second) -> \(output)"
+            }
+        }
+    }
+}

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoCLIIntegration.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoCLIIntegration.swift
@@ -62,9 +62,6 @@ enum MotionPhotoCLIIntegration {
         if outputWasExplicit {
             outputImageURL = command.outputURL.standardizedFileURL
         } else if isHEIC(inputURL) {
-            // A HEIF Motion Photo is already named .heic/.heif. Never overwrite the source just to
-            // obtain the Apple paired representation; the suffix makes the one-to-two conversion
-            // explicit while preserving the original Android file.
             outputImageURL = inputURL.deletingPathExtension()
                 .appendingPathExtension("live")
                 .appendingPathExtension("heic")
@@ -87,12 +84,9 @@ enum MotionPhotoCLIIntegration {
         return true
     }
 
-    /// Plans the Motion Photo portion of a default batch. Explicit --glob retains the old contract.
-    ///
-    /// JPEG Motion Photos can coexist with the unchanged legacy HEIC pass by deferring their output
-    /// until that pass completes. HEIF Motion Photos are themselves `.heic` inputs, so any batch
-    /// containing one must classify HEIC files first; otherwise the legacy `*.heic` enumerator would
-    /// feed the Android Motion Photo container into the ProXDR pipeline.
+    /// Plans the entire Motion Photo portion of a default batch before the first write. Explicit
+    /// --glob retains the old contract. Stable Motion Photo destination names are derived from the
+    /// source path relative to input-dir, never from the current batch ordering or membership.
     private static func prepareDefaultBatch(_ rawArguments: [String]) throws -> Bool {
         guard !rawArguments.contains("--glob") else { return false }
 
@@ -125,7 +119,7 @@ enum MotionPhotoCLIIntegration {
         let motionInputs = jpegMotionInputs + heifMotionInputs
         guard !motionInputs.isEmpty else { return false }
 
-        let workItems = makeWorkItems(
+        let workItems = try makeWorkItems(
             inputs: motionInputs,
             heicInputs: sourceHEICInputs,
             command: command
@@ -137,15 +131,10 @@ enum MotionPhotoCLIIntegration {
         }
 
         if heifMotionInputs.isEmpty, existingLivePhotoStills.isEmpty {
-            // First JPEG-only mixed run: no Motion Photo HEIC source/output exists, so the unchanged
-            // HEIC batch can enumerate safely. Motion outputs are emitted only after it succeeds.
             pendingBatchStore.set(PendingBatch(command: command, workItems: workItems))
             return false
         }
 
-        // HEIF Motion Photo source or an already generated Live Photo pair is present. Do not invoke
-        // the legacy glob-based batch enumerator because it cannot distinguish those paired/source
-        // Motion Photo HEICs from ProXDR HEIC inputs. Convert only the classified source HEIC set.
         try runClassifiedHEICBatch(command: command, inputs: sourceHEICInputs)
         try runMotionBatch(command: command, workItems: workItems)
         return true
@@ -223,12 +212,10 @@ enum MotionPhotoCLIIntegration {
         workItems: [MotionBatchWorkItem]
     ) throws {
         let checkpointURL = MotionPhotoBatchCheckpoint.resolvedURL(for: command)
-        if !command.resume {
-            try MotionPhotoBatchCheckpoint.reset(url: checkpointURL)
-        }
-        let checkpointState = command.resume
-            ? try MotionPhotoBatchCheckpoint.load(url: checkpointURL)
-            : [:]
+        // Keep successful entries as durable provenance instead of deleting/resetting them. Old
+        // schema-1 entries remain readable but cannot authorize reuse because they have no SHA-256
+        // or asset identifier.
+        let checkpointState = try MotionPhotoBatchCheckpoint.load(url: checkpointURL)
         let checkpointWriter = try MotionPhotoBatchCheckpoint.Writer(url: checkpointURL)
         defer { try? checkpointWriter.close() }
 
@@ -247,20 +234,42 @@ enum MotionPhotoCLIIntegration {
                         for: item.outputImageURL
                     )
                     let inputKey = item.inputURL.standardizedFileURL.path
-                    let signature = try? MotionPhotoBatchCheckpoint.signature(for: item.inputURL)
                     let prior = checkpointState[inputKey]
+
+                    let signature: MotionPhotoBatchCheckpoint.FileSignature
+                    do {
+                        signature = try MotionPhotoBatchCheckpoint.signature(for: item.inputURL)
+                    } catch {
+                        lock.lock(); failures.append((item.inputURL, error)); lock.unlock()
+                        printSynchronized("failed \(item.inputURL.lastPathComponent): could not fingerprint source: \(singleLine(error))")
+                        return
+                    }
+
+                    func pairIsValid(expectedAssetIdentifier: String? = nil) -> Bool {
+                        if let expectedAssetIdentifier,
+                           AppleLivePhotoStillWriter.assetIdentifier(in: item.outputImageURL) != expectedAssetIdentifier {
+                            return false
+                        }
+                        return AppleLivePhotoValidator.isValidPair(
+                            imageURL: item.outputImageURL,
+                            videoURL: outputVideoURL
+                        )
+                    }
 
                     func record(
                         _ status: MotionPhotoBatchCheckpoint.Status,
+                        assetIdentifier: String? = nil,
                         error: String? = nil
                     ) {
                         do {
                             try checkpointWriter.append(
                                 inputURL: item.inputURL,
+                                inputRootURL: command.inputDirURL,
                                 outputImageURL: item.outputImageURL,
                                 outputVideoURL: outputVideoURL,
                                 status: status,
                                 signature: signature,
+                                assetIdentifier: assetIdentifier,
                                 error: error
                             )
                         } catch {
@@ -268,49 +277,54 @@ enum MotionPhotoCLIIntegration {
                         }
                     }
 
-                    func pairIsValid() -> Bool {
-                        AppleLivePhotoValidator.isValidPair(
-                            imageURL: item.outputImageURL,
-                            videoURL: outputVideoURL
-                        )
-                    }
-
                     let signatureMatches = prior?.matchesSignature(signature) == true
-                    if command.resume,
-                       let prior,
-                       signatureMatches,
-                       prior.matchesOutputs(
-                            imageURL: item.outputImageURL,
-                            videoURL: outputVideoURL
-                       ),
-                       (prior.status == .success || prior.status == .skippedExisting),
-                       pairIsValid() {
+                    let outputsMatch = prior?.matchesOutputs(
+                        imageURL: item.outputImageURL,
+                        videoURL: outputVideoURL
+                    ) == true
+                    let priorSucceeded = prior?.status == .success || prior?.status == .skippedExisting
+                    let priorAssetIdentifier = prior?.assetIdentifier
+                    let provenanceMatches = signatureMatches
+                        && outputsMatch
+                        && priorSucceeded
+                        && priorAssetIdentifier != nil
+                        && pairIsValid(expectedAssetIdentifier: priorAssetIdentifier)
+
+                    if (command.resume || command.skipExisting), provenanceMatches,
+                       let priorAssetIdentifier {
                         lock.lock(); skipped += 1; lock.unlock()
-                        record(.skippedExisting)
-                        printSynchronized("skipped \(item.inputURL.lastPathComponent) (Live Photo pair already up to date)")
+                        record(.skippedExisting, assetIdentifier: priorAssetIdentifier)
+                        printSynchronized("skipped \(item.inputURL.lastPathComponent) (Live Photo source provenance matched)")
                         return
                     }
 
-                    if command.skipExisting {
-                        let mustRetryFailure = command.resume
-                            && signatureMatches
-                            && prior?.status == .failure
-                        let inputChanged = prior != nil && !signatureMatches
-                        if !mustRetryFailure, !inputChanged, pairIsValid() {
-                            lock.lock(); skipped += 1; lock.unlock()
-                            record(.skippedExisting)
-                            printSynchronized("skipped \(item.inputURL.lastPathComponent) (Live Photo pair already valid)")
+                    if command.resume || command.skipExisting {
+                        let existingPairValid = pairIsValid()
+                        let knownLineage = outputsMatch
+                            && priorAssetIdentifier != nil
+                            && pairIsValid(expectedAssetIdentifier: priorAssetIdentifier)
+                        if existingPairValid && !knownLineage {
+                            let error = MotionBatchOutputConflictError(
+                                input: item.inputURL,
+                                image: item.outputImageURL,
+                                video: outputVideoURL
+                            )
+                            lock.lock(); failures.append((item.inputURL, error)); lock.unlock()
+                            record(.failure, error: error.localizedDescription)
+                            printSynchronized("failed \(item.inputURL.lastPathComponent): \(singleLine(error))")
                             return
                         }
+                        // A known pair from the same source path with a different content digest is
+                        // stale, not foreign. Rebuild it rather than silently reusing old content.
                     }
 
                     do {
-                        _ = try AppleLivePhotoConversionEngine.convert(
+                        let result = try AppleLivePhotoConversionEngine.convert(
                             inputURL: item.inputURL,
                             outputImageURL: item.outputImageURL
                         )
                         lock.lock(); converted += 1; lock.unlock()
-                        record(.success)
+                        record(.success, assetIdentifier: result.assetIdentifier)
                         printSynchronized("converted Motion Photo \(item.inputURL.lastPathComponent)")
                     } catch {
                         lock.lock(); failures.append((item.inputURL, error)); lock.unlock()
@@ -327,10 +341,8 @@ enum MotionPhotoCLIIntegration {
             "Motion Photo batch pass: \(converted) converted, \(skipped) skipped, "
                 + "\(failures.count) failed"
         )
-        if failures.isEmpty {
-            try? FileManager.default.removeItem(at: checkpointURL)
-        } else {
-            print("run the same command again to retry only the \(failures.count) failed Motion Photo file(s)")
+        if !failures.isEmpty {
+            print("run the same command again to retry the \(failures.count) unresolved Motion Photo file(s)")
             throw CLIError.batchFailed(
                 failures: failures.count,
                 checkpoint: checkpointURL
@@ -352,6 +364,25 @@ enum MotionPhotoCLIIntegration {
         let failures: Int
         var errorDescription: String? {
             "classified HEIC batch pass failed for \(failures) file(s); rerun the same command to retry unresolved inputs"
+        }
+    }
+
+    private struct MotionBatchOutputConflictError: LocalizedError {
+        let input: URL
+        let image: URL
+        let video: URL
+
+        var errorDescription: String? {
+            "existing Live Photo pair \(image.lastPathComponent) + \(video.lastPathComponent) has no matching provenance for \(input.path); refusing silent reuse"
+        }
+    }
+
+    private struct MotionBatchPlanningConflictError: LocalizedError {
+        let input: URL
+        let output: URL
+
+        var errorDescription: String? {
+            "stable Motion Photo destination for \(input.path) conflicts with another planned output: \(output.path)"
         }
     }
 
@@ -399,34 +430,35 @@ enum MotionPhotoCLIIntegration {
         inputs: [URL],
         heicInputs: [URL],
         command: BatchCommand
-    ) -> [MotionBatchWorkItem] {
-        var reserved = Set<String>()
+    ) throws -> [MotionBatchWorkItem] {
+        let heicItems = makeHEICWorkItems(inputs: heicInputs, command: command)
+        var reserved = Set(heicItems.map { $0.outputURL.standardizedFileURL.path })
 
-        for item in makeHEICWorkItems(inputs: heicInputs, command: command) {
-            reserved.insert(item.outputURL.standardizedFileURL.path)
-        }
-
-        return inputs.sorted { $0.path < $1.path }.map { input in
-            let directory = categorizedOutputDirectory(for: input, command: command)
-            let sourceStem = input.deletingPathExtension().lastPathComponent
-            let outputStem = isHEIC(input) ? "\(sourceStem).live" : sourceStem
-            var sequence = 1
-            var output = directory.appendingPathComponent(outputStem).appendingPathExtension("heic")
-            while reserved.contains(output.standardizedFileURL.path)
-                || reserved.contains(
-                    AppleLivePhotoConversionEngine.companionVideoURL(for: output)
-                        .standardizedFileURL.path
-                )
-                || output.standardizedFileURL.path == input.standardizedFileURL.path {
-                sequence += 1
-                output = directory.appendingPathComponent("\(outputStem) (\(sequence))").appendingPathExtension("heic")
-            }
-            reserved.insert(output.standardizedFileURL.path)
-            reserved.insert(
-                AppleLivePhotoConversionEngine.companionVideoURL(for: output).standardizedFileURL.path
+        let planned = inputs.sorted { $0.path < $1.path }.map { input -> (input: URL, output: URL) in
+            let output = MotionPhotoBatchPlanner.outputImageURL(
+                for: input,
+                inputRootURL: command.inputDirURL,
+                outputDirectoryURL: categorizedOutputDirectory(for: input, command: command)
             )
-            return MotionBatchWorkItem(inputURL: input, outputImageURL: output)
+            return (input, output)
         }
+        try MotionPhotoBatchPlanner.validateUnique(planned)
+
+        var result: [MotionBatchWorkItem] = []
+        for item in planned {
+            let imagePath = item.output.standardizedFileURL.path
+            let videoPath = AppleLivePhotoConversionEngine.companionVideoURL(for: item.output)
+                .standardizedFileURL.path
+            if reserved.contains(imagePath)
+                || reserved.contains(videoPath)
+                || imagePath == item.input.standardizedFileURL.path {
+                throw MotionBatchPlanningConflictError(input: item.input, output: item.output)
+            }
+            reserved.insert(imagePath)
+            reserved.insert(videoPath)
+            result.append(MotionBatchWorkItem(inputURL: item.input, outputImageURL: item.output))
+        }
+        return result
     }
 
     private static func categorizedOutputDirectory(for input: URL, command: BatchCommand) -> URL {

--- a/Tests/XDRemuxAppleFeaturesTests/CrossRuntimeLivePhotoTransactionSchemaTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/CrossRuntimeLivePhotoTransactionSchemaTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import XCTest
+@testable import XDRemuxAppleFeatures
+
+final class CrossRuntimeLivePhotoTransactionSchemaTests: XCTestCase {
+    func testSwiftRecoversCanonicalPythonCommittedJournal() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "xdremux-python-journal-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let journalDirectory = directory.appendingPathComponent(
+            LivePhotoPairTransaction.journalDirectoryName,
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: journalDirectory, withIntermediateDirectories: true)
+
+        let transactionID = "feed-face"
+        let image = directory.appendingPathComponent("photo.heic")
+        let video = directory.appendingPathComponent("photo.mov")
+        let imageBackup = directory.appendingPathComponent(".photo.heic.feed-face.backup")
+        let videoBackup = directory.appendingPathComponent(".photo.mov.feed-face.backup")
+        try Data("new-image".utf8).write(to: image)
+        try Data("new-video".utf8).write(to: video)
+        try Data("old-image".utf8).write(to: imageBackup)
+        try Data("old-video".utf8).write(to: videoBackup)
+
+        // Exact camelCase wire names emitted by xdremux_py.live_photo_transaction.
+        let object: [String: Any] = [
+            "schemaVersion": LivePhotoPairTransaction.schemaVersion,
+            "transactionID": transactionID,
+            "state": "committed",
+            "finalImage": image.lastPathComponent,
+            "finalVideo": video.lastPathComponent,
+            "temporaryImage": ".photo.feed-face.tmp.heic",
+            "temporaryVideo": ".photo.feed-face.tmp.mov",
+            "backupImage": imageBackup.lastPathComponent,
+            "backupVideo": videoBackup.lastPathComponent,
+            "hadImage": true,
+            "hadVideo": true,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        try data.write(
+            to: journalDirectory
+                .appendingPathComponent(transactionID)
+                .appendingPathExtension("json")
+        )
+
+        try LivePhotoPairTransaction.recover(in: directory, validatePair: { _, _ in false })
+
+        XCTAssertEqual(try Data(contentsOf: image), Data("new-image".utf8))
+        XCTAssertEqual(try Data(contentsOf: video), Data("new-video".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: imageBackup.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: videoBackup.path))
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: journalDirectory
+                    .appendingPathComponent(transactionID)
+                    .appendingPathExtension("json")
+                    .path
+            )
+        )
+    }
+}

--- a/Tests/XDRemuxAppleFeaturesTests/LivePhotoPairTransactionTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/LivePhotoPairTransactionTests.swift
@@ -166,6 +166,41 @@ final class LivePhotoPairTransactionTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: videoBackup.path))
     }
 
+    func testCommittedRecoveryNeverRollsBackWhenCleanupWasInterrupted() throws {
+        let directory = try makeDirectory("recovery-committed-cleanup")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let id = "c0ffee"
+        let image = directory.appendingPathComponent("photo.heic")
+        let video = directory.appendingPathComponent("photo.mov")
+        let imageBackup = directory.appendingPathComponent(".photo.heic.c0ffee.backup")
+        let videoBackup = directory.appendingPathComponent(".photo.mov.c0ffee.backup")
+        try Data("new-image".utf8).write(to: image)
+        try Data("new-video".utf8).write(to: video)
+        // Simulate cleanup already having deleted one backup when the process died.
+        try Data("old-video".utf8).write(to: videoBackup)
+
+        let manifest = LivePhotoPairTransaction.Manifest(
+            schemaVersion: LivePhotoPairTransaction.schemaVersion,
+            transactionID: id,
+            state: .committed,
+            finalImage: image.lastPathComponent,
+            finalVideo: video.lastPathComponent,
+            temporaryImage: ".photo.c0ffee.tmp.heic",
+            temporaryVideo: ".photo.c0ffee.tmp.mov",
+            backupImage: imageBackup.lastPathComponent,
+            backupVideo: videoBackup.lastPathComponent,
+            hadImage: true,
+            hadVideo: true
+        )
+        _ = try LivePhotoPairTransaction.writeManifest(manifest, in: directory)
+
+        try LivePhotoPairTransaction.recover(in: directory, validatePair: { _, _ in false })
+
+        XCTAssertEqual(try Data(contentsOf: image), Data("new-image".utf8))
+        XCTAssertEqual(try Data(contentsOf: video), Data("new-video".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: videoBackup.path))
+    }
+
     private func makeDirectory(_ suffix: String) throws -> URL {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
             "xdremux-live-photo-transaction-\(suffix)-\(UUID().uuidString)",

--- a/Tests/XDRemuxAppleFeaturesTests/LivePhotoPairTransactionTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/LivePhotoPairTransactionTests.swift
@@ -1,0 +1,177 @@
+import Foundation
+import XCTest
+@testable import XDRemuxAppleFeatures
+
+final class LivePhotoPairTransactionTests: XCTestCase {
+    func testCommitReplacesBothResourcesAndCleansJournal() throws {
+        let directory = try makeDirectory("commit")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let image = directory.appendingPathComponent("photo.heic")
+        let video = directory.appendingPathComponent("photo.mov")
+        let tempImage = directory.appendingPathComponent(".photo.tx.tmp.heic")
+        let tempVideo = directory.appendingPathComponent(".photo.tx.tmp.mov")
+        try Data("old-image".utf8).write(to: image)
+        try Data("old-video".utf8).write(to: video)
+        try Data("new-image".utf8).write(to: tempImage)
+        try Data("new-video".utf8).write(to: tempVideo)
+
+        try LivePhotoPairTransaction.commit(
+            temporaryImageURL: tempImage,
+            temporaryVideoURL: tempVideo,
+            finalImageURL: image,
+            finalVideoURL: video,
+            validatePair: { _, _ in true }
+        )
+
+        XCTAssertEqual(try Data(contentsOf: image), Data("new-image".utf8))
+        XCTAssertEqual(try Data(contentsOf: video), Data("new-video".utf8))
+        let journalDirectory = directory.appendingPathComponent(
+            LivePhotoPairTransaction.journalDirectoryName,
+            isDirectory: true
+        )
+        let journals = (try? FileManager.default.contentsOfDirectory(at: journalDirectory, includingPropertiesForKeys: nil)) ?? []
+        XCTAssertFalse(journals.contains { $0.pathExtension == "json" })
+    }
+
+    func testCommitRejectsTemporaryPairOutsideDestinationDirectory() throws {
+        let directory = try makeDirectory("destination")
+        let other = try makeDirectory("other")
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+            try? FileManager.default.removeItem(at: other)
+        }
+        let image = directory.appendingPathComponent("photo.heic")
+        let video = directory.appendingPathComponent("photo.mov")
+        let tempImage = other.appendingPathComponent("photo.tmp.heic")
+        let tempVideo = other.appendingPathComponent("photo.tmp.mov")
+        try Data("image".utf8).write(to: tempImage)
+        try Data("video".utf8).write(to: tempVideo)
+
+        XCTAssertThrowsError(
+            try LivePhotoPairTransaction.commit(
+                temporaryImageURL: tempImage,
+                temporaryVideoURL: tempVideo,
+                finalImageURL: image,
+                finalVideoURL: video,
+                validatePair: { _, _ in true }
+            )
+        )
+    }
+
+    func testRecoveryRestoresOriginalsAfterImageWasInstalled() throws {
+        let directory = try makeDirectory("recovery-image")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let id = "abc123"
+        let image = directory.appendingPathComponent("photo.heic")
+        let video = directory.appendingPathComponent("photo.mov")
+        let tempImage = directory.appendingPathComponent(".photo.abc123.tmp.heic")
+        let tempVideo = directory.appendingPathComponent(".photo.abc123.tmp.mov")
+        let imageBackup = directory.appendingPathComponent(".photo.heic.abc123.backup")
+        let videoBackup = directory.appendingPathComponent(".photo.mov.abc123.backup")
+        try Data("new-image".utf8).write(to: image)
+        try Data("new-video".utf8).write(to: tempVideo)
+        try Data("old-image".utf8).write(to: imageBackup)
+        try Data("old-video".utf8).write(to: videoBackup)
+
+        let manifest = LivePhotoPairTransaction.Manifest(
+            schemaVersion: LivePhotoPairTransaction.schemaVersion,
+            transactionID: id,
+            state: .imageInstalled,
+            finalImage: image.lastPathComponent,
+            finalVideo: video.lastPathComponent,
+            temporaryImage: tempImage.lastPathComponent,
+            temporaryVideo: tempVideo.lastPathComponent,
+            backupImage: imageBackup.lastPathComponent,
+            backupVideo: videoBackup.lastPathComponent,
+            hadImage: true,
+            hadVideo: true
+        )
+        _ = try LivePhotoPairTransaction.writeManifest(manifest, in: directory)
+
+        try LivePhotoPairTransaction.recover(in: directory, validatePair: { _, _ in false })
+
+        XCTAssertEqual(try Data(contentsOf: image), Data("old-image".utf8))
+        XCTAssertEqual(try Data(contentsOf: video), Data("old-video".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tempVideo.path))
+    }
+
+    func testRecoveryInfersRenameThatHappenedBeforeStateUpdate() throws {
+        let directory = try makeDirectory("recovery-window")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let id = "deadbeef"
+        let image = directory.appendingPathComponent("photo.heic")
+        let video = directory.appendingPathComponent("photo.mov")
+        let tempImage = directory.appendingPathComponent(".photo.deadbeef.tmp.heic")
+        let tempVideo = directory.appendingPathComponent(".photo.deadbeef.tmp.mov")
+        try Data("new-image".utf8).write(to: image)
+        try Data("new-video".utf8).write(to: tempVideo)
+
+        let manifest = LivePhotoPairTransaction.Manifest(
+            schemaVersion: LivePhotoPairTransaction.schemaVersion,
+            transactionID: id,
+            state: .originalsBackedUp,
+            finalImage: image.lastPathComponent,
+            finalVideo: video.lastPathComponent,
+            temporaryImage: tempImage.lastPathComponent,
+            temporaryVideo: tempVideo.lastPathComponent,
+            backupImage: ".photo.heic.deadbeef.backup",
+            backupVideo: ".photo.mov.deadbeef.backup",
+            hadImage: false,
+            hadVideo: false
+        )
+        _ = try LivePhotoPairTransaction.writeManifest(manifest, in: directory)
+
+        try LivePhotoPairTransaction.recover(in: directory, validatePair: { _, _ in false })
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: image.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: video.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tempVideo.path))
+    }
+
+    func testPairInstalledRecoveryFinalizesValidPair() throws {
+        let directory = try makeDirectory("recovery-finalize")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let id = "feedface"
+        let image = directory.appendingPathComponent("photo.heic")
+        let video = directory.appendingPathComponent("photo.mov")
+        let imageBackup = directory.appendingPathComponent(".photo.heic.feedface.backup")
+        let videoBackup = directory.appendingPathComponent(".photo.mov.feedface.backup")
+        try Data("new-image".utf8).write(to: image)
+        try Data("new-video".utf8).write(to: video)
+        try Data("old-image".utf8).write(to: imageBackup)
+        try Data("old-video".utf8).write(to: videoBackup)
+
+        let manifest = LivePhotoPairTransaction.Manifest(
+            schemaVersion: LivePhotoPairTransaction.schemaVersion,
+            transactionID: id,
+            state: .pairInstalled,
+            finalImage: image.lastPathComponent,
+            finalVideo: video.lastPathComponent,
+            temporaryImage: ".photo.feedface.tmp.heic",
+            temporaryVideo: ".photo.feedface.tmp.mov",
+            backupImage: imageBackup.lastPathComponent,
+            backupVideo: videoBackup.lastPathComponent,
+            hadImage: true,
+            hadVideo: true
+        )
+        _ = try LivePhotoPairTransaction.writeManifest(manifest, in: directory)
+
+        try LivePhotoPairTransaction.recover(in: directory, validatePair: { candidateImage, candidateVideo in
+            candidateImage == image && candidateVideo == video
+        })
+
+        XCTAssertEqual(try Data(contentsOf: image), Data("new-image".utf8))
+        XCTAssertEqual(try Data(contentsOf: video), Data("new-video".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: imageBackup.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: videoBackup.path))
+    }
+
+    private func makeDirectory(_ suffix: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "xdremux-live-photo-transaction-\(suffix)-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+}

--- a/Tests/XDRemuxCLITests/MotionPhotoBatchCheckpointTests.swift
+++ b/Tests/XDRemuxCLITests/MotionPhotoBatchCheckpointTests.swift
@@ -37,6 +37,59 @@ final class MotionPhotoBatchCheckpointTests: XCTestCase {
         XCTAssertEqual(item.sourceRelativePath, "source.jpg")
     }
 
+    func testCanonicalPythonWireRecordLoadsInSwift() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-motion-checkpoint-python-wire-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let input = directory.appendingPathComponent("source.jpg")
+        let image = directory.appendingPathComponent("source.heic")
+        let video = directory.appendingPathComponent("source.mov")
+        let checkpoint = directory.appendingPathComponent("checkpoint.jsonl")
+        let digest = String(repeating: "ab", count: 32)
+        let record: [String: Any] = [
+            "kind": "item",
+            "inputPath": input.standardizedFileURL.path,
+            "sourceRelativePath": "source.jpg",
+            "outputImagePath": image.standardizedFileURL.path,
+            "outputVideoPath": video.standardizedFileURL.path,
+            "status": "success",
+            "inputSize": 123,
+            "inputMtimeNs": 456,
+            "inputSHA256": digest,
+            "assetIdentifier": "ASSET-PYTHON",
+            "error": NSNull(),
+        ]
+        let data = try JSONSerialization.data(withJSONObject: record, options: [.sortedKeys])
+        try data.write(to: checkpoint)
+        let handle = try FileHandle(forWritingTo: checkpoint)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data([0x0a]))
+        try handle.close()
+
+        let state = try MotionPhotoBatchCheckpoint.load(url: checkpoint)
+        let item = try XCTUnwrap(state[input.standardizedFileURL.path])
+        XCTAssertEqual(item.inputSHA256, digest)
+        XCTAssertEqual(item.assetIdentifier, "ASSET-PYTHON")
+        XCTAssertTrue(item.matchesOutputs(imageURL: image, videoURL: video))
+    }
+
+    func testMalformedForeignRecordIsIgnoredFailClosed() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-motion-checkpoint-malformed-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let checkpoint = directory.appendingPathComponent("checkpoint.jsonl")
+        let input = directory.appendingPathComponent("source.jpg").standardizedFileURL.path
+        let contents = """
+        {"kind":"item","inputPath":"\(input)","unexpected":true}
+        {"kind":"item"
+        """
+        try Data(contents.utf8).write(to: checkpoint)
+        XCTAssertEqual(try MotionPhotoBatchCheckpoint.load(url: checkpoint).count, 0)
+    }
+
     func testChangedInputSignatureDoesNotResumeAsDone() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("xdremux-motion-checkpoint-change-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/XDRemuxCLITests/MotionPhotoBatchCheckpointTests.swift
+++ b/Tests/XDRemuxCLITests/MotionPhotoBatchCheckpointTests.swift
@@ -19,10 +19,12 @@ final class MotionPhotoBatchCheckpointTests: XCTestCase {
         let writer = try MotionPhotoBatchCheckpoint.Writer(url: checkpoint)
         try writer.append(
             inputURL: input,
+            inputRootURL: directory,
             outputImageURL: image,
             outputVideoURL: video,
             status: .success,
-            signature: signature
+            signature: signature,
+            assetIdentifier: "ASSET-1"
         )
         try writer.close()
 
@@ -31,6 +33,8 @@ final class MotionPhotoBatchCheckpointTests: XCTestCase {
         XCTAssertEqual(item.status, .success)
         XCTAssertTrue(item.matchesSignature(signature))
         XCTAssertTrue(item.matchesOutputs(imageURL: image, videoURL: video))
+        XCTAssertEqual(item.assetIdentifier, "ASSET-1")
+        XCTAssertEqual(item.sourceRelativePath, "source.jpg")
     }
 
     func testChangedInputSignatureDoesNotResumeAsDone() throws {
@@ -52,7 +56,8 @@ final class MotionPhotoBatchCheckpointTests: XCTestCase {
             outputImageURL: image,
             outputVideoURL: video,
             status: .success,
-            signature: before
+            signature: before,
+            assetIdentifier: "ASSET-1"
         )
         try writer.close()
 
@@ -61,5 +66,26 @@ final class MotionPhotoBatchCheckpointTests: XCTestCase {
         let state = try MotionPhotoBatchCheckpoint.load(url: checkpoint)
         let item = try XCTUnwrap(state[input.standardizedFileURL.path])
         XCTAssertFalse(item.matchesSignature(after))
+    }
+
+    func testDigestDetectsSameSizeContentChangeEvenWhenMtimeIsRestored() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-motion-checkpoint-digest-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let input = directory.appendingPathComponent("source.jpg")
+        try Data("AAAA".utf8).write(to: input)
+        let before = try MotionPhotoBatchCheckpoint.signature(for: input)
+        let attributes = try FileManager.default.attributesOfItem(atPath: input.path)
+        let modificationDate = try XCTUnwrap(attributes[.modificationDate] as? Date)
+
+        try Data("BBBB".utf8).write(to: input)
+        try FileManager.default.setAttributes([.modificationDate: modificationDate], ofItemAtPath: input.path)
+        let after = try MotionPhotoBatchCheckpoint.signature(for: input)
+
+        XCTAssertEqual(before.size, after.size)
+        XCTAssertNotEqual(before.sha256, after.sha256)
+        XCTAssertNotEqual(before, after)
     }
 }

--- a/Tests/XDRemuxCLITests/MotionPhotoBatchPlannerTests.swift
+++ b/Tests/XDRemuxCLITests/MotionPhotoBatchPlannerTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import XCTest
+@testable import XDRemuxCLI
+
+final class MotionPhotoBatchPlannerTests: XCTestCase {
+    func testDuplicateBasenamesRemainDistinctAndStableAcrossSubsetRuns() throws {
+        let root = URL(fileURLWithPath: "/tmp/xdremux-input", isDirectory: true)
+        let output = URL(fileURLWithPath: "/tmp/xdremux-output", isDirectory: true)
+        let a = root.appendingPathComponent("A/IMG.jpg")
+        let b = root.appendingPathComponent("B/IMG.jpg")
+
+        let aOutput = MotionPhotoBatchPlanner.outputImageURL(
+            for: a,
+            inputRootURL: root,
+            outputDirectoryURL: output
+        )
+        let bOutput = MotionPhotoBatchPlanner.outputImageURL(
+            for: b,
+            inputRootURL: root,
+            outputDirectoryURL: output
+        )
+        let bSubsetOutput = MotionPhotoBatchPlanner.outputImageURL(
+            for: b,
+            inputRootURL: root,
+            outputDirectoryURL: output
+        )
+
+        XCTAssertNotEqual(aOutput, bOutput)
+        XCTAssertEqual(bOutput, bSubsetOutput)
+        XCTAssertTrue(aOutput.lastPathComponent.hasPrefix("IMG~"))
+        XCTAssertTrue(bOutput.lastPathComponent.hasPrefix("IMG~"))
+        XCTAssertEqual(aOutput.pathExtension, "heic")
+    }
+
+    func testHEIFMotionPhotoUsesSeparateLiveNamespace() {
+        let root = URL(fileURLWithPath: "/tmp/xdremux-input", isDirectory: true)
+        let output = URL(fileURLWithPath: "/tmp/xdremux-output", isDirectory: true)
+        let input = root.appendingPathComponent("IMG.heic")
+        let planned = MotionPhotoBatchPlanner.outputImageURL(
+            for: input,
+            inputRootURL: root,
+            outputDirectoryURL: output
+        )
+        XCTAssertTrue(planned.lastPathComponent.hasPrefix("IMG.live~"))
+        XCTAssertEqual(planned.pathExtension, "heic")
+    }
+
+    func testPlannerRejectsDuplicateDestinationInsteadOfRenumberingByOrder() {
+        let first = URL(fileURLWithPath: "/tmp/a.jpg")
+        let second = URL(fileURLWithPath: "/tmp/b.jpg")
+        let output = URL(fileURLWithPath: "/tmp/result.heic")
+        XCTAssertThrowsError(
+            try MotionPhotoBatchPlanner.validateUnique([
+                (input: first, output: output),
+                (input: second, output: output),
+            ])
+        )
+    }
+}

--- a/Tests/XDRemuxCLITests/MotionPhotoBatchPlannerTests.swift
+++ b/Tests/XDRemuxCLITests/MotionPhotoBatchPlannerTests.swift
@@ -32,6 +32,27 @@ final class MotionPhotoBatchPlannerTests: XCTestCase {
         XCTAssertEqual(aOutput.pathExtension, "heic")
     }
 
+    func testSameRelativePathInDifferentInputRootsCannotAliasSharedOutputDirectory() {
+        let firstRoot = URL(fileURLWithPath: "/tmp/xdremux-root-one", isDirectory: true)
+        let secondRoot = URL(fileURLWithPath: "/tmp/xdremux-root-two", isDirectory: true)
+        let output = URL(fileURLWithPath: "/tmp/xdremux-shared-output", isDirectory: true)
+        let first = firstRoot.appendingPathComponent("A/IMG.jpg")
+        let second = secondRoot.appendingPathComponent("A/IMG.jpg")
+
+        let firstOutput = MotionPhotoBatchPlanner.outputImageURL(
+            for: first,
+            inputRootURL: firstRoot,
+            outputDirectoryURL: output
+        )
+        let secondOutput = MotionPhotoBatchPlanner.outputImageURL(
+            for: second,
+            inputRootURL: secondRoot,
+            outputDirectoryURL: output
+        )
+
+        XCTAssertNotEqual(firstOutput, secondOutput)
+    }
+
     func testHEIFMotionPhotoUsesSeparateLiveNamespace() {
         let root = URL(fileURLWithPath: "/tmp/xdremux-input", isDirectory: true)
         let output = URL(fileURLWithPath: "/tmp/xdremux-output", isDirectory: true)

--- a/Tests/test_python_live_photo_batch_reliability.py
+++ b/Tests/test_python_live_photo_batch_reliability.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from xdremux_py.cli import _default_batch_candidates, _validate_unique_normal_plan
 from xdremux_py.live_photo_batch import (
     StateWriter,
     load_state,
@@ -156,6 +157,24 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
                 state_path(output, requested),
                 requested.parent / "state.jsonl.motion-photo",
             )
+
+    def test_hidden_transaction_temp_is_never_discovered_as_user_input(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            visible = root / "IMG.heic"
+            hidden_temp = root / ".IMG.abc123.tmp.heic"
+            visible.write_bytes(b"visible")
+            hidden_temp.write_bytes(b"transaction-temp")
+            self.assertEqual(_default_batch_candidates(root), [visible])
+
+    def test_normal_output_collision_fails_before_any_write(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            first = root / "A" / "IMG.heic"
+            second = root / "B" / "IMG.heic"
+            output = root / "output" / "IMG.heic"
+            with self.assertRaisesRegex(ValueError, "planned ProXDR output collision"):
+                _validate_unique_normal_plan([(first, output), (second, output)])
 
     def test_schema_one_style_entry_without_digest_is_not_trusted(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/Tests/test_python_live_photo_batch_reliability.py
+++ b/Tests/test_python_live_photo_batch_reliability.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import tempfile
 import unittest
@@ -100,7 +101,6 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
                     lambda i, v, identifier: False,
                 )
             )
-            changed = source_signature(source)
             source.write_bytes(b"SOURCE")
             changed = source_signature(source)
             self.assertFalse(
@@ -112,6 +112,40 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
                     lambda i, v, identifier: True,
                 )
             )
+
+    def test_python_writer_uses_swift_checkpoint_wire_schema(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "input"
+            output = Path(tmp) / "output"
+            root.mkdir()
+            output.mkdir()
+            source = root / "IMG.jpg"
+            source.write_bytes(b"source")
+            signature = source_signature(source)
+            image = planned_output_image(source, root, output)
+            video = image.with_suffix(".mov")
+            state_path = output / ".state.jsonl"
+
+            with StateWriter(state_path) as writer:
+                writer.append(
+                    source=source,
+                    input_root=root,
+                    image=image,
+                    video=video,
+                    status="success",
+                    signature=signature,
+                    asset_identifier="ASSET-1",
+                )
+
+            records = [json.loads(line) for line in state_path.read_text(encoding="utf-8").splitlines()]
+            self.assertEqual(records[0]["schemaVersion"], 2)
+            item = records[1]
+            self.assertEqual(item["inputPath"], str(source.resolve()))
+            self.assertEqual(item["sourceRelativePath"], "IMG.jpg")
+            self.assertEqual(item["inputSHA256"], signature.sha256)
+            self.assertEqual(item["assetIdentifier"], "ASSET-1")
+            self.assertNotIn("input_path", item)
+            self.assertNotIn("input_sha256", item)
 
     def test_schema_one_style_entry_without_digest_is_not_trusted(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/Tests/test_python_live_photo_batch_reliability.py
+++ b/Tests/test_python_live_photo_batch_reliability.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from xdremux_py.live_photo_batch import (
+    StateWriter,
+    load_state,
+    planned_output_image,
+    provenance_allows_reuse,
+    source_signature,
+)
+
+
+class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
+    def test_duplicate_basenames_have_stable_distinct_outputs_across_subset_rerun(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "input"
+            output = Path(tmp) / "output"
+            a = root / "A" / "IMG.jpg"
+            b = root / "B" / "IMG.jpg"
+            a.parent.mkdir(parents=True)
+            b.parent.mkdir(parents=True)
+            a.write_bytes(b"a")
+            b.write_bytes(b"b")
+
+            a_output = planned_output_image(a, root, output)
+            b_output = planned_output_image(b, root, output)
+            b_subset_output = planned_output_image(b, root, output)
+
+            self.assertNotEqual(a_output, b_output)
+            self.assertEqual(b_output, b_subset_output)
+            self.assertTrue(a_output.name.startswith("IMG~"))
+            self.assertTrue(b_output.name.startswith("IMG~"))
+
+    def test_heif_motion_photo_uses_live_namespace_and_stable_token(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "input"
+            root.mkdir()
+            source = root / "same.heic"
+            source.write_bytes(b"heif")
+            output = planned_output_image(source, root, Path(tmp) / "output")
+            self.assertTrue(output.name.startswith("same.live~"))
+            self.assertTrue(output.name.endswith(".heic"))
+
+    def test_content_hash_detects_change_even_when_size_and_mtime_are_preserved(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "source.jpg"
+            source.write_bytes(b"AAAA")
+            before = source_signature(source)
+            source.write_bytes(b"BBBB")
+            os.utime(source, ns=(before.mtime_ns, before.mtime_ns))
+            after = source_signature(source)
+            self.assertEqual(before.size, after.size)
+            self.assertEqual(before.mtime_ns, after.mtime_ns)
+            self.assertNotEqual(before.sha256, after.sha256)
+
+    def test_state_requires_source_hash_outputs_asset_identifier_and_pair_match(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "input"
+            output = Path(tmp) / "output"
+            root.mkdir()
+            output.mkdir()
+            source = root / "IMG.jpg"
+            source.write_bytes(b"source")
+            image = planned_output_image(source, root, output)
+            video = image.with_suffix(".mov")
+            signature = source_signature(source)
+            state_path = output / ".state.jsonl"
+
+            with StateWriter(state_path) as writer:
+                writer.append(
+                    source=source,
+                    input_root=root,
+                    image=image,
+                    video=video,
+                    status="success",
+                    signature=signature,
+                    asset_identifier="ASSET-1",
+                )
+
+            prior = load_state(state_path)[str(source.resolve())]
+            self.assertTrue(
+                provenance_allows_reuse(
+                    prior,
+                    signature,
+                    image,
+                    video,
+                    lambda i, v, identifier: identifier == "ASSET-1",
+                )
+            )
+            self.assertFalse(
+                provenance_allows_reuse(
+                    prior,
+                    signature,
+                    image,
+                    video,
+                    lambda i, v, identifier: False,
+                )
+            )
+            changed = source_signature(source)
+            source.write_bytes(b"SOURCE")
+            changed = source_signature(source)
+            self.assertFalse(
+                provenance_allows_reuse(
+                    prior,
+                    changed,
+                    image,
+                    video,
+                    lambda i, v, identifier: True,
+                )
+            )
+
+    def test_schema_one_style_entry_without_digest_is_not_trusted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_path = Path(tmp) / "state.jsonl"
+            state_path.write_text(
+                '{"kind":"header","schema_version":1}\n'
+                '{"kind":"item","input_path":"/tmp/a.jpg","output_image_path":"/tmp/a.heic",'
+                '"output_video_path":"/tmp/a.mov","status":"success","input_size":1,'
+                '"input_mtime_ns":1,"error":null}\n',
+                encoding="utf-8",
+            )
+            self.assertEqual(load_state(state_path), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/test_python_live_photo_batch_reliability.py
+++ b/Tests/test_python_live_photo_batch_reliability.py
@@ -12,6 +12,7 @@ from xdremux_py.live_photo_batch import (
     planned_output_image,
     provenance_allows_reuse,
     source_signature,
+    state_path,
 )
 
 
@@ -69,9 +70,9 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
             image = planned_output_image(source, root, output)
             video = image.with_suffix(".mov")
             signature = source_signature(source)
-            state_path = output / ".state.jsonl"
+            checkpoint = output / ".state.jsonl"
 
-            with StateWriter(state_path) as writer:
+            with StateWriter(checkpoint) as writer:
                 writer.append(
                     source=source,
                     input_root=root,
@@ -82,7 +83,7 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
                     asset_identifier="ASSET-1",
                 )
 
-            prior = load_state(state_path)[str(source.resolve())]
+            prior = load_state(checkpoint)[str(source.resolve())]
             self.assertTrue(
                 provenance_allows_reuse(
                     prior,
@@ -124,9 +125,9 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
             signature = source_signature(source)
             image = planned_output_image(source, root, output)
             video = image.with_suffix(".mov")
-            state_path = output / ".state.jsonl"
+            checkpoint = output / ".state.jsonl"
 
-            with StateWriter(state_path) as writer:
+            with StateWriter(checkpoint) as writer:
                 writer.append(
                     source=source,
                     input_root=root,
@@ -137,7 +138,7 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
                     asset_identifier="ASSET-1",
                 )
 
-            records = [json.loads(line) for line in state_path.read_text(encoding="utf-8").splitlines()]
+            records = [json.loads(line) for line in checkpoint.read_text(encoding="utf-8").splitlines()]
             self.assertEqual(records[0]["schemaVersion"], 2)
             item = records[1]
             self.assertEqual(item["inputPath"], str(source.resolve()))
@@ -147,17 +148,26 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
             self.assertNotIn("input_path", item)
             self.assertNotIn("input_sha256", item)
 
+    def test_custom_checkpoint_path_matches_swift_motion_photo_suffix_contract(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "output"
+            requested = Path(tmp) / "state.jsonl"
+            self.assertEqual(
+                state_path(output, requested),
+                requested.parent / "state.jsonl.motion-photo",
+            )
+
     def test_schema_one_style_entry_without_digest_is_not_trusted(self):
         with tempfile.TemporaryDirectory() as tmp:
-            state_path = Path(tmp) / "state.jsonl"
-            state_path.write_text(
+            checkpoint = Path(tmp) / "state.jsonl"
+            checkpoint.write_text(
                 '{"kind":"header","schema_version":1}\n'
                 '{"kind":"item","input_path":"/tmp/a.jpg","output_image_path":"/tmp/a.heic",'
                 '"output_video_path":"/tmp/a.mov","status":"success","input_size":1,'
                 '"input_mtime_ns":1,"error":null}\n',
                 encoding="utf-8",
             )
-            self.assertEqual(load_state(state_path), {})
+            self.assertEqual(load_state(checkpoint), {})
 
 
 if __name__ == "__main__":

--- a/Tests/test_python_live_photo_batch_reliability.py
+++ b/Tests/test_python_live_photo_batch_reliability.py
@@ -38,6 +38,24 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
             self.assertTrue(a_output.name.startswith("IMG~"))
             self.assertTrue(b_output.name.startswith("IMG~"))
 
+    def test_same_relative_path_in_different_input_roots_cannot_alias_shared_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            first_root = base / "root-one"
+            second_root = base / "root-two"
+            output = base / "shared-output"
+            first = first_root / "A" / "IMG.jpg"
+            second = second_root / "A" / "IMG.jpg"
+            first.parent.mkdir(parents=True)
+            second.parent.mkdir(parents=True)
+            first.write_bytes(b"first")
+            second.write_bytes(b"second")
+
+            self.assertNotEqual(
+                planned_output_image(first, first_root, output),
+                planned_output_image(second, second_root, output),
+            )
+
     def test_heif_motion_photo_uses_live_namespace_and_stable_token(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "input"

--- a/Tests/test_python_live_photo_cross_runtime_schema.py
+++ b/Tests/test_python_live_photo_cross_runtime_schema.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from xdremux_py.live_photo_transaction import JOURNAL_DIRECTORY, SCHEMA_VERSION, recover_transactions
+
+
+class PythonLivePhotoCrossRuntimeSchemaTests(unittest.TestCase):
+    def test_python_recovers_canonical_swift_committed_journal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            journal_directory = directory / JOURNAL_DIRECTORY
+            journal_directory.mkdir()
+            transaction_id = "swift-feedface"
+            # Swift UUIDs normally contain hyphens; use only the accepted portable character set.
+            transaction_id = "feed-face"
+            image = directory / "photo.heic"
+            video = directory / "photo.mov"
+            image_backup = directory / ".photo.heic.feed-face.backup"
+            video_backup = directory / ".photo.mov.feed-face.backup"
+            image.write_bytes(b"new-image")
+            video.write_bytes(b"new-video")
+            image_backup.write_bytes(b"old-image")
+            video_backup.write_bytes(b"old-video")
+
+            # Exact camelCase wire names emitted by Swift JSONEncoder.
+            manifest = {
+                "schemaVersion": SCHEMA_VERSION,
+                "transactionID": transaction_id,
+                "state": "committed",
+                "finalImage": image.name,
+                "finalVideo": video.name,
+                "temporaryImage": ".photo.feed-face.tmp.heic",
+                "temporaryVideo": ".photo.feed-face.tmp.mov",
+                "backupImage": image_backup.name,
+                "backupVideo": video_backup.name,
+                "hadImage": True,
+                "hadVideo": True,
+            }
+            (journal_directory / f"{transaction_id}.json").write_text(
+                json.dumps(manifest), encoding="utf-8"
+            )
+
+            recover_transactions(directory, pair_validator=lambda i, v: False)
+
+            self.assertEqual(image.read_bytes(), b"new-image")
+            self.assertEqual(video.read_bytes(), b"new-video")
+            self.assertFalse(image_backup.exists())
+            self.assertFalse(video_backup.exists())
+            self.assertEqual(list(journal_directory.glob("*.json")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/test_python_live_photo_transaction.py
+++ b/Tests/test_python_live_photo_transaction.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from xdremux_py.live_photo_transaction import (
+    JOURNAL_DIRECTORY,
+    SCHEMA_VERSION,
+    commit_pair,
+    recover_transactions,
+)
+
+
+class PythonLivePhotoTransactionTests(unittest.TestCase):
+    def test_commit_replaces_both_resources_and_removes_journal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            image = directory / "photo.heic"
+            video = directory / "photo.mov"
+            temp_image = directory / ".photo.tx.tmp.heic"
+            temp_video = directory / ".photo.tx.tmp.mov"
+            image.write_bytes(b"old-image")
+            video.write_bytes(b"old-video")
+            temp_image.write_bytes(b"new-image")
+            temp_video.write_bytes(b"new-video")
+
+            commit_pair(temp_image, temp_video, image, video, pair_validator=lambda i, v: True)
+
+            self.assertEqual(image.read_bytes(), b"new-image")
+            self.assertEqual(video.read_bytes(), b"new-video")
+            journal_dir = directory / JOURNAL_DIRECTORY
+            self.assertEqual(list(journal_dir.glob("*.json")), [])
+            self.assertEqual(list(directory.glob("*.backup")), [])
+
+    def test_commit_rejects_cross_directory_temporary_files_before_rename(self):
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as other:
+            directory = Path(tmp)
+            image = directory / "photo.heic"
+            video = directory / "photo.mov"
+            temp_image = Path(other) / "photo.tmp.heic"
+            temp_video = Path(other) / "photo.tmp.mov"
+            temp_image.write_bytes(b"image")
+            temp_video.write_bytes(b"video")
+            with self.assertRaisesRegex(ValueError, "destination directory/filesystem"):
+                commit_pair(temp_image, temp_video, image, video)
+
+    def test_recovery_restores_originals_when_crash_occurs_after_image_install(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            journal_dir = directory / JOURNAL_DIRECTORY
+            journal_dir.mkdir()
+            transaction_id = "abc123"
+            image = directory / "photo.heic"
+            video = directory / "photo.mov"
+            temp_image = directory / ".photo.abc123.tmp.heic"
+            temp_video = directory / ".photo.abc123.tmp.mov"
+            image_backup = directory / ".photo.heic.abc123.backup"
+            video_backup = directory / ".photo.mov.abc123.backup"
+
+            # Filesystem truth after: old pair -> backups, new image installed, new video pending.
+            image.write_bytes(b"new-image")
+            temp_video.write_bytes(b"new-video")
+            image_backup.write_bytes(b"old-image")
+            video_backup.write_bytes(b"old-video")
+            manifest = {
+                "schema_version": SCHEMA_VERSION,
+                "transaction_id": transaction_id,
+                "state": "image_installed",
+                "final_image": image.name,
+                "final_video": video.name,
+                "temporary_image": temp_image.name,
+                "temporary_video": temp_video.name,
+                "backup_image": image_backup.name,
+                "backup_video": video_backup.name,
+                "had_image": True,
+                "had_video": True,
+            }
+            (journal_dir / f"{transaction_id}.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+            recover_transactions(directory, pair_validator=lambda i, v: False)
+
+            self.assertEqual(image.read_bytes(), b"old-image")
+            self.assertEqual(video.read_bytes(), b"old-video")
+            self.assertFalse(temp_video.exists())
+            self.assertEqual(list(journal_dir.glob("*.json")), [])
+
+    def test_recovery_handles_crash_between_rename_and_state_update(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            journal_dir = directory / JOURNAL_DIRECTORY
+            journal_dir.mkdir()
+            transaction_id = "deadbeef"
+            image = directory / "photo.heic"
+            video = directory / "photo.mov"
+            temp_image = directory / ".photo.deadbeef.tmp.heic"
+            temp_video = directory / ".photo.deadbeef.tmp.mov"
+
+            # No originals existed. The image rename happened, then the process died before the
+            # journal advanced from originals_backed_up to image_installed.
+            image.write_bytes(b"new-image")
+            temp_video.write_bytes(b"new-video")
+            manifest = {
+                "schema_version": SCHEMA_VERSION,
+                "transaction_id": transaction_id,
+                "state": "originals_backed_up",
+                "final_image": image.name,
+                "final_video": video.name,
+                "temporary_image": temp_image.name,
+                "temporary_video": temp_video.name,
+                "backup_image": ".photo.heic.deadbeef.backup",
+                "backup_video": ".photo.mov.deadbeef.backup",
+                "had_image": False,
+                "had_video": False,
+            }
+            (journal_dir / f"{transaction_id}.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+            recover_transactions(directory, pair_validator=lambda i, v: False)
+
+            self.assertFalse(image.exists())
+            self.assertFalse(video.exists())
+            self.assertFalse(temp_video.exists())
+            self.assertEqual(list(journal_dir.glob("*.json")), [])
+
+    def test_pair_installed_recovery_finalizes_valid_pair_instead_of_rolling_back(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            journal_dir = directory / JOURNAL_DIRECTORY
+            journal_dir.mkdir()
+            transaction_id = "feedface"
+            image = directory / "photo.heic"
+            video = directory / "photo.mov"
+            image.write_bytes(b"new-image")
+            video.write_bytes(b"new-video")
+            image_backup = directory / ".photo.heic.feedface.backup"
+            video_backup = directory / ".photo.mov.feedface.backup"
+            image_backup.write_bytes(b"old-image")
+            video_backup.write_bytes(b"old-video")
+            manifest = {
+                "schema_version": SCHEMA_VERSION,
+                "transaction_id": transaction_id,
+                "state": "pair_installed",
+                "final_image": image.name,
+                "final_video": video.name,
+                "temporary_image": ".photo.feedface.tmp.heic",
+                "temporary_video": ".photo.feedface.tmp.mov",
+                "backup_image": image_backup.name,
+                "backup_video": video_backup.name,
+                "had_image": True,
+                "had_video": True,
+            }
+            (journal_dir / f"{transaction_id}.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+            recover_transactions(directory, pair_validator=lambda i, v: i == image and v == video)
+
+            self.assertEqual(image.read_bytes(), b"new-image")
+            self.assertEqual(video.read_bytes(), b"new-video")
+            self.assertFalse(image_backup.exists())
+            self.assertFalse(video_backup.exists())
+            self.assertEqual(list(journal_dir.glob("*.json")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/test_python_live_photo_transaction.py
+++ b/Tests/test_python_live_photo_transaction.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -60,7 +59,6 @@ class PythonLivePhotoTransactionTests(unittest.TestCase):
             image_backup = directory / ".photo.heic.abc123.backup"
             video_backup = directory / ".photo.mov.abc123.backup"
 
-            # Filesystem truth after: old pair -> backups, new image installed, new video pending.
             image.write_bytes(b"new-image")
             temp_video.write_bytes(b"new-video")
             image_backup.write_bytes(b"old-image")
@@ -98,8 +96,6 @@ class PythonLivePhotoTransactionTests(unittest.TestCase):
             temp_image = directory / ".photo.deadbeef.tmp.heic"
             temp_video = directory / ".photo.deadbeef.tmp.mov"
 
-            # No originals existed. The image rename happened, then the process died before the
-            # journal advanced from originals_backed_up to image_installed.
             image.write_bytes(b"new-image")
             temp_video.write_bytes(b"new-video")
             manifest = {
@@ -158,6 +154,41 @@ class PythonLivePhotoTransactionTests(unittest.TestCase):
             self.assertEqual(image.read_bytes(), b"new-image")
             self.assertEqual(video.read_bytes(), b"new-video")
             self.assertFalse(image_backup.exists())
+            self.assertFalse(video_backup.exists())
+            self.assertEqual(list(journal_dir.glob("*.json")), [])
+
+    def test_committed_recovery_never_rolls_back_during_cleanup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            journal_dir = directory / JOURNAL_DIRECTORY
+            journal_dir.mkdir()
+            transaction_id = "c0ffee"
+            image = directory / "photo.heic"
+            video = directory / "photo.mov"
+            image.write_bytes(b"new-image")
+            video.write_bytes(b"new-video")
+            # Simulate a crash after cleanup removed the image backup but before removing video backup.
+            video_backup = directory / ".photo.mov.c0ffee.backup"
+            video_backup.write_bytes(b"old-video")
+            manifest = {
+                "schema_version": SCHEMA_VERSION,
+                "transaction_id": transaction_id,
+                "state": "committed",
+                "final_image": image.name,
+                "final_video": video.name,
+                "temporary_image": ".photo.c0ffee.tmp.heic",
+                "temporary_video": ".photo.c0ffee.tmp.mov",
+                "backup_image": ".photo.heic.c0ffee.backup",
+                "backup_video": video_backup.name,
+                "had_image": True,
+                "had_video": True,
+            }
+            (journal_dir / f"{transaction_id}.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+            recover_transactions(directory, pair_validator=lambda i, v: False)
+
+            self.assertEqual(image.read_bytes(), b"new-image")
+            self.assertEqual(video.read_bytes(), b"new-video")
             self.assertFalse(video_backup.exists())
             self.assertEqual(list(journal_dir.glob("*.json")), [])
 

--- a/xdremux_py/cli.py
+++ b/xdremux_py/cli.py
@@ -112,6 +112,11 @@ def cmd_convert(command: ConvertCommand) -> int:
     return _convert_one(command.input_path, command.output_path, command.configuration)
 
 
+def _is_internal_batch_artifact(path: Path) -> bool:
+    """Never classify XDRemux hidden temp/recovery files as user inputs."""
+    return path.name.startswith(".")
+
+
 def _default_batch_candidates(input_dir: Path) -> list[Path]:
     """Preserve the legacy non-recursive Python batch discovery contract."""
     allowed = {".heic", ".heif", ".jpg", ".jpeg"}
@@ -119,7 +124,9 @@ def _default_batch_candidates(input_dir: Path) -> list[Path]:
         (
             path
             for path in input_dir.iterdir()
-            if path.is_file() and path.suffix.lower() in allowed
+            if path.is_file()
+            and path.suffix.lower() in allowed
+            and not _is_internal_batch_artifact(path)
         ),
         key=lambda value: str(value.resolve()),
     )
@@ -150,6 +157,17 @@ def _plan_motion_outputs(motion_inputs: list[Path], command: BatchCommand) -> li
     return plan
 
 
+def _validate_unique_normal_plan(plan: list[tuple[Path, Path]]) -> None:
+    """Fail before writes if an explicit glob/categorization flattens two inputs onto one output."""
+    owners: dict[str, Path] = {}
+    for source, output in plan:
+        key = str(output.resolve())
+        prior = owners.get(key)
+        if prior is not None and prior.resolve() != source.resolve():
+            raise ValueError(f"planned ProXDR output collision: {prior} and {source} -> {output}")
+        owners[key] = source
+
+
 def cmd_batch(command: BatchCommand) -> int:
     if not command.input_dir.is_dir():
         print(f"error: input dir not found: {command.input_dir}", file=sys.stderr)
@@ -157,7 +175,11 @@ def cmd_batch(command: BatchCommand) -> int:
     command.output_dir.mkdir(parents=True, exist_ok=True)
     candidates = (
         sorted(
-            (path for path in command.input_dir.glob(command.glob) if path.is_file()),
+            (
+                path
+                for path in command.input_dir.glob(command.glob)
+                if path.is_file() and not _is_internal_batch_artifact(path)
+            ),
             key=lambda value: str(value.resolve()),
         )
         if command.glob_explicit
@@ -198,6 +220,7 @@ def cmd_batch(command: BatchCommand) -> int:
         for input_path in normal_inputs
     ]
     try:
+        _validate_unique_normal_plan(normal_plan)
         motion_plan = _plan_motion_outputs(motion_inputs, command)
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/xdremux_py/cli.py
+++ b/xdremux_py/cli.py
@@ -22,6 +22,15 @@ if __package__ in (None, ""):
 
 from . import categorize, live_photo, pipeline
 from .commands import DEFAULT_BATCH_GLOB, BatchCommand, CategorizeCommand, ConvertCommand
+from .live_photo_batch import (
+    StateWriter,
+    load_state,
+    planned_output_image,
+    provenance_allows_reuse,
+    source_signature,
+    state_path,
+    validate_unique_plan,
+)
 from .motion_photo import MotionPhotoError, parse_motion_photo
 from .pipeline import ConversionAnalysis, ConversionConfiguration, ConversionError, MissingImagingDependencies
 
@@ -60,12 +69,12 @@ def _motion_configuration_is_default(configuration: ConversionConfiguration) -> 
     return not configuration.oppo_compat and not configuration.reencode and configuration.debug_dir is None
 
 
-def _convert_motion(input_path: Path, output_image: Path) -> int:
+def _convert_motion(input_path: Path, output_image: Path) -> live_photo.LivePhotoResult | None:
     try:
         result = live_photo.convert_motion_photo(input_path, output_image)
     except live_photo.LivePhotoConversionError as exc:
         print(f"error: {exc}", file=sys.stderr)
-        return 1
+        return None
     print(f"converted Motion Photo {input_path.name}")
     print(f"  still -> {result.image_path}")
     print(f"  video -> {result.video_path}")
@@ -73,7 +82,7 @@ def _convert_motion(input_path: Path, output_image: Path) -> int:
     print(f"  still-image-time: {result.still_time_seconds:.6f} s")
     for diagnostic in result.diagnostics:
         print(f"  note: {diagnostic}")
-    return 0
+    return result
 
 
 def _probe_motion(path: Path):
@@ -96,27 +105,59 @@ def cmd_convert(command: ConvertCommand) -> int:
             )
             return 1
         output = command.output_path if command.output_explicit else live_photo.default_output_image(command.input_path)
-        return _convert_motion(command.input_path, output)
+        return 0 if _convert_motion(command.input_path, output) is not None else 1
     if command.input_path.suffix.lower() in {".jpg", ".jpeg"}:
         print("error: JPEG input is not a supported Motion Photo", file=sys.stderr)
         return 1
     return _convert_one(command.input_path, command.output_path, command.configuration)
 
 
-def _default_batch_candidates(input_dir: Path) -> list[Path]:
+def _default_batch_candidates(input_dir: Path, output_dir: Path) -> list[Path]:
+    """Recursively snapshot batch inputs while excluding hidden and separate output subtrees."""
     allowed = {".heic", ".heif", ".jpg", ".jpeg"}
-    return sorted(path for path in input_dir.iterdir() if path.is_file() and path.suffix.lower() in allowed)
+    input_root = input_dir.resolve()
+    output_root = output_dir.resolve()
+    exclude_output_subtree = output_root != input_root and output_root.is_relative_to(input_root)
+    candidates: list[Path] = []
+    for path in input_dir.rglob("*"):
+        if not path.is_file() or path.suffix.lower() not in allowed:
+            continue
+        resolved = path.resolve()
+        if exclude_output_subtree and resolved.is_relative_to(output_root):
+            continue
+        try:
+            relative_parts = resolved.relative_to(input_root).parts
+        except ValueError:
+            relative_parts = resolved.parts
+        if any(part.startswith(".") for part in relative_parts):
+            continue
+        candidates.append(path)
+    return sorted(candidates, key=lambda value: str(value.resolve()))
 
 
-def _motion_output_for(source: Path, command: BatchCommand) -> Path:
+def _motion_output_directory(source: Path, command: BatchCommand) -> Path:
     parent = command.output_dir
     if command.categorize_output:
         destination = categorize.batch_destinations([source], command.output_dir).get(source)
         if destination is not None:
             parent = destination.parent
-    if source.suffix.lower() in {".heic", ".heif"}:
-        return parent / f"{source.stem}.live.heic"
-    return parent / f"{source.stem}.heic"
+    return parent
+
+
+def _plan_motion_outputs(motion_inputs: list[Path], command: BatchCommand) -> list[tuple[Path, Path]]:
+    plan = [
+        (
+            source,
+            planned_output_image(
+                source,
+                command.input_dir,
+                _motion_output_directory(source, command),
+            ),
+        )
+        for source in sorted(motion_inputs, key=lambda value: str(value.resolve()))
+    ]
+    validate_unique_plan(plan)
+    return plan
 
 
 def cmd_batch(command: BatchCommand) -> int:
@@ -125,9 +166,16 @@ def cmd_batch(command: BatchCommand) -> int:
         return 1
     command.output_dir.mkdir(parents=True, exist_ok=True)
     candidates = (
-        sorted(path for path in command.input_dir.glob(command.glob) if path.is_file())
-        if command.glob_explicit else _default_batch_candidates(command.input_dir)
+        sorted(
+            (path for path in command.input_dir.glob(command.glob) if path.is_file()),
+            key=lambda value: str(value.resolve()),
+        )
+        if command.glob_explicit
+        else _default_batch_candidates(command.input_dir, command.output_dir)
     )
+
+    # Classification and destination planning are completed before the first write. Batch membership
+    # or worker ordering therefore cannot silently change a source -> Live Photo mapping mid-run.
     motion_inputs: list[Path] = []
     normal_inputs: list[Path] = []
     failed = 0
@@ -150,15 +198,35 @@ def cmd_batch(command: BatchCommand) -> int:
             failed += 1
         # Ordinary JPEG is intentionally ignored by default discovery.
 
+    normal_destinations = (
+        categorize.batch_destinations(normal_inputs, command.output_dir)
+        if normal_inputs and command.categorize_output
+        else {}
+    )
+    normal_plan = [
+        (input_path, normal_destinations.get(input_path, command.output_dir / input_path.name))
+        for input_path in normal_inputs
+    ]
+    try:
+        motion_plan = _plan_motion_outputs(motion_inputs, command)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    normal_output_paths = {str(output.resolve()) for _, output in normal_plan}
+    for source, output in motion_plan:
+        image_key = str(output.resolve())
+        video_key = str(live_photo.companion_video_path(output).resolve())
+        if image_key in normal_output_paths or video_key in normal_output_paths:
+            print(f"error: planned output collision for {source}: {output}", file=sys.stderr)
+            return 1
+
     converted = 0
-    if normal_inputs:
-        destinations = categorize.batch_destinations(normal_inputs, command.output_dir) if command.categorize_output else {}
-        for input_path in normal_inputs:
-            output_path = destinations.get(input_path, command.output_dir / input_path.name)
-            if _convert_one(input_path, output_path, command.configuration) == 0:
-                converted += 1
-            else:
-                failed += 1
+    for input_path, output_path in normal_plan:
+        if _convert_one(input_path, output_path, command.configuration) == 0:
+            converted += 1
+        else:
+            failed += 1
 
     if motion_inputs and not _motion_configuration_is_default(command.configuration):
         print(
@@ -166,17 +234,99 @@ def cmd_batch(command: BatchCommand) -> int:
             file=sys.stderr,
         )
         failed += len(motion_inputs)
-    else:
-        for input_path in motion_inputs:
-            output_image = _motion_output_for(input_path, command)
-            output_video = live_photo.companion_video_path(output_image)
-            if live_photo.existing_pair_is_valid(output_image, output_video):
-                print(f"skipped existing Live Photo pair {output_image.name} + {output_video.name}")
-                continue
-            if _convert_motion(input_path, output_image) == 0:
-                converted += 1
-            else:
-                failed += 1
+    elif motion_plan:
+        checkpoint = state_path(command.output_dir, command.checkpoint_path)
+        state = load_state(checkpoint)
+        with StateWriter(checkpoint) as writer:
+            for input_path, output_image in motion_plan:
+                output_video = live_photo.companion_video_path(output_image)
+                try:
+                    signature = source_signature(input_path)
+                except OSError as exc:
+                    failed += 1
+                    print(f"error: {input_path.name}: could not fingerprint source: {exc}", file=sys.stderr)
+                    continue
+
+                input_key = str(input_path.resolve())
+                prior = state.get(input_key)
+                reuse_requested = command.skip_existing or command.resume
+                if reuse_requested and provenance_allows_reuse(
+                    prior,
+                    signature,
+                    output_image,
+                    output_video,
+                    live_photo.existing_pair_matches_identifier,
+                ):
+                    assert prior is not None and prior.asset_identifier is not None
+                    writer.append(
+                        source=input_path,
+                        input_root=command.input_dir,
+                        image=output_image,
+                        video=output_video,
+                        status="skipped_existing",
+                        signature=signature,
+                        asset_identifier=prior.asset_identifier,
+                    )
+                    state[input_key] = load_state(checkpoint).get(input_key, prior)
+                    print(f"skipped existing Live Photo pair {output_image.name} + {output_video.name} (provenance matched)")
+                    continue
+
+                if reuse_requested and live_photo.existing_pair_is_valid(output_image, output_video):
+                    known_lineage = (
+                        prior is not None
+                        and prior.matches_outputs(output_image, output_video)
+                        and prior.asset_identifier is not None
+                        and live_photo.existing_pair_matches_identifier(
+                            output_image,
+                            output_video,
+                            prior.asset_identifier,
+                        )
+                    )
+                    if not known_lineage:
+                        failed += 1
+                        message = (
+                            "existing Live Photo pair has no matching source provenance; "
+                            "refusing to treat it as this input"
+                        )
+                        writer.append(
+                            source=input_path,
+                            input_root=command.input_dir,
+                            image=output_image,
+                            video=output_video,
+                            status="failure",
+                            signature=signature,
+                            asset_identifier=None,
+                            error=message,
+                        )
+                        print(f"error: {input_path.name}: {message}", file=sys.stderr)
+                        continue
+                    # The pair belongs to this source path but the source content changed. Rebuild it
+                    # rather than silently reusing stale output.
+
+                result = _convert_motion(input_path, output_image)
+                if result is not None:
+                    converted += 1
+                    writer.append(
+                        source=input_path,
+                        input_root=command.input_dir,
+                        image=output_image,
+                        video=output_video,
+                        status="success",
+                        signature=signature,
+                        asset_identifier=result.content_identifier,
+                    )
+                else:
+                    failed += 1
+                    writer.append(
+                        source=input_path,
+                        input_root=command.input_dir,
+                        image=output_image,
+                        video=output_video,
+                        status="failure",
+                        signature=signature,
+                        asset_identifier=None,
+                        error="conversion failed; see stderr",
+                    )
 
     print(f"batch complete: {converted} converted, {failed} failed")
     return 0 if failed == 0 else 1
@@ -241,12 +391,17 @@ def build_parser() -> argparse.ArgumentParser:
     b.add_argument(
         "--glob",
         help=(
-            f"Explicit file match pattern. Without --glob, discover HEIC/HEIF and classify "
+            f"Explicit file match pattern. Without --glob, recursively discover HEIC/HEIF and classify "
             f"JPEG/JPG Motion Photos (legacy ProXDR pattern was {DEFAULT_BATCH_GLOB})"
         ),
     )
     b.add_argument("--categorize", action="store_true", dest="categorize_output",
                    help="Write outputs under Chinese shooting-mode directories")
+    b.add_argument("--skip-existing", action="store_true",
+                   help="Reuse an existing Live Photo pair only when saved source provenance matches")
+    b.add_argument("--resume", action="store_true",
+                   help="Resume using the durable Motion Photo checkpoint/provenance state")
+    b.add_argument("--checkpoint", help="Path for durable Motion Photo batch checkpoint/provenance state")
     category = sub.add_parser("categorize", help="Copy photos into shooting-mode directories")
     category.add_argument("--input", action="append", required=True,
                           help="Input photo or directory; may be repeated")

--- a/xdremux_py/cli.py
+++ b/xdremux_py/cli.py
@@ -112,27 +112,17 @@ def cmd_convert(command: ConvertCommand) -> int:
     return _convert_one(command.input_path, command.output_path, command.configuration)
 
 
-def _default_batch_candidates(input_dir: Path, output_dir: Path) -> list[Path]:
-    """Recursively snapshot batch inputs while excluding hidden and separate output subtrees."""
+def _default_batch_candidates(input_dir: Path) -> list[Path]:
+    """Preserve the legacy non-recursive Python batch discovery contract."""
     allowed = {".heic", ".heif", ".jpg", ".jpeg"}
-    input_root = input_dir.resolve()
-    output_root = output_dir.resolve()
-    exclude_output_subtree = output_root != input_root and output_root.is_relative_to(input_root)
-    candidates: list[Path] = []
-    for path in input_dir.rglob("*"):
-        if not path.is_file() or path.suffix.lower() not in allowed:
-            continue
-        resolved = path.resolve()
-        if exclude_output_subtree and resolved.is_relative_to(output_root):
-            continue
-        try:
-            relative_parts = resolved.relative_to(input_root).parts
-        except ValueError:
-            relative_parts = resolved.parts
-        if any(part.startswith(".") for part in relative_parts):
-            continue
-        candidates.append(path)
-    return sorted(candidates, key=lambda value: str(value.resolve()))
+    return sorted(
+        (
+            path
+            for path in input_dir.iterdir()
+            if path.is_file() and path.suffix.lower() in allowed
+        ),
+        key=lambda value: str(value.resolve()),
+    )
 
 
 def _motion_output_directory(source: Path, command: BatchCommand) -> Path:
@@ -171,7 +161,7 @@ def cmd_batch(command: BatchCommand) -> int:
             key=lambda value: str(value.resolve()),
         )
         if command.glob_explicit
-        else _default_batch_candidates(command.input_dir, command.output_dir)
+        else _default_batch_candidates(command.input_dir)
     )
 
     # Classification and destination planning are completed before the first write. Batch membership
@@ -267,7 +257,6 @@ def cmd_batch(command: BatchCommand) -> int:
                         signature=signature,
                         asset_identifier=prior.asset_identifier,
                     )
-                    state[input_key] = load_state(checkpoint).get(input_key, prior)
                     print(f"skipped existing Live Photo pair {output_image.name} + {output_video.name} (provenance matched)")
                     continue
 
@@ -391,7 +380,7 @@ def build_parser() -> argparse.ArgumentParser:
     b.add_argument(
         "--glob",
         help=(
-            f"Explicit file match pattern. Without --glob, recursively discover HEIC/HEIF and classify "
+            f"Explicit file match pattern. Without --glob, discover HEIC/HEIF and classify "
             f"JPEG/JPG Motion Photos (legacy ProXDR pattern was {DEFAULT_BATCH_GLOB})"
         ),
     )

--- a/xdremux_py/commands.py
+++ b/xdremux_py/commands.py
@@ -36,6 +36,9 @@ class BatchCommand:
     glob: str
     glob_explicit: bool
     categorize_output: bool
+    skip_existing: bool
+    resume: bool
+    checkpoint_path: Path | None
     configuration: ConversionConfiguration
 
     @classmethod
@@ -47,6 +50,9 @@ class BatchCommand:
             glob=args.glob or DEFAULT_BATCH_GLOB,
             glob_explicit=bool(args.glob),
             categorize_output=bool(getattr(args, "categorize_output", False)),
+            skip_existing=bool(getattr(args, "skip_existing", False)),
+            resume=bool(getattr(args, "resume", False)),
+            checkpoint_path=Path(args.checkpoint) if getattr(args, "checkpoint", None) else None,
             configuration=conversion_configuration(args),
         )
 

--- a/xdremux_py/live_photo.py
+++ b/xdremux_py/live_photo.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import shutil
 import tempfile
 import uuid
@@ -23,6 +22,7 @@ from .live_photo_still_portable import (
     read_apple_content_identifier,
     write_live_photo_still,
 )
+from .live_photo_transaction import commit_pair, recover_transactions
 from .motion_photo import MotionPhotoError, copy_range, parse_motion_photo, primary_video_range
 from .motion_video import MotionVideoError, strip_trailing_vendor_data
 
@@ -60,38 +60,6 @@ def companion_video_path(image_path: Path) -> Path:
     return image_path.with_suffix(".mov")
 
 
-def _transactional_commit(temp_image: Path, temp_video: Path, image: Path, video: Path) -> None:
-    image.parent.mkdir(parents=True, exist_ok=True)
-    backup_id = uuid.uuid4().hex
-    image_backup = image.with_name(f".{image.name}.{backup_id}.backup")
-    video_backup = video.with_name(f".{video.name}.{backup_id}.backup")
-    had_image, had_video = image.exists(), video.exists()
-    image_installed = video_installed = False
-    try:
-        if had_image:
-            os.replace(image, image_backup)
-        if had_video:
-            os.replace(video, video_backup)
-        os.replace(temp_image, image)
-        image_installed = True
-        os.replace(temp_video, video)
-        video_installed = True
-        if image_backup.exists():
-            image_backup.unlink()
-        if video_backup.exists():
-            video_backup.unlink()
-    except Exception:
-        if image_installed and image.exists():
-            image.unlink()
-        if video_installed and video.exists():
-            video.unlink()
-        if image_backup.exists():
-            os.replace(image_backup, image)
-        if video_backup.exists():
-            os.replace(video_backup, video)
-        raise
-
-
 def validate_pair(image: Path, video: Path, content_identifier: str, still_time_seconds: float) -> None:
     image_identifier = read_apple_content_identifier(image)
     if image_identifier is None or image_identifier.upper() != content_identifier.upper():
@@ -102,7 +70,7 @@ def validate_pair(image: Path, video: Path, content_identifier: str, still_time_
     validate_live_photo_movie(video, movie_identifier, still_time_seconds)
 
 
-def existing_pair_is_valid(image: Path, video: Path) -> bool:
+def existing_pair_matches_identifier(image: Path, video: Path, content_identifier: str) -> bool:
     image, video = Path(image), Path(video)
     if not image.is_file() or not video.is_file():
         return False
@@ -110,12 +78,26 @@ def existing_pair_is_valid(image: Path, video: Path) -> bool:
         image_identifier = read_apple_content_identifier(image)
         movie_identifier = read_movie_identifier(video)
         still_time = read_still_time(video)
+        expected = content_identifier.upper()
         if not image_identifier or not movie_identifier or still_time is None:
             return False
-        if image_identifier.upper() != movie_identifier.upper():
+        if image_identifier.upper() != expected or movie_identifier.upper() != expected:
             return False
         validate_live_photo_movie(video, movie_identifier, still_time)
         return True
+    except (OSError, ValueError, LivePhotoMovieError, LivePhotoStillError):
+        return False
+
+
+def existing_pair_is_valid(image: Path, video: Path) -> bool:
+    image, video = Path(image), Path(video)
+    if not image.is_file() or not video.is_file():
+        return False
+    try:
+        image_identifier = read_apple_content_identifier(image)
+        if not image_identifier:
+            return False
+        return existing_pair_matches_identifier(image, video, image_identifier)
     except (OSError, ValueError, LivePhotoMovieError, LivePhotoStillError):
         return False
 
@@ -137,7 +119,23 @@ def convert_motion_photo(input_path: Path, output_image: Path | None = None) -> 
     if output_image.resolve() == input_path.resolve():
         raise LivePhotoConversionError("Motion Photo conversion never overwrites the source image")
     output_video = companion_video_path(output_image)
+    output_directory = output_image.parent
+    output_directory.mkdir(parents=True, exist_ok=True)
+
+    # Recover an interrupted two-file commit before starting a new one. The transaction journal
+    # itself lives under output_directory and validates any pair that reached pair_installed.
+    try:
+        recover_transactions(output_directory, existing_pair_is_valid)
+    except (OSError, ValueError) as exc:
+        raise LivePhotoConversionError(f"could not recover prior Live Photo transaction: {exc}") from exc
+
     content_identifier = str(uuid.uuid4()).upper()
+    transaction_id = uuid.uuid4().hex
+    stem = output_image.stem
+    # Final-pair temporaries intentionally live beside the destination. This is required for
+    # rename/replace atomicity and prevents EXDEV when /tmp and the output are different volumes.
+    temp_image = output_directory / f".{stem}.{transaction_id}.tmp.heic"
+    temp_video = output_directory / f".{stem}.{transaction_id}.tmp.mov"
 
     scratch = Path(tempfile.mkdtemp(prefix="xdremux-py-livephoto-"))
     try:
@@ -149,8 +147,6 @@ def convert_motion_photo(input_path: Path, output_image: Path | None = None) -> 
         except (LivePhotoMovieError, MotionVideoError) as exc:
             raise LivePhotoConversionError(str(exc)) from exc
 
-        temp_image = scratch / "pair.heic"
-        temp_video = scratch / "pair.mov"
         try:
             had_gain_map = write_live_photo_still(asset, temp_image, content_identifier)
             source_media_hashes = media_payload_sha256(video_source)
@@ -190,7 +186,17 @@ def convert_motion_photo(input_path: Path, output_image: Path | None = None) -> 
         if asset.source_kind == "androidHeifMotionPhotoV1":
             diagnostics.append("HEIF mpvd video extracted without trailing vendor boxes")
 
-        _transactional_commit(temp_image, temp_video, output_image, output_video)
+        try:
+            commit_pair(
+                temp_image,
+                temp_video,
+                output_image,
+                output_video,
+                pair_validator=existing_pair_is_valid,
+            )
+        except (OSError, ValueError) as exc:
+            raise LivePhotoConversionError(f"Live Photo pair commit failed: {exc}") from exc
+
         return LivePhotoResult(
             input_path=input_path,
             image_path=output_image,
@@ -202,4 +208,12 @@ def convert_motion_photo(input_path: Path, output_image: Path | None = None) -> 
             diagnostics=tuple(diagnostics),
         )
     finally:
+        try:
+            temp_image.unlink()
+        except FileNotFoundError:
+            pass
+        try:
+            temp_video.unlink()
+        except FileNotFoundError:
+            pass
         shutil.rmtree(scratch, ignore_errors=True)

--- a/xdremux_py/live_photo_batch.py
+++ b/xdremux_py/live_photo_batch.py
@@ -157,7 +157,13 @@ def validate_unique_plan(outputs: list[tuple[Path, Path]]) -> None:
 
 
 def state_path(output_dir: Path, requested: Path | None = None) -> Path:
-    return Path(requested) if requested is not None else Path(output_dir) / DEFAULT_STATE_NAME
+    if requested is not None:
+        requested = Path(requested)
+        # Swift keeps the Motion Photo state separate from the legacy ProXDR batch checkpoint by
+        # appending this suffix to a user-specified checkpoint path. Mirror that contract exactly so
+        # either runtime can resume the other's batch state.
+        return requested.parent / f"{requested.name}.motion-photo"
+    return Path(output_dir) / DEFAULT_STATE_NAME
 
 
 def load_state(path: Path) -> dict[str, BatchStateItem]:

--- a/xdremux_py/live_photo_batch.py
+++ b/xdremux_py/live_photo_batch.py
@@ -1,4 +1,8 @@
-"""Stable output planning and provenance for Python Motion Photo batch conversion."""
+"""Stable output planning and provenance for Python Motion Photo batch conversion.
+
+The JSONL wire schema intentionally matches the Swift CLI (camelCase field names). Both runtimes
+can therefore reuse the same durable provenance file without weakening skip/resume checks.
+"""
 
 from __future__ import annotations
 
@@ -6,7 +10,7 @@ import hashlib
 import json
 import os
 import unicodedata
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
@@ -26,13 +30,13 @@ class SourceSignature:
 class BatchStateItem:
     kind: str
     input_path: str
-    relative_source_path: str
+    relative_source_path: str | None
     output_image_path: str
     output_video_path: str
     status: str
-    input_size: int
-    input_mtime_ns: int
-    input_sha256: str
+    input_size: int | None
+    input_mtime_ns: int | None
+    input_sha256: str | None
     asset_identifier: str | None
     error: str | None = None
 
@@ -54,6 +58,51 @@ class BatchStateItem:
             and self.matches_source(signature)
             and self.matches_outputs(image, video)
         )
+
+    def to_wire(self) -> dict[str, object]:
+        """Canonical schema shared with Swift MotionPhotoBatchCheckpoint.Item."""
+        return {
+            "kind": self.kind,
+            "inputPath": self.input_path,
+            "sourceRelativePath": self.relative_source_path,
+            "outputImagePath": self.output_image_path,
+            "outputVideoPath": self.output_video_path,
+            "status": self.status,
+            "inputSize": self.input_size,
+            "inputMtimeNs": self.input_mtime_ns,
+            "inputSHA256": self.input_sha256,
+            "assetIdentifier": self.asset_identifier,
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_wire(cls, raw: dict[str, object]) -> "BatchStateItem" | None:
+        """Read canonical camelCase and the short-lived Python snake_case schema fail-closed."""
+        def value(camel: str, snake: str):
+            return raw[camel] if camel in raw else raw.get(snake)
+
+        try:
+            input_path = value("inputPath", "input_path")
+            image_path = value("outputImagePath", "output_image_path")
+            video_path = value("outputVideoPath", "output_video_path")
+            status = raw.get("status")
+            if not all(isinstance(item, str) and item for item in (input_path, image_path, video_path, status)):
+                return None
+            return cls(
+                kind="item",
+                input_path=input_path,
+                relative_source_path=value("sourceRelativePath", "relative_source_path") if isinstance(value("sourceRelativePath", "relative_source_path"), str) else None,
+                output_image_path=image_path,
+                output_video_path=video_path,
+                status=status,
+                input_size=int(value("inputSize", "input_size")) if value("inputSize", "input_size") is not None else None,
+                input_mtime_ns=int(value("inputMtimeNs", "input_mtime_ns")) if value("inputMtimeNs", "input_mtime_ns") is not None else None,
+                input_sha256=value("inputSHA256", "input_sha256") if isinstance(value("inputSHA256", "input_sha256"), str) else None,
+                asset_identifier=value("assetIdentifier", "asset_identifier") if isinstance(value("assetIdentifier", "asset_identifier"), str) else None,
+                error=value("error", "error") if isinstance(value("error", "error"), str) else None,
+            )
+        except (TypeError, ValueError):
+            return None
 
 
 def source_signature(path: Path, chunk_size: int = 1024 * 1024) -> SourceSignature:
@@ -124,16 +173,17 @@ def load_state(path: Path) -> dict[str, BatchStateItem]:
             try:
                 raw = json.loads(line)
             except json.JSONDecodeError:
+                # A power loss may leave a truncated final JSONL record. Ignoring an unreadable
+                # provenance record is safe because it can only force a rebuild, never a reuse.
                 continue
-            if raw.get("kind") != "item":
+            if not isinstance(raw, dict) or raw.get("kind") != "item":
+                continue
+            item = BatchStateItem.from_wire(raw)
+            if item is None:
                 continue
             # Schema-1 entries did not contain a content digest/asset identifier and therefore are
             # deliberately not trusted as provenance for --skip-existing.
-            if not raw.get("input_sha256") or not raw.get("asset_identifier"):
-                continue
-            try:
-                item = BatchStateItem(**raw)
-            except TypeError:
+            if not item.input_sha256 or not item.asset_identifier:
                 continue
             state[item.input_path] = item
     return state
@@ -146,7 +196,7 @@ class StateWriter:
         new_file = not self.path.exists() or self.path.stat().st_size == 0
         self._handle = self.path.open("a", encoding="utf-8", newline="\n")
         if new_file:
-            self._append({"kind": "header", "schema_version": SCHEMA_VERSION})
+            self._append({"kind": "header", "schemaVersion": SCHEMA_VERSION})
 
     def _append(self, value: dict[str, object]) -> None:
         self._handle.write(json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n")
@@ -178,7 +228,7 @@ class StateWriter:
             asset_identifier=asset_identifier,
             error=error,
         )
-        self._append(asdict(item))
+        self._append(item.to_wire())
 
     def close(self) -> None:
         if not self._handle.closed:

--- a/xdremux_py/live_photo_batch.py
+++ b/xdremux_py/live_photo_batch.py
@@ -131,9 +131,12 @@ def relative_source_path(source: Path, input_root: Path) -> str:
 
 
 def stable_source_token(source: Path, input_root: Path, length: int = 32) -> str:
-    """Return a 128-bit-by-default deterministic token from normalized source-relative path."""
-    relative = relative_source_path(source, input_root)
-    return hashlib.sha256(relative.encode("utf-8")).hexdigest()[:length]
+    """Return a 128-bit token namespaced by canonical root plus normalized relative path."""
+    root = Path(input_root).resolve()
+    root_identity = unicodedata.normalize("NFC", root.as_posix())
+    relative = relative_source_path(source, root)
+    identity = root_identity + "\0" + relative
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:length]
 
 
 def planned_output_image(source: Path, input_root: Path, output_directory: Path) -> Path:

--- a/xdremux_py/live_photo_batch.py
+++ b/xdremux_py/live_photo_batch.py
@@ -81,7 +81,8 @@ def relative_source_path(source: Path, input_root: Path) -> str:
     return unicodedata.normalize("NFC", relative)
 
 
-def stable_source_token(source: Path, input_root: Path, length: int = 16) -> str:
+def stable_source_token(source: Path, input_root: Path, length: int = 32) -> str:
+    """Return a 128-bit-by-default deterministic token from normalized source-relative path."""
     relative = relative_source_path(source, input_root)
     return hashlib.sha256(relative.encode("utf-8")).hexdigest()[:length]
 

--- a/xdremux_py/live_photo_batch.py
+++ b/xdremux_py/live_photo_batch.py
@@ -1,0 +1,204 @@
+"""Stable output planning and provenance for Python Motion Photo batch conversion."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import unicodedata
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Callable
+
+
+SCHEMA_VERSION = 2
+DEFAULT_STATE_NAME = ".xdremux-motion-photo-checkpoint.jsonl"
+
+
+@dataclass(frozen=True)
+class SourceSignature:
+    size: int
+    mtime_ns: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class BatchStateItem:
+    kind: str
+    input_path: str
+    relative_source_path: str
+    output_image_path: str
+    output_video_path: str
+    status: str
+    input_size: int
+    input_mtime_ns: int
+    input_sha256: str
+    asset_identifier: str | None
+    error: str | None = None
+
+    def matches_source(self, signature: SourceSignature) -> bool:
+        # Size is a cheap corruption guard; SHA-256 is the source identity. mtime is retained for
+        # diagnostics but touching/copying an unchanged source does not invalidate provenance.
+        return self.input_size == signature.size and self.input_sha256 == signature.sha256
+
+    def matches_outputs(self, image: Path, video: Path) -> bool:
+        return (
+            self.output_image_path == str(Path(image).resolve())
+            and self.output_video_path == str(Path(video).resolve())
+        )
+
+    def reusable(self, signature: SourceSignature, image: Path, video: Path) -> bool:
+        return (
+            self.status in {"success", "skipped_existing"}
+            and bool(self.asset_identifier)
+            and self.matches_source(signature)
+            and self.matches_outputs(image, video)
+        )
+
+
+def source_signature(path: Path, chunk_size: int = 1024 * 1024) -> SourceSignature:
+    path = Path(path)
+    stat = path.stat()
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(chunk_size)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return SourceSignature(size=stat.st_size, mtime_ns=stat.st_mtime_ns, sha256=digest.hexdigest())
+
+
+def relative_source_path(source: Path, input_root: Path) -> str:
+    source = Path(source).resolve()
+    input_root = Path(input_root).resolve()
+    try:
+        relative = source.relative_to(input_root).as_posix()
+    except ValueError:
+        # Explicit globs should normally stay below input_root. If a caller supplies an unusual
+        # path, hashing the absolute path is still deterministic and cannot alias another source.
+        relative = source.as_posix()
+    return unicodedata.normalize("NFC", relative)
+
+
+def stable_source_token(source: Path, input_root: Path, length: int = 16) -> str:
+    relative = relative_source_path(source, input_root)
+    return hashlib.sha256(relative.encode("utf-8")).hexdigest()[:length]
+
+
+def planned_output_image(source: Path, input_root: Path, output_directory: Path) -> Path:
+    """Return a stable Motion Photo output independent of the current batch membership/order."""
+    source = Path(source)
+    output_directory = Path(output_directory)
+    token = stable_source_token(source, input_root)
+    stem = source.stem + (".live" if source.suffix.lower() in {".heic", ".heif"} else "")
+    return output_directory / f"{stem}~{token}.heic"
+
+
+def validate_unique_plan(outputs: list[tuple[Path, Path]]) -> None:
+    """Fail closed on the practically-impossible deterministic-token/path collision."""
+    seen: dict[str, Path] = {}
+    for source, output in outputs:
+        key = str(Path(output).resolve())
+        prior = seen.get(key)
+        if prior is not None and prior.resolve() != Path(source).resolve():
+            raise ValueError(f"stable Motion Photo output collision: {prior} and {source} -> {output}")
+        seen[key] = Path(source)
+
+
+def state_path(output_dir: Path, requested: Path | None = None) -> Path:
+    return Path(requested) if requested is not None else Path(output_dir) / DEFAULT_STATE_NAME
+
+
+def load_state(path: Path) -> dict[str, BatchStateItem]:
+    path = Path(path)
+    if not path.is_file():
+        return {}
+    state: dict[str, BatchStateItem] = {}
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                raw = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if raw.get("kind") != "item":
+                continue
+            # Schema-1 entries did not contain a content digest/asset identifier and therefore are
+            # deliberately not trusted as provenance for --skip-existing.
+            if not raw.get("input_sha256") or not raw.get("asset_identifier"):
+                continue
+            try:
+                item = BatchStateItem(**raw)
+            except TypeError:
+                continue
+            state[item.input_path] = item
+    return state
+
+
+class StateWriter:
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        new_file = not self.path.exists() or self.path.stat().st_size == 0
+        self._handle = self.path.open("a", encoding="utf-8", newline="\n")
+        if new_file:
+            self._append({"kind": "header", "schema_version": SCHEMA_VERSION})
+
+    def _append(self, value: dict[str, object]) -> None:
+        self._handle.write(json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n")
+        self._handle.flush()
+        os.fsync(self._handle.fileno())
+
+    def append(
+        self,
+        *,
+        source: Path,
+        input_root: Path,
+        image: Path,
+        video: Path,
+        status: str,
+        signature: SourceSignature,
+        asset_identifier: str | None,
+        error: str | None = None,
+    ) -> None:
+        item = BatchStateItem(
+            kind="item",
+            input_path=str(Path(source).resolve()),
+            relative_source_path=relative_source_path(source, input_root),
+            output_image_path=str(Path(image).resolve()),
+            output_video_path=str(Path(video).resolve()),
+            status=status,
+            input_size=signature.size,
+            input_mtime_ns=signature.mtime_ns,
+            input_sha256=signature.sha256,
+            asset_identifier=asset_identifier,
+            error=error,
+        )
+        self._append(asdict(item))
+
+    def close(self) -> None:
+        if not self._handle.closed:
+            self._handle.flush()
+            os.fsync(self._handle.fileno())
+            self._handle.close()
+
+    def __enter__(self) -> "StateWriter":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+def provenance_allows_reuse(
+    prior: BatchStateItem | None,
+    signature: SourceSignature,
+    image: Path,
+    video: Path,
+    pair_matches_identifier: Callable[[Path, Path, str], bool],
+) -> bool:
+    if prior is None or not prior.reusable(signature, image, video) or prior.asset_identifier is None:
+        return False
+    return pair_matches_identifier(image, video, prior.asset_identifier)

--- a/xdremux_py/live_photo_transaction.py
+++ b/xdremux_py/live_photo_transaction.py
@@ -2,9 +2,9 @@
 
 A Live Photo is a HEIC/HEIF still plus a MOV resource. No filesystem primitive can
 atomically rename both files together, so this module uses a small, durable journal
-and same-directory renames. The durable ``committed`` marker is written before backup
-cleanup so another crash during cleanup can never cause a later rollback to mix old
-and new resources.
+and same-directory renames. The journal wire schema and POSIX record lock intentionally
+match the Swift implementation so either runtime can recover the other's interrupted
+transaction.
 """
 
 from __future__ import annotations
@@ -13,7 +13,7 @@ import json
 import os
 import uuid
 from contextlib import contextmanager
-from dataclasses import asdict, dataclass, replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Callable, Iterator
 
@@ -49,6 +49,49 @@ class TransactionManifest:
     had_image: bool
     had_video: bool
 
+    def to_wire(self) -> dict[str, object]:
+        """Canonical camelCase schema shared with Swift LivePhotoPairTransaction.Manifest."""
+        return {
+            "schemaVersion": self.schema_version,
+            "transactionID": self.transaction_id,
+            "state": self.state,
+            "finalImage": self.final_image,
+            "finalVideo": self.final_video,
+            "temporaryImage": self.temporary_image,
+            "temporaryVideo": self.temporary_video,
+            "backupImage": self.backup_image,
+            "backupVideo": self.backup_video,
+            "hadImage": self.had_image,
+            "hadVideo": self.had_video,
+        }
+
+    @classmethod
+    def from_wire(cls, raw: dict[str, object]) -> "TransactionManifest":
+        """Read canonical Swift/Python schema and the short-lived Python snake_case schema."""
+        def required(camel: str, snake: str):
+            if camel in raw:
+                return raw[camel]
+            if snake in raw:
+                return raw[snake]
+            raise ValueError(f"missing Live Photo transaction field: {camel}")
+
+        try:
+            return cls(
+                schema_version=int(required("schemaVersion", "schema_version")),
+                transaction_id=str(required("transactionID", "transaction_id")),
+                state=str(required("state", "state")),
+                final_image=str(required("finalImage", "final_image")),
+                final_video=str(required("finalVideo", "final_video")),
+                temporary_image=str(required("temporaryImage", "temporary_image")),
+                temporary_video=str(required("temporaryVideo", "temporary_video")),
+                backup_image=str(required("backupImage", "backup_image")),
+                backup_video=str(required("backupVideo", "backup_video")),
+                had_image=bool(required("hadImage", "had_image")),
+                had_video=bool(required("hadVideo", "had_video")),
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"invalid Live Photo transaction manifest: {exc}") from exc
+
 
 _STATE_ORDER = {
     "prepared": 0,
@@ -60,7 +103,6 @@ _STATE_ORDER = {
 
 
 def _safe_child(directory: Path, name: str) -> Path:
-    """Resolve a journal basename without allowing path traversal."""
     candidate = Path(name)
     if not name or candidate.name != name or candidate.is_absolute() or name in {".", ".."}:
         raise ValueError(f"unsafe Live Photo transaction path: {name!r}")
@@ -92,13 +134,15 @@ def _fsync_directory(directory: Path) -> None:
 
 @contextmanager
 def _directory_lock(directory: Path) -> Iterator[None]:
-    """Serialize recovery/commit across XDRemux processes for one output directory."""
+    """Serialize recovery/commit across Python and Swift XDRemux processes."""
     directory.mkdir(parents=True, exist_ok=True)
     lock_path = directory / LOCK_FILE
     fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
     try:
         if fcntl is not None:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+            # Swift uses POSIX lockf(). Python lockf() is the same fcntl record-lock family; using
+            # flock() here would not be guaranteed to interoperate with it on every Unix platform.
+            fcntl.lockf(fd, fcntl.LOCK_EX)
         elif msvcrt is not None:  # pragma: no cover - Windows-only path
             if os.fstat(fd).st_size == 0:
                 os.write(fd, b"\0")
@@ -107,7 +151,7 @@ def _directory_lock(directory: Path) -> Iterator[None]:
         yield
     finally:
         if fcntl is not None:
-            fcntl.flock(fd, fcntl.LOCK_UN)
+            fcntl.lockf(fd, fcntl.LOCK_UN)
         elif msvcrt is not None:  # pragma: no cover - Windows-only path
             os.lseek(fd, 0, os.SEEK_SET)
             try:
@@ -132,7 +176,7 @@ def _write_manifest(directory: Path, manifest: TransactionManifest) -> Path:
     journal_dir.mkdir(parents=True, exist_ok=True)
     destination = _journal_path(directory, manifest.transaction_id)
     temporary = journal_dir / f".{manifest.transaction_id}.{uuid.uuid4().hex}.tmp"
-    payload = (json.dumps(asdict(manifest), sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    payload = (json.dumps(manifest.to_wire(), sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
     try:
         with temporary.open("xb") as handle:
             handle.write(payload)
@@ -150,7 +194,9 @@ def _write_manifest(directory: Path, manifest: TransactionManifest) -> Path:
 
 def _load_manifest(path: Path) -> TransactionManifest:
     raw = json.loads(path.read_text(encoding="utf-8"))
-    manifest = TransactionManifest(**raw)
+    if not isinstance(raw, dict):
+        raise ValueError("Live Photo transaction manifest must be an object")
+    manifest = TransactionManifest.from_wire(raw)
     if manifest.schema_version != SCHEMA_VERSION:
         raise ValueError(f"unsupported Live Photo transaction schema: {manifest.schema_version}")
     if manifest.state not in _STATE_ORDER:
@@ -179,7 +225,6 @@ def _rollback(directory: Path, manifest: TransactionManifest, journal_path: Path
         _remove_if_exists(final_image)
         os.replace(image_backup, final_image)
     elif not manifest.had_image and not temp_image.exists() and final_image.exists():
-        # The temporary still disappeared, so it may have been installed before the state update.
         _remove_if_exists(final_image)
 
     if video_backup.exists():
@@ -198,7 +243,6 @@ def _rollback(directory: Path, manifest: TransactionManifest, journal_path: Path
 
 
 def _cleanup_committed(directory: Path, manifest: TransactionManifest, journal_path: Path) -> None:
-    """Complete post-commit cleanup; this is idempotent and never rolls the pair back."""
     _remove_if_exists(_safe_child(directory, manifest.backup_image))
     _remove_if_exists(_safe_child(directory, manifest.backup_video))
     _remove_if_exists(_safe_child(directory, manifest.temporary_image))
@@ -241,7 +285,6 @@ def _recover_locked(directory: Path, pair_validator: PairValidator | None) -> No
 
 
 def recover_transactions(directory: Path, pair_validator: PairValidator | None = None) -> None:
-    """Recover every interrupted XDRemux Live Photo transaction in ``directory``."""
     directory = Path(directory)
     if not directory.exists():
         return
@@ -257,11 +300,7 @@ def commit_pair(
     *,
     pair_validator: PairValidator | None = None,
 ) -> None:
-    """Install a validated Live Photo pair with durable crash recovery.
-
-    All four resources must live in the same directory. This intentionally prevents a system
-    temporary directory from being renamed onto another filesystem/volume.
-    """
+    """Install a validated Live Photo pair with durable crash recovery."""
     temporary_image = Path(temporary_image)
     temporary_video = Path(temporary_video)
     final_image = Path(final_image)
@@ -309,26 +348,19 @@ def commit_pair(
             os.replace(temporary_video, final_video)
             manifest = replace(manifest, state="pair_installed")
             journal_path = _write_manifest(directory, manifest)
-            # Make both installed directory entries durable before publishing the committed marker.
             _fsync_directory(directory)
 
             if pair_validator is not None and not pair_validator(final_image, final_video):
                 raise ValueError("installed Live Photo pair failed final validation")
 
-            # This is the transaction commit point. Once durable state says committed, recovery must
-            # only clean backups; it must never attempt rollback even if cleanup was interrupted.
             manifest, journal_path = _mark_committed(directory, manifest)
             _cleanup_committed(directory, manifest, journal_path)
         except BaseException:
-            # Before the committed marker, Python exceptions, KeyboardInterrupt and SystemExit get
-            # an immediate rollback. After it, rollback would be incorrect; finish cleanup instead.
             try:
                 if manifest.state == "committed":
                     _cleanup_committed(directory, manifest, journal_path)
                 else:
                     _rollback(directory, manifest, journal_path)
             except Exception:
-                # Keep the original exception. Any surviving journal is intentionally left for the
-                # next recovery pass if cleanup/rollback itself could not finish.
                 pass
             raise

--- a/xdremux_py/live_photo_transaction.py
+++ b/xdremux_py/live_photo_transaction.py
@@ -2,9 +2,9 @@
 
 A Live Photo is a HEIC/HEIF still plus a MOV resource. No filesystem primitive can
 atomically rename both files together, so this module uses a small, durable journal
-and same-directory renames. Recovery is conservative: an interrupted transaction is
-rolled back unless the journal reached ``pair_installed`` and the caller confirms the
-final pair is valid.
+and same-directory renames. The durable ``committed`` marker is written before backup
+cleanup so another crash during cleanup can never cause a later rollback to mix old
+and new resources.
 """
 
 from __future__ import annotations
@@ -55,6 +55,7 @@ _STATE_ORDER = {
     "originals_backed_up": 1,
     "image_installed": 2,
     "pair_installed": 3,
+    "committed": 4,
 }
 
 
@@ -196,14 +197,22 @@ def _rollback(directory: Path, manifest: TransactionManifest, journal_path: Path
     _fsync_directory(journal_path.parent)
 
 
-def _finalize(directory: Path, manifest: TransactionManifest, journal_path: Path) -> None:
+def _cleanup_committed(directory: Path, manifest: TransactionManifest, journal_path: Path) -> None:
+    """Complete post-commit cleanup; this is idempotent and never rolls the pair back."""
     _remove_if_exists(_safe_child(directory, manifest.backup_image))
     _remove_if_exists(_safe_child(directory, manifest.backup_video))
     _remove_if_exists(_safe_child(directory, manifest.temporary_image))
     _remove_if_exists(_safe_child(directory, manifest.temporary_video))
     _fsync_directory(directory)
+    # Journal removal is deliberately last. Until then, a crash simply re-enters this cleanup path.
     _remove_if_exists(journal_path)
     _fsync_directory(journal_path.parent)
+
+
+def _mark_committed(directory: Path, manifest: TransactionManifest) -> tuple[TransactionManifest, Path]:
+    committed = replace(manifest, state="committed")
+    journal_path = _write_manifest(directory, committed)
+    return committed, journal_path
 
 
 def _recover_locked(directory: Path, pair_validator: PairValidator | None) -> None:
@@ -212,6 +221,10 @@ def _recover_locked(directory: Path, pair_validator: PairValidator | None) -> No
         return
     for journal_path in sorted(journal_dir.glob("*.json")):
         manifest = _load_manifest(journal_path)
+        if manifest.state == "committed":
+            _cleanup_committed(directory, manifest, journal_path)
+            continue
+
         final_image = _safe_child(directory, manifest.final_image)
         final_video = _safe_child(directory, manifest.final_video)
         if (
@@ -221,7 +234,8 @@ def _recover_locked(directory: Path, pair_validator: PairValidator | None) -> No
             and final_video.is_file()
             and pair_validator(final_image, final_video)
         ):
-            _finalize(directory, manifest, journal_path)
+            manifest, journal_path = _mark_committed(directory, manifest)
+            _cleanup_committed(directory, manifest, journal_path)
         else:
             _rollback(directory, manifest, journal_path)
 
@@ -295,19 +309,26 @@ def commit_pair(
             os.replace(temporary_video, final_video)
             manifest = replace(manifest, state="pair_installed")
             journal_path = _write_manifest(directory, manifest)
+            # Make both installed directory entries durable before publishing the committed marker.
             _fsync_directory(directory)
 
             if pair_validator is not None and not pair_validator(final_image, final_video):
                 raise ValueError("installed Live Photo pair failed final validation")
-            _finalize(directory, manifest, journal_path)
+
+            # This is the transaction commit point. Once durable state says committed, recovery must
+            # only clean backups; it must never attempt rollback even if cleanup was interrupted.
+            manifest, journal_path = _mark_committed(directory, manifest)
+            _cleanup_committed(directory, manifest, journal_path)
         except BaseException:
-            # Python exceptions, KeyboardInterrupt and SystemExit all get an immediate rollback.
-            # SIGKILL/power loss cannot execute this block; the durable journal handles those on
-            # the next invocation.
+            # Before the committed marker, Python exceptions, KeyboardInterrupt and SystemExit get
+            # an immediate rollback. After it, rollback would be incorrect; finish cleanup instead.
             try:
-                _rollback(directory, manifest, journal_path)
+                if manifest.state == "committed":
+                    _cleanup_committed(directory, manifest, journal_path)
+                else:
+                    _rollback(directory, manifest, journal_path)
             except Exception:
                 # Keep the original exception. Any surviving journal is intentionally left for the
-                # next recovery pass if rollback itself could not finish.
+                # next recovery pass if cleanup/rollback itself could not finish.
                 pass
             raise

--- a/xdremux_py/live_photo_transaction.py
+++ b/xdremux_py/live_photo_transaction.py
@@ -1,0 +1,313 @@
+"""Crash-recoverable two-file commit protocol for Apple Live Photo pairs.
+
+A Live Photo is a HEIC/HEIF still plus a MOV resource. No filesystem primitive can
+atomically rename both files together, so this module uses a small, durable journal
+and same-directory renames. Recovery is conservative: an interrupted transaction is
+rolled back unless the journal reached ``pair_installed`` and the caller confirms the
+final pair is valid.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Callable, Iterator
+
+try:  # POSIX/macOS/Linux
+    import fcntl  # type: ignore
+except ImportError:  # pragma: no cover - exercised on Windows only
+    fcntl = None
+
+try:  # Windows
+    import msvcrt  # type: ignore
+except ImportError:  # pragma: no cover - exercised on POSIX only
+    msvcrt = None
+
+
+JOURNAL_DIRECTORY = ".xdremux-live-photo-transactions"
+LOCK_FILE = ".xdremux-live-photo-transactions.lock"
+SCHEMA_VERSION = 1
+
+PairValidator = Callable[[Path, Path], bool]
+
+
+@dataclass(frozen=True)
+class TransactionManifest:
+    schema_version: int
+    transaction_id: str
+    state: str
+    final_image: str
+    final_video: str
+    temporary_image: str
+    temporary_video: str
+    backup_image: str
+    backup_video: str
+    had_image: bool
+    had_video: bool
+
+
+_STATE_ORDER = {
+    "prepared": 0,
+    "originals_backed_up": 1,
+    "image_installed": 2,
+    "pair_installed": 3,
+}
+
+
+def _safe_child(directory: Path, name: str) -> Path:
+    """Resolve a journal basename without allowing path traversal."""
+    candidate = Path(name)
+    if not name or candidate.name != name or candidate.is_absolute() or name in {".", ".."}:
+        raise ValueError(f"unsafe Live Photo transaction path: {name!r}")
+    return directory / name
+
+
+def _fsync_file(path: Path) -> None:
+    with path.open("rb") as handle:
+        os.fsync(handle.fileno())
+
+
+def _fsync_directory(directory: Path) -> None:
+    """Best-effort directory sync; some platforms/filesystems reject directory fsync."""
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    try:
+        fd = os.open(directory, flags)
+    except OSError:
+        return
+    try:
+        try:
+            os.fsync(fd)
+        except OSError:
+            pass
+    finally:
+        os.close(fd)
+
+
+@contextmanager
+def _directory_lock(directory: Path) -> Iterator[None]:
+    """Serialize recovery/commit across XDRemux processes for one output directory."""
+    directory.mkdir(parents=True, exist_ok=True)
+    lock_path = directory / LOCK_FILE
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        if fcntl is not None:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        elif msvcrt is not None:  # pragma: no cover - Windows-only path
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"\0")
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+        yield
+    finally:
+        if fcntl is not None:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        elif msvcrt is not None:  # pragma: no cover - Windows-only path
+            os.lseek(fd, 0, os.SEEK_SET)
+            try:
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            except OSError:
+                pass
+        os.close(fd)
+
+
+def _journal_directory(directory: Path) -> Path:
+    return directory / JOURNAL_DIRECTORY
+
+
+def _journal_path(directory: Path, transaction_id: str) -> Path:
+    if not transaction_id or any(ch not in "0123456789abcdefABCDEF-" for ch in transaction_id):
+        raise ValueError("invalid Live Photo transaction identifier")
+    return _journal_directory(directory) / f"{transaction_id}.json"
+
+
+def _write_manifest(directory: Path, manifest: TransactionManifest) -> Path:
+    journal_dir = _journal_directory(directory)
+    journal_dir.mkdir(parents=True, exist_ok=True)
+    destination = _journal_path(directory, manifest.transaction_id)
+    temporary = journal_dir / f".{manifest.transaction_id}.{uuid.uuid4().hex}.tmp"
+    payload = (json.dumps(asdict(manifest), sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    try:
+        with temporary.open("xb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+        _fsync_directory(journal_dir)
+        return destination
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _load_manifest(path: Path) -> TransactionManifest:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    manifest = TransactionManifest(**raw)
+    if manifest.schema_version != SCHEMA_VERSION:
+        raise ValueError(f"unsupported Live Photo transaction schema: {manifest.schema_version}")
+    if manifest.state not in _STATE_ORDER:
+        raise ValueError(f"invalid Live Photo transaction state: {manifest.state}")
+    return manifest
+
+
+def _remove_if_exists(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _rollback(directory: Path, manifest: TransactionManifest, journal_path: Path) -> None:
+    final_image = _safe_child(directory, manifest.final_image)
+    final_video = _safe_child(directory, manifest.final_video)
+    temp_image = _safe_child(directory, manifest.temporary_image)
+    temp_video = _safe_child(directory, manifest.temporary_video)
+    image_backup = _safe_child(directory, manifest.backup_image)
+    video_backup = _safe_child(directory, manifest.backup_video)
+
+    # Backup existence is stronger evidence than the persisted state because a crash can occur
+    # between a rename and the following journal update.
+    if image_backup.exists():
+        _remove_if_exists(final_image)
+        os.replace(image_backup, final_image)
+    elif not manifest.had_image and not temp_image.exists() and final_image.exists():
+        # The temporary still disappeared, so it may have been installed before the state update.
+        _remove_if_exists(final_image)
+
+    if video_backup.exists():
+        _remove_if_exists(final_video)
+        os.replace(video_backup, final_video)
+    elif not manifest.had_video and not temp_video.exists() and final_video.exists():
+        _remove_if_exists(final_video)
+
+    _remove_if_exists(temp_image)
+    _remove_if_exists(temp_video)
+    _remove_if_exists(image_backup)
+    _remove_if_exists(video_backup)
+    _fsync_directory(directory)
+    _remove_if_exists(journal_path)
+    _fsync_directory(journal_path.parent)
+
+
+def _finalize(directory: Path, manifest: TransactionManifest, journal_path: Path) -> None:
+    _remove_if_exists(_safe_child(directory, manifest.backup_image))
+    _remove_if_exists(_safe_child(directory, manifest.backup_video))
+    _remove_if_exists(_safe_child(directory, manifest.temporary_image))
+    _remove_if_exists(_safe_child(directory, manifest.temporary_video))
+    _fsync_directory(directory)
+    _remove_if_exists(journal_path)
+    _fsync_directory(journal_path.parent)
+
+
+def _recover_locked(directory: Path, pair_validator: PairValidator | None) -> None:
+    journal_dir = _journal_directory(directory)
+    if not journal_dir.is_dir():
+        return
+    for journal_path in sorted(journal_dir.glob("*.json")):
+        manifest = _load_manifest(journal_path)
+        final_image = _safe_child(directory, manifest.final_image)
+        final_video = _safe_child(directory, manifest.final_video)
+        if (
+            manifest.state == "pair_installed"
+            and pair_validator is not None
+            and final_image.is_file()
+            and final_video.is_file()
+            and pair_validator(final_image, final_video)
+        ):
+            _finalize(directory, manifest, journal_path)
+        else:
+            _rollback(directory, manifest, journal_path)
+
+
+def recover_transactions(directory: Path, pair_validator: PairValidator | None = None) -> None:
+    """Recover every interrupted XDRemux Live Photo transaction in ``directory``."""
+    directory = Path(directory)
+    if not directory.exists():
+        return
+    with _directory_lock(directory):
+        _recover_locked(directory, pair_validator)
+
+
+def commit_pair(
+    temporary_image: Path,
+    temporary_video: Path,
+    final_image: Path,
+    final_video: Path,
+    *,
+    pair_validator: PairValidator | None = None,
+) -> None:
+    """Install a validated Live Photo pair with durable crash recovery.
+
+    All four resources must live in the same directory. This intentionally prevents a system
+    temporary directory from being renamed onto another filesystem/volume.
+    """
+    temporary_image = Path(temporary_image)
+    temporary_video = Path(temporary_video)
+    final_image = Path(final_image)
+    final_video = Path(final_video)
+    directory = final_image.parent
+    if final_video.parent != directory or temporary_image.parent != directory or temporary_video.parent != directory:
+        raise ValueError("Live Photo transaction resources must be on the destination directory/filesystem")
+    if not temporary_image.is_file() or not temporary_video.is_file():
+        raise FileNotFoundError("validated Live Photo temporary pair is incomplete")
+
+    directory.mkdir(parents=True, exist_ok=True)
+    with _directory_lock(directory):
+        _recover_locked(directory, pair_validator)
+        transaction_id = uuid.uuid4().hex
+        image_backup = f".{final_image.name}.{transaction_id}.backup"
+        video_backup = f".{final_video.name}.{transaction_id}.backup"
+        manifest = TransactionManifest(
+            schema_version=SCHEMA_VERSION,
+            transaction_id=transaction_id,
+            state="prepared",
+            final_image=final_image.name,
+            final_video=final_video.name,
+            temporary_image=temporary_image.name,
+            temporary_video=temporary_video.name,
+            backup_image=image_backup,
+            backup_video=video_backup,
+            had_image=final_image.exists(),
+            had_video=final_video.exists(),
+        )
+        _fsync_file(temporary_image)
+        _fsync_file(temporary_video)
+        journal_path = _write_manifest(directory, manifest)
+        try:
+            if manifest.had_image:
+                os.replace(final_image, directory / image_backup)
+            if manifest.had_video:
+                os.replace(final_video, directory / video_backup)
+            manifest = replace(manifest, state="originals_backed_up")
+            _write_manifest(directory, manifest)
+
+            os.replace(temporary_image, final_image)
+            manifest = replace(manifest, state="image_installed")
+            _write_manifest(directory, manifest)
+
+            os.replace(temporary_video, final_video)
+            manifest = replace(manifest, state="pair_installed")
+            journal_path = _write_manifest(directory, manifest)
+            _fsync_directory(directory)
+
+            if pair_validator is not None and not pair_validator(final_image, final_video):
+                raise ValueError("installed Live Photo pair failed final validation")
+            _finalize(directory, manifest, journal_path)
+        except BaseException:
+            # Python exceptions, KeyboardInterrupt and SystemExit all get an immediate rollback.
+            # SIGKILL/power loss cannot execute this block; the durable journal handles those on
+            # the next invocation.
+            try:
+                _rollback(directory, manifest, journal_path)
+            except Exception:
+                # Keep the original exception. Any surviving journal is intentionally left for the
+                # next recovery pass if rollback itself could not finish.
+                pass
+            raise


### PR DESCRIPTION
Fixes the two batch-integrity issues found after Motion Photo/Live Photo support landed, in both Swift and Python.

- stable Motion Photo batch destinations are derived from the canonical input-root namespace plus normalized source-relative path, never current batch ordering/membership; two different input roots sharing an output directory cannot alias the same persisted name
- 128-bit deterministic destination token plus fail-closed collision validation
- SHA-256 source provenance + exact output paths + Apple asset identifier required before skip/resume can reuse a pair
- structurally valid Live Photo pairs with unknown provenance are never silently claimed for the current source
- durable provenance/checkpoint state is retained after success; legacy records without a digest/asset ID cannot authorize reuse
- Swift and Python share the same checkpoint wire schema and custom checkpoint suffix contract
- crash-recoverable HEIC+MOV transaction journal with same-directory temporary resources, backup recovery, inter-process locking, and directory/file synchronization
- explicit durable `committed` state is the transaction commit point; backup cleanup occurs only after it and journal removal is last, so a crash during cleanup cannot roll back only half of a pair
- Swift and Python share the transaction journal wire schema; POSIX builds use interoperable record locks on the same lock file
- Python no longer renames the final pair from the system temporary directory, eliminating cross-filesystem `EXDEV` exposure
- Python default discovery ignores hidden transaction/recovery artifacts; explicit legacy ProXDR output collisions are detected before the first write instead of silently flattening two inputs onto one destination
- Python keeps its pre-existing non-recursive default batch discovery contract so this reliability fix does not broaden legacy ProXDR routing semantics
- regression tests cover duplicate basenames/subset reruns, shared output directories across independent input roots, same-size source mutation, foreign valid pairs/provenance rules, custom checkpoint paths, hidden recovery artifacts, cross-runtime checkpoint/journal compatibility, cross-directory temp rejection, every relevant simulated crash window, and interrupted post-commit cleanup

The transaction is deliberately described as crash-recoverable rather than a two-file atomic rename: filesystems do not provide a primitive that atomically renames both Live Photo resources together. The durable journal defines a recoverable commit protocol around the two resource renames.

Validation on head `4b75ae34a62ef00e9adc42841c9c9cadc8072bb0` passed the macOS XDRemux CI, the real Motion Photo fixture + PhotoKit gate, and the Python-generated Live Photo -> macOS PhotoKit compatibility gate. PR remains Draft pending maintainer merge/review decision.