### PR TITLE
Simplify Motion Photo batch identity and resume

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,10 @@ jobs:
           echo "::endgroup::"
           echo "MACOS_APP_RESULT=Passed" >> "$GITHUB_ENV"
 
-      # This bundle is the pre-existing ProXDR / Apple feature regression fixture set. Keep it
-      # separate from XDREMUX_FIXTURE_ARCHIVE_URL, which is reserved for the dedicated real
-      # Samsung/Xiaomi/OPPO/vivo Motion Photo gate.
-      - name: Prepare private fixtures
+      # This bundle is the pre-existing ProXDR / Apple-feature regression fixture set. Motion Photo
+      # real-fixture acceptance is owned by the dedicated Motion Photo workflows, so ordinary CI
+      # does not run those expensive conversions a second time.
+      - name: Prepare private regression fixtures
         shell: bash
         env:
           FIXTURE_ARCHIVE_URL: ${{ secrets.XDREMUX_REGRESSION_FIXTURE_ARCHIVE_URL }}
@@ -89,29 +89,6 @@ jobs:
           curl --fail --location --silent --show-error "$FIXTURE_ARCHIVE_URL" --output "$RUNNER_TEMP/xdremux-fixtures.zip"
           ditto -x -k "$RUNNER_TEMP/xdremux-fixtures.zip" "$RUNNER_TEMP/xdremux-fixtures"
           echo "FIXTURE_ROOT=$RUNNER_TEMP/xdremux-fixtures" >> "$GITHUB_ENV"
-
-      - name: Run private Motion Photo fixtures
-        shell: bash
-        run: |
-          if [[ -z "${FIXTURE_ROOT:-}" ]]; then
-            echo "MOTION_PHOTO_REAL_RESULT=Not configured" >> "$GITHUB_ENV"
-            exit 0
-          fi
-          C15="$(find "$FIXTURE_ROOT" -type f -name 'IMG20250425184722.jpg' -print -quit)"
-          C16="$(find "$FIXTURE_ROOT" -type f -name 'IMG20250901181353.jpg' -print -quit)"
-          if [[ -z "$C15" && -z "$C16" ]]; then
-            echo "MOTION_PHOTO_REAL_RESULT=Fixtures not present" >> "$GITHUB_ENV"
-            exit 0
-          fi
-          echo "::group::Real OPPO Motion Photo characterization and conversion"
-          XDREMUX_MOTION_PHOTO_FIXTURE_ROOT="$FIXTURE_ROOT" \
-            swift test --filter RealMotionPhotoFixtureTests 2>&1 | tee artifacts/motion-photo-real-fixtures.log
-          echo "::endgroup::"
-          if [[ -n "$C15" && -n "$C16" ]]; then
-            echo "MOTION_PHOTO_REAL_RESULT=Passed (ColorOS 15 + 16)" >> "$GITHUB_ENV"
-          else
-            echo "MOTION_PHOTO_REAL_RESULT=Passed available fixture; one generation absent" >> "$GITHUB_ENV"
-          fi
 
       - name: "[4/5] Run fixture conversions"
         shell: bash
@@ -192,7 +169,6 @@ jobs:
             echo "| Swift package build | ${SWIFT_BUILD_RESULT:-Failed} |"
             echo "| Unit tests | ${UNIT_TEST_RESULT:-Not run} |"
             echo "| macOS App build | ${MACOS_APP_RESULT:-Not run} |"
-            echo "| Real OPPO Motion Photo fixtures | ${MOTION_PHOTO_REAL_RESULT:-Not run} |"
             echo "| Standard ISO fixture | ${STANDARD_FIXTURE_RESULT:-Not run} |"
             echo "| OPPO compatibility fixture | ${OPPO_FIXTURE_RESULT:-Not run} |"
             echo "| Apple styles fixture | ${APPLE_STYLES_RESULT:-Not run} |"

--- a/.github/workflows/python-motion-photo-real-fixtures.yml
+++ b/.github/workflows/python-motion-photo-real-fixtures.yml
@@ -42,8 +42,7 @@ jobs:
 
       - name: Run portable Python tests
         shell: bash
-        run: |
-          python -m unittest discover -s Tests -p 'test_*.py' -v
+        run: python -m unittest discover -s Tests -p 'test_*.py' -v
 
       - name: Resolve private fixture archive
         shell: bash
@@ -60,13 +59,23 @@ jobs:
             --output "$RUNNER_TEMP/xdremux-fixtures.zip"
           unzip -q "$RUNNER_TEMP/xdremux-fixtures.zip" -d "$RUNNER_TEMP/xdremux-fixtures"
 
-      - name: Convert all real fixtures on Linux with pure Python
+      - name: Convert all real fixtures once on Linux
         shell: bash
         run: |
+          OUTPUT_ROOT="$RUNNER_TEMP/xdremux-python-live-photo-output"
+          mkdir -p "$OUTPUT_ROOT"
           python Tests/validation/verify_python_motion_photo_fixtures.py \
             --fixture-root "$RUNNER_TEMP/xdremux-fixtures" \
-            --output-root "$RUNNER_TEMP/xdremux-python-live-photo-output" \
-            --manifest "$RUNNER_TEMP/xdremux-python-live-photo-manifest.json"
+            --output-root "$OUTPUT_ROOT" \
+            --manifest "$OUTPUT_ROOT/manifest.json" \
+            2>&1 | tee "$OUTPUT_ROOT/conversion.log"
+
+      - name: Upload generated Live Photo pairs
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-live-photo-generated-pairs
+          if-no-files-found: error
+          path: ${{ runner.temp }}/xdremux-python-live-photo-output/
 
   apple-compatibility-oracle:
     needs: portable-python
@@ -83,27 +92,17 @@ jobs:
             echo "runner_os=$(sw_vers -productVersion)"
             echo "runner_build=$(sw_vers -buildVersion)"
             echo "arch=$(uname -m)"
-            echo "conversion_runtime=pure Python; Apple frameworks are validation-only"
+            echo "conversion_runtime=Linux pure Python"
+            echo "Apple frameworks=validation-only"
           } | tee artifacts/python-live-photo-runner.txt
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install Python package
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .
-
-      - name: Resolve private fixture archive
+      - name: Resolve private fixture archive for source-side validation
         shell: bash
         env:
           FIXTURE_ARCHIVE_URL: ${{ secrets.XDREMUX_FIXTURE_ARCHIVE_URL }}
         run: |
           if [[ -z "$FIXTURE_ARCHIVE_URL" ]]; then
-            echo "::error::XDREMUX_FIXTURE_ARCHIVE_URL is required for the strict Python gate"
+            echo "::error::XDREMUX_FIXTURE_ARCHIVE_URL is required for the PhotoKit oracle"
             exit 1
           fi
           mkdir -p "$RUNNER_TEMP/xdremux-fixtures"
@@ -112,22 +111,48 @@ jobs:
             --output "$RUNNER_TEMP/xdremux-fixtures.zip"
           ditto -x -k "$RUNNER_TEMP/xdremux-fixtures.zip" "$RUNNER_TEMP/xdremux-fixtures"
           echo "FIXTURE_ROOT=$RUNNER_TEMP/xdremux-fixtures" >> "$GITHUB_ENV"
-          echo "PYTHON_OUTPUT_ROOT=$RUNNER_TEMP/xdremux-python-live-photo-output" >> "$GITHUB_ENV"
-          echo "PYTHON_MANIFEST=$RUNNER_TEMP/xdremux-python-live-photo-manifest.json" >> "$GITHUB_ENV"
 
-      - name: Convert all real fixtures with pure Python
+      - name: Download Linux-generated Live Photo pairs
+        uses: actions/download-artifact@v8
+        with:
+          name: python-live-photo-generated-pairs
+          path: ${{ runner.temp }}/xdremux-python-live-photo-output
+
+      - name: Rebase artifact manifest paths for this runner
         shell: bash
         run: |
-          echo "::group::Pure Python Samsung / Xiaomi / OPPO / vivo conversion"
-          python Tests/validation/verify_python_motion_photo_fixtures.py \
-            --fixture-root "$FIXTURE_ROOT" \
-            --output-root "$PYTHON_OUTPUT_ROOT" \
-            --manifest "$PYTHON_MANIFEST" \
-            2>&1 | tee artifacts/python-motion-photo-real-fixtures.log
-          echo "::endgroup::"
-          cp "$PYTHON_MANIFEST" artifacts/python-live-photo-manifest.json
+          OUTPUT_ROOT="$RUNNER_TEMP/xdremux-python-live-photo-output"
+          MANIFEST="$OUTPUT_ROOT/manifest.json"
+          python3 - "$MANIFEST" "$FIXTURE_ROOT" "$OUTPUT_ROOT" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
 
-      - name: Validate Python outputs with macOS PhotoKit
+          manifest_path = Path(sys.argv[1])
+          fixture_root = Path(sys.argv[2])
+          output_root = Path(sys.argv[3])
+          data = json.loads(manifest_path.read_text(encoding="utf-8"))
+          by_name = {}
+          wanted = {entry["sourceFilename"] for entry in data["fixtures"]}
+          for candidate in fixture_root.rglob("*"):
+              if candidate.is_file() and candidate.name in wanted:
+                  if candidate.name in by_name and by_name[candidate.name] != candidate:
+                      raise RuntimeError(f"duplicate fixture filename: {candidate.name}")
+                  by_name[candidate.name] = candidate
+          missing = wanted - by_name.keys()
+          if missing:
+              raise RuntimeError("missing source fixtures: " + ", ".join(sorted(missing)))
+          for entry in data["fixtures"]:
+              entry["sourcePath"] = str(by_name[entry["sourceFilename"]])
+              entry["outputImagePath"] = str(output_root / Path(entry["outputImagePath"]).name)
+              entry["outputVideoPath"] = str(output_root / Path(entry["outputVideoPath"]).name)
+          manifest_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+          PY
+          cp "$MANIFEST" artifacts/python-live-photo-manifest.json
+          cp "$OUTPUT_ROOT/conversion.log" artifacts/python-motion-photo-real-fixtures.log
+          echo "PYTHON_MANIFEST=$MANIFEST" >> "$GITHUB_ENV"
+
+      - name: Validate Linux outputs with macOS PhotoKit
         shell: bash
         env:
           XDREMUX_PYTHON_LIVE_PHOTO_MANIFEST: ${{ env.PYTHON_MANIFEST }}
@@ -144,11 +169,11 @@ jobs:
           {
             echo "## Python Motion Photo → Apple Live Photo Gate"
             echo
-            echo "- Linux real-fixture conversion: required before this job"
-            echo "- macOS conversion runtime: pure Python/container code"
-            echo "- Apple frameworks: final structural/PhotoKit acceptance oracle only"
+            echo "- Linux real-fixture conversion: one authoritative generation pass"
+            echo "- macOS conversion: none"
+            echo "- Apple frameworks: structural/PhotoKit acceptance oracle only"
             if [[ -f artifacts/python-live-photo-manifest.json ]]; then
-              echo "- Real fixture manifest: produced"
+              echo "- Linux-generated artifact manifest: validated"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoBatchCheckpoint.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoBatchCheckpoint.swift
@@ -1,9 +1,9 @@
-import CryptoKit
 import Foundation
 
-/// Durable sidecar state for the Motion Photo pre-pass. Besides retry status, this is the
-/// provenance record that proves a specific source produced a specific HEIC+MOV pair.
-/// The wire format intentionally matches xdremux_py.live_photo_batch.
+/// Small resume checkpoint for the Motion Photo batch pass.
+///
+/// This state is local to the Swift CLI. It records enough source metadata and output identity to
+/// avoid repeating completed work, but it is not a cross-runtime provenance database.
 enum MotionPhotoBatchCheckpoint {
     enum Status: String, Codable {
         case success
@@ -14,29 +14,22 @@ enum MotionPhotoBatchCheckpoint {
     struct FileSignature: Equatable {
         let size: Int64
         let mtimeNs: Int64
-        let sha256: String
     }
 
     struct Item: Codable {
         let kind: String
         let inputPath: String
-        let sourceRelativePath: String?
         let outputImagePath: String
         let outputVideoPath: String
         let status: Status
         let inputSize: Int64?
         let inputMtimeNs: Int64?
-        let inputSHA256: String?
         let assetIdentifier: String?
         let error: String?
 
-        /// Old schema-1 entries intentionally fail this check: size/mtime alone are not strong
-        /// enough provenance to allow --skip-existing to claim a pair for the current source.
         func matchesSignature(_ signature: FileSignature?) -> Bool {
-            guard let signature,
-                  let inputSize,
-                  let inputSHA256 else { return false }
-            return inputSize == signature.size && inputSHA256 == signature.sha256
+            guard let signature, let inputSize, let inputMtimeNs else { return false }
+            return inputSize == signature.size && inputMtimeNs == signature.mtimeNs
         }
 
         func matchesOutputs(imageURL: URL, videoURL: URL) -> Bool {
@@ -52,7 +45,7 @@ enum MotionPhotoBatchCheckpoint {
 
         init(createdAt: String) {
             self.kind = "header"
-            self.schemaVersion = 2
+            self.schemaVersion = 1
             self.createdAt = createdAt
         }
     }
@@ -60,8 +53,7 @@ enum MotionPhotoBatchCheckpoint {
     static func resolvedURL(for command: BatchCommand) -> URL {
         if let requested = command.checkpointURL {
             let parent = requested.deletingLastPathComponent()
-            let name = requested.lastPathComponent
-            return parent.appendingPathComponent("\(name).motion-photo")
+            return parent.appendingPathComponent("\(requested.lastPathComponent).motion-photo")
         }
         return command.outputDirURL.appendingPathComponent(".xdremux-motion-photo-checkpoint.jsonl")
     }
@@ -70,29 +62,7 @@ enum MotionPhotoBatchCheckpoint {
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
         let size = (attributes[.size] as? NSNumber)?.int64Value ?? 0
         let modified = (attributes[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
-
-        let handle = try FileHandle(forReadingFrom: url)
-        defer { try? handle.close() }
-        var hasher = SHA256()
-        while let data = try handle.read(upToCount: 1024 * 1024), !data.isEmpty {
-            hasher.update(data: data)
-        }
-        let digest = hasher.finalize().map { String(format: "%02x", $0) }.joined()
-        return FileSignature(
-            size: size,
-            mtimeNs: Int64(modified * 1_000_000_000),
-            sha256: digest
-        )
-    }
-
-    static func relativeSourcePath(inputURL: URL, inputRootURL: URL) -> String {
-        let input = inputURL.standardizedFileURL.path
-        let root = inputRootURL.standardizedFileURL.path
-        let prefix = root.hasSuffix("/") ? root : root + "/"
-        if input.hasPrefix(prefix) {
-            return String(input.dropFirst(prefix.count)).precomposedStringWithCanonicalMapping
-        }
-        return input.precomposedStringWithCanonicalMapping
+        return FileSignature(size: size, mtimeNs: Int64(modified * 1_000_000_000))
     }
 
     static func load(url: URL) throws -> [String: Item] {
@@ -103,26 +73,14 @@ enum MotionPhotoBatchCheckpoint {
         var state: [String: Item] = [:]
         for line in data.split(separator: 0x0a) where !line.isEmpty {
             guard let object = try? JSONSerialization.jsonObject(with: Data(line)) as? [String: Any],
-                  object["kind"] as? String == "item" else {
-                // A crash can leave a truncated final JSONL record. Ignoring it is fail-closed:
-                // the input will be rebuilt rather than incorrectly authorized for reuse.
-                continue
-            }
-            guard let item = try? decoder.decode(Item.self, from: Data(line)) else {
-                // Foreign/unsupported item schemas also cannot authorize reuse. This makes the
-                // checkpoint robust to mixed runtime versions without turning corruption into a
-                // batch-wide availability failure.
+                  object["kind"] as? String == "item",
+                  let item = try? decoder.decode(Item.self, from: Data(line)) else {
+                // Truncated or older foreign records simply cause the source to be rebuilt.
                 continue
             }
             state[item.inputPath] = item
         }
         return state
-    }
-
-    static func reset(url: URL) throws {
-        if FileManager.default.fileExists(atPath: url.path) {
-            try FileManager.default.removeItem(at: url)
-        }
     }
 
     final class Writer: @unchecked Sendable {
@@ -146,15 +104,13 @@ enum MotionPhotoBatchCheckpoint {
 
             let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
             if (attributes[.size] as? NSNumber)?.int64Value == 0 {
-                try appendEncodable(
-                    Header(createdAt: ISO8601DateFormatter().string(from: Date()))
-                )
+                try appendEncodable(Header(createdAt: ISO8601DateFormatter().string(from: Date())))
             }
         }
 
         func append(
             inputURL: URL,
-            inputRootURL: URL? = nil,
+            inputRootURL _: URL? = nil,
             outputImageURL: URL,
             outputVideoURL: URL,
             status: Status,
@@ -166,18 +122,11 @@ enum MotionPhotoBatchCheckpoint {
                 Item(
                     kind: "item",
                     inputPath: inputURL.standardizedFileURL.path,
-                    sourceRelativePath: inputRootURL.map {
-                        MotionPhotoBatchCheckpoint.relativeSourcePath(
-                            inputURL: inputURL,
-                            inputRootURL: $0
-                        )
-                    },
                     outputImagePath: outputImageURL.standardizedFileURL.path,
                     outputVideoPath: outputVideoURL.standardizedFileURL.path,
                     status: status,
                     inputSize: signature?.size,
                     inputMtimeNs: signature?.mtimeNs,
-                    inputSHA256: signature?.sha256,
                     assetIdentifier: assetIdentifier,
                     error: error
                 )
@@ -200,7 +149,6 @@ enum MotionPhotoBatchCheckpoint {
             guard let handle else { throw CocoaError(.fileWriteUnknown) }
             try handle.write(contentsOf: data)
             try handle.write(contentsOf: Data([0x0a]))
-            try handle.synchronize()
         }
 
         deinit {

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoBatchPlanner.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoBatchPlanner.swift
@@ -1,9 +1,8 @@
-import CryptoKit
 import Foundation
 
-/// Stable Motion Photo batch naming. A destination is a pure function of the canonical batch root
-/// plus the source path relative to that root, so batch membership/order cannot remap a source and
-/// two different input roots cannot silently target the same persisted Live Photo name.
+/// Stable Motion Photo batch naming based on the source path below the batch input root.
+/// Preserving the relative directory structure makes duplicate basenames unambiguous without
+/// introducing opaque hashed namespaces into user-visible filenames.
 enum MotionPhotoBatchPlanner {
     static func outputImageURL(
         for inputURL: URL,
@@ -12,29 +11,26 @@ enum MotionPhotoBatchPlanner {
     ) -> URL {
         let source = inputURL.resolvingSymlinksInPath().standardizedFileURL
         let root = inputRootURL.resolvingSymlinksInPath().standardizedFileURL
-        let rootIdentity = root.path.precomposedStringWithCanonicalMapping
-        let relativePath: String
         let prefix = root.path.hasSuffix("/") ? root.path : root.path + "/"
+        let relativePath: String
         if source.path.hasPrefix(prefix) {
             relativePath = String(source.path.dropFirst(prefix.count)).precomposedStringWithCanonicalMapping
         } else {
-            relativePath = source.path.precomposedStringWithCanonicalMapping
+            // Batch discovery normally guarantees that inputs are below inputRootURL. Keep the
+            // fallback readable and let validateUnique() reject any resulting collision.
+            relativePath = source.lastPathComponent.precomposedStringWithCanonicalMapping
         }
 
-        // Root namespace + relative path is equivalent to a canonical source identity while keeping
-        // the intent explicit. This prevents two independent input trees with the same A/IMG.jpg
-        // layout from overwriting each other when they share an output directory.
-        let identity = rootIdentity + "\u{0}" + relativePath
-        let digest = SHA256.hash(data: Data(identity.utf8))
-        // 128 bits keeps the filename compact while making accidental persisted-name collisions
-        // negligible. validateUnique() still fails closed if a collision is ever observed.
-        let token = digest.prefix(16).map { String(format: "%02x", $0) }.joined()
+        let components = relativePath.split(separator: "/").map(String.init)
+        var directory = outputDirectoryURL
+        for component in components.dropLast() {
+            directory.appendPathComponent(component, isDirectory: true)
+        }
+
         let ext = source.pathExtension.lowercased()
         let sourceStem = source.deletingPathExtension().lastPathComponent
         let stem = (ext == "heic" || ext == "heif") ? "\(sourceStem).live" : sourceStem
-        return outputDirectoryURL
-            .appendingPathComponent("\(stem)~\(token)")
-            .appendingPathExtension("heic")
+        return directory.appendingPathComponent(stem).appendingPathExtension("heic")
     }
 
     static func validateUnique(_ items: [(input: URL, output: URL)]) throws {
@@ -55,7 +51,7 @@ enum MotionPhotoBatchPlanner {
         var errorDescription: String? {
             switch self {
             case let .collision(first, second, output):
-                return "stable Motion Photo output collision: \(first) and \(second) -> \(output)"
+                return "Motion Photo output collision: \(first) and \(second) -> \(output)"
             }
         }
     }

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoBatchPlanner.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoBatchPlanner.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 /// Stable Motion Photo batch naming based on the source path below the batch input root.
-/// Preserving the relative directory structure makes duplicate basenames unambiguous without
-/// introducing opaque hashed namespaces into user-visible filenames.
+/// Preserving the relative directory structure plus a readable `.live` suffix makes duplicate
+/// basenames unambiguous without opaque hashes and avoids the common JPEG/HEIC sibling collision.
 enum MotionPhotoBatchPlanner {
     static func outputImageURL(
         for inputURL: URL,
@@ -27,10 +27,8 @@ enum MotionPhotoBatchPlanner {
             directory.appendPathComponent(component, isDirectory: true)
         }
 
-        let ext = source.pathExtension.lowercased()
         let sourceStem = source.deletingPathExtension().lastPathComponent
-        let stem = (ext == "heic" || ext == "heif") ? "\(sourceStem).live" : sourceStem
-        return directory.appendingPathComponent(stem).appendingPathExtension("heic")
+        return directory.appendingPathComponent("\(sourceStem).live").appendingPathExtension("heic")
     }
 
     static func validateUnique(_ items: [(input: URL, output: URL)]) throws {

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoBatchPlanner.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoBatchPlanner.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 /// Stable Motion Photo batch naming based on the source path below the batch input root.
-/// Preserving the relative directory structure plus a readable `.live` suffix makes duplicate
-/// basenames unambiguous without opaque hashes and avoids the common JPEG/HEIC sibling collision.
+/// Preserving the relative directory structure plus a readable source-kind suffix makes duplicate
+/// basenames unambiguous without opaque hashes and avoids common JPEG/HEIF sibling collisions.
 enum MotionPhotoBatchPlanner {
     static func outputImageURL(
         for inputURL: URL,
@@ -27,8 +27,10 @@ enum MotionPhotoBatchPlanner {
             directory.appendPathComponent(component, isDirectory: true)
         }
 
+        let ext = source.pathExtension.lowercased()
         let sourceStem = source.deletingPathExtension().lastPathComponent
-        return directory.appendingPathComponent("\(sourceStem).live").appendingPathExtension("heic")
+        let kindSuffix = (ext == "heic" || ext == "heif") ? "live" : "motion"
+        return directory.appendingPathComponent("\(sourceStem).\(kindSuffix)").appendingPathExtension("heic")
     }
 
     static func validateUnique(_ items: [(input: URL, output: URL)]) throws {

--- a/Tests/XDRemuxCLITests/MotionPhotoBatchCheckpointTests.swift
+++ b/Tests/XDRemuxCLITests/MotionPhotoBatchCheckpointTests.swift
@@ -3,12 +3,9 @@ import XCTest
 @testable import XDRemuxCLI
 
 final class MotionPhotoBatchCheckpointTests: XCTestCase {
-    func testRoundTripsPairOutputsAndInputSignature() throws {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("xdremux-motion-checkpoint-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    func testRoundTripsPairOutputsAndCheapInputSignature() throws {
+        let directory = try makeDirectory("roundtrip")
         defer { try? FileManager.default.removeItem(at: directory) }
-
         let input = directory.appendingPathComponent("source.jpg")
         try Data("source".utf8).write(to: input)
         let image = directory.appendingPathComponent("source.heic")
@@ -19,7 +16,6 @@ final class MotionPhotoBatchCheckpointTests: XCTestCase {
         let writer = try MotionPhotoBatchCheckpoint.Writer(url: checkpoint)
         try writer.append(
             inputURL: input,
-            inputRootURL: directory,
             outputImageURL: image,
             outputVideoURL: video,
             status: .success,
@@ -34,20 +30,15 @@ final class MotionPhotoBatchCheckpointTests: XCTestCase {
         XCTAssertTrue(item.matchesSignature(signature))
         XCTAssertTrue(item.matchesOutputs(imageURL: image, videoURL: video))
         XCTAssertEqual(item.assetIdentifier, "ASSET-1")
-        XCTAssertEqual(item.sourceRelativePath, "source.jpg")
     }
 
-    func testCanonicalPythonWireRecordLoadsInSwift() throws {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("xdremux-motion-checkpoint-python-wire-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    func testPR18CheckpointRecordMigratesWithoutDigestDependency() throws {
+        let directory = try makeDirectory("migration")
         defer { try? FileManager.default.removeItem(at: directory) }
-
         let input = directory.appendingPathComponent("source.jpg")
         let image = directory.appendingPathComponent("source.heic")
         let video = directory.appendingPathComponent("source.mov")
         let checkpoint = directory.appendingPathComponent("checkpoint.jsonl")
-        let digest = String(repeating: "ab", count: 32)
         let record: [String: Any] = [
             "kind": "item",
             "inputPath": input.standardizedFileURL.path,
@@ -57,28 +48,23 @@ final class MotionPhotoBatchCheckpointTests: XCTestCase {
             "status": "success",
             "inputSize": 123,
             "inputMtimeNs": 456,
-            "inputSHA256": digest,
-            "assetIdentifier": "ASSET-PYTHON",
+            "inputSHA256": String(repeating: "ab", count: 32),
+            "assetIdentifier": "ASSET-OLD",
             "error": NSNull(),
         ]
         let data = try JSONSerialization.data(withJSONObject: record, options: [.sortedKeys])
         try data.write(to: checkpoint)
-        let handle = try FileHandle(forWritingTo: checkpoint)
-        try handle.seekToEnd()
-        try handle.write(contentsOf: Data([0x0a]))
-        try handle.close()
+        try FileHandle(forWritingTo: checkpoint).close()
 
         let state = try MotionPhotoBatchCheckpoint.load(url: checkpoint)
         let item = try XCTUnwrap(state[input.standardizedFileURL.path])
-        XCTAssertEqual(item.inputSHA256, digest)
-        XCTAssertEqual(item.assetIdentifier, "ASSET-PYTHON")
-        XCTAssertTrue(item.matchesOutputs(imageURL: image, videoURL: video))
+        XCTAssertEqual(item.inputSize, 123)
+        XCTAssertEqual(item.inputMtimeNs, 456)
+        XCTAssertEqual(item.assetIdentifier, "ASSET-OLD")
     }
 
-    func testMalformedForeignRecordIsIgnoredFailClosed() throws {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("xdremux-motion-checkpoint-malformed-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    func testMalformedRecordIsIgnored() throws {
+        let directory = try makeDirectory("malformed")
         defer { try? FileManager.default.removeItem(at: directory) }
         let checkpoint = directory.appendingPathComponent("checkpoint.jsonl")
         let input = directory.appendingPathComponent("source.jpg").standardizedFileURL.path
@@ -90,12 +76,9 @@ final class MotionPhotoBatchCheckpointTests: XCTestCase {
         XCTAssertEqual(try MotionPhotoBatchCheckpoint.load(url: checkpoint).count, 0)
     }
 
-    func testChangedInputSignatureDoesNotResumeAsDone() throws {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("xdremux-motion-checkpoint-change-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    func testChangedSourceMetadataDoesNotResumeAsDone() throws {
+        let directory = try makeDirectory("change")
         defer { try? FileManager.default.removeItem(at: directory) }
-
         let input = directory.appendingPathComponent("source.jpg")
         try Data("before".utf8).write(to: input)
         let image = directory.appendingPathComponent("source.heic")
@@ -116,29 +99,29 @@ final class MotionPhotoBatchCheckpointTests: XCTestCase {
 
         try Data("after-with-different-size".utf8).write(to: input, options: .atomic)
         let after = try MotionPhotoBatchCheckpoint.signature(for: input)
-        let state = try MotionPhotoBatchCheckpoint.load(url: checkpoint)
-        let item = try XCTUnwrap(state[input.standardizedFileURL.path])
+        let item = try XCTUnwrap(try MotionPhotoBatchCheckpoint.load(url: checkpoint)[input.standardizedFileURL.path])
         XCTAssertFalse(item.matchesSignature(after))
     }
 
-    func testDigestDetectsSameSizeContentChangeEvenWhenMtimeIsRestored() throws {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("xdremux-motion-checkpoint-digest-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    func testMtimeChangeInvalidatesSameSizeSource() throws {
+        let directory = try makeDirectory("mtime")
         defer { try? FileManager.default.removeItem(at: directory) }
-
         let input = directory.appendingPathComponent("source.jpg")
         try Data("AAAA".utf8).write(to: input)
         let before = try MotionPhotoBatchCheckpoint.signature(for: input)
-        let attributes = try FileManager.default.attributesOfItem(atPath: input.path)
-        let modificationDate = try XCTUnwrap(attributes[.modificationDate] as? Date)
-
-        try Data("BBBB".utf8).write(to: input)
-        try FileManager.default.setAttributes([.modificationDate: modificationDate], ofItemAtPath: input.path)
+        let future = Date(timeIntervalSince1970: Double(before.mtimeNs) / 1_000_000_000 + 10)
+        try FileManager.default.setAttributes([.modificationDate: future], ofItemAtPath: input.path)
         let after = try MotionPhotoBatchCheckpoint.signature(for: input)
 
         XCTAssertEqual(before.size, after.size)
-        XCTAssertNotEqual(before.sha256, after.sha256)
+        XCTAssertNotEqual(before.mtimeNs, after.mtimeNs)
         XCTAssertNotEqual(before, after)
+    }
+
+    private func makeDirectory(_ suffix: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-motion-checkpoint-\(suffix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
     }
 }

--- a/Tests/XDRemuxCLITests/MotionPhotoBatchPlannerTests.swift
+++ b/Tests/XDRemuxCLITests/MotionPhotoBatchPlannerTests.swift
@@ -9,39 +9,34 @@ final class MotionPhotoBatchPlannerTests: XCTestCase {
         let a = root.appendingPathComponent("A/IMG.jpg")
         let b = root.appendingPathComponent("B/IMG.jpg")
 
-        let aOutput = MotionPhotoBatchPlanner.outputImageURL(
-            for: a,
-            inputRootURL: root,
-            outputDirectoryURL: output
-        )
-        let bOutput = MotionPhotoBatchPlanner.outputImageURL(
-            for: b,
-            inputRootURL: root,
-            outputDirectoryURL: output
-        )
-        let bSubsetOutput = MotionPhotoBatchPlanner.outputImageURL(
-            for: b,
-            inputRootURL: root,
-            outputDirectoryURL: output
-        )
+        let aOutput = MotionPhotoBatchPlanner.outputImageURL(for: a, inputRootURL: root, outputDirectoryURL: output)
+        let bOutput = MotionPhotoBatchPlanner.outputImageURL(for: b, inputRootURL: root, outputDirectoryURL: output)
+        let bSubsetOutput = MotionPhotoBatchPlanner.outputImageURL(for: b, inputRootURL: root, outputDirectoryURL: output)
 
-        XCTAssertEqual(aOutput.path, output.appendingPathComponent("A/IMG.live.heic").path)
-        XCTAssertEqual(bOutput.path, output.appendingPathComponent("B/IMG.live.heic").path)
+        XCTAssertEqual(aOutput.path, output.appendingPathComponent("A/IMG.motion.heic").path)
+        XCTAssertEqual(bOutput.path, output.appendingPathComponent("B/IMG.motion.heic").path)
         XCTAssertEqual(bOutput, bSubsetOutput)
     }
 
     func testJPEGOutputDoesNotUseSiblingSourceHEICName() {
         let root = URL(fileURLWithPath: "/tmp/xdremux-input", isDirectory: true)
-        let output = root
         let jpeg = root.appendingPathComponent("A/IMG.jpg")
         let siblingHEIC = root.appendingPathComponent("A/IMG.heic")
-        let planned = MotionPhotoBatchPlanner.outputImageURL(
-            for: jpeg,
-            inputRootURL: root,
-            outputDirectoryURL: output
-        )
+        let planned = MotionPhotoBatchPlanner.outputImageURL(for: jpeg, inputRootURL: root, outputDirectoryURL: root)
         XCTAssertNotEqual(planned.path, siblingHEIC.path)
-        XCTAssertEqual(planned.path, root.appendingPathComponent("A/IMG.live.heic").path)
+        XCTAssertEqual(planned.path, root.appendingPathComponent("A/IMG.motion.heic").path)
+    }
+
+    func testSameStemJPEGAndHEIFInputsRemainDistinct() {
+        let root = URL(fileURLWithPath: "/tmp/xdremux-input", isDirectory: true)
+        let output = URL(fileURLWithPath: "/tmp/xdremux-output", isDirectory: true)
+        let jpeg = root.appendingPathComponent("A/IMG.jpg")
+        let heif = root.appendingPathComponent("A/IMG.heic")
+        let jpegOutput = MotionPhotoBatchPlanner.outputImageURL(for: jpeg, inputRootURL: root, outputDirectoryURL: output)
+        let heifOutput = MotionPhotoBatchPlanner.outputImageURL(for: heif, inputRootURL: root, outputDirectoryURL: output)
+        XCTAssertEqual(jpegOutput.path, output.appendingPathComponent("A/IMG.motion.heic").path)
+        XCTAssertEqual(heifOutput.path, output.appendingPathComponent("A/IMG.live.heic").path)
+        XCTAssertNotEqual(jpegOutput, heifOutput)
     }
 
     func testAbsoluteInputRootDoesNotLeakIntoOutputName() {
@@ -50,19 +45,9 @@ final class MotionPhotoBatchPlannerTests: XCTestCase {
         let output = URL(fileURLWithPath: "/tmp/xdremux-output", isDirectory: true)
         let first = firstRoot.appendingPathComponent("A/IMG.jpg")
         let second = secondRoot.appendingPathComponent("A/IMG.jpg")
-
-        let firstOutput = MotionPhotoBatchPlanner.outputImageURL(
-            for: first,
-            inputRootURL: firstRoot,
-            outputDirectoryURL: output
-        )
-        let secondOutput = MotionPhotoBatchPlanner.outputImageURL(
-            for: second,
-            inputRootURL: secondRoot,
-            outputDirectoryURL: output
-        )
-
-        XCTAssertEqual(firstOutput.path, output.appendingPathComponent("A/IMG.live.heic").path)
+        let firstOutput = MotionPhotoBatchPlanner.outputImageURL(for: first, inputRootURL: firstRoot, outputDirectoryURL: output)
+        let secondOutput = MotionPhotoBatchPlanner.outputImageURL(for: second, inputRootURL: secondRoot, outputDirectoryURL: output)
+        XCTAssertEqual(firstOutput.path, output.appendingPathComponent("A/IMG.motion.heic").path)
         XCTAssertEqual(secondOutput, firstOutput)
     }
 
@@ -70,11 +55,7 @@ final class MotionPhotoBatchPlannerTests: XCTestCase {
         let root = URL(fileURLWithPath: "/tmp/xdremux-input", isDirectory: true)
         let output = URL(fileURLWithPath: "/tmp/xdremux-output", isDirectory: true)
         let input = root.appendingPathComponent("Trips/IMG.heic")
-        let planned = MotionPhotoBatchPlanner.outputImageURL(
-            for: input,
-            inputRootURL: root,
-            outputDirectoryURL: output
-        )
+        let planned = MotionPhotoBatchPlanner.outputImageURL(for: input, inputRootURL: root, outputDirectoryURL: output)
         XCTAssertEqual(planned.path, output.appendingPathComponent("Trips/IMG.live.heic").path)
     }
 

--- a/Tests/XDRemuxCLITests/MotionPhotoBatchPlannerTests.swift
+++ b/Tests/XDRemuxCLITests/MotionPhotoBatchPlannerTests.swift
@@ -25,9 +25,23 @@ final class MotionPhotoBatchPlannerTests: XCTestCase {
             outputDirectoryURL: output
         )
 
-        XCTAssertEqual(aOutput.path, output.appendingPathComponent("A/IMG.heic").path)
-        XCTAssertEqual(bOutput.path, output.appendingPathComponent("B/IMG.heic").path)
+        XCTAssertEqual(aOutput.path, output.appendingPathComponent("A/IMG.live.heic").path)
+        XCTAssertEqual(bOutput.path, output.appendingPathComponent("B/IMG.live.heic").path)
         XCTAssertEqual(bOutput, bSubsetOutput)
+    }
+
+    func testJPEGOutputDoesNotUseSiblingSourceHEICName() {
+        let root = URL(fileURLWithPath: "/tmp/xdremux-input", isDirectory: true)
+        let output = root
+        let jpeg = root.appendingPathComponent("A/IMG.jpg")
+        let siblingHEIC = root.appendingPathComponent("A/IMG.heic")
+        let planned = MotionPhotoBatchPlanner.outputImageURL(
+            for: jpeg,
+            inputRootURL: root,
+            outputDirectoryURL: output
+        )
+        XCTAssertNotEqual(planned.path, siblingHEIC.path)
+        XCTAssertEqual(planned.path, root.appendingPathComponent("A/IMG.live.heic").path)
     }
 
     func testAbsoluteInputRootDoesNotLeakIntoOutputName() {
@@ -48,7 +62,7 @@ final class MotionPhotoBatchPlannerTests: XCTestCase {
             outputDirectoryURL: output
         )
 
-        XCTAssertEqual(firstOutput.path, output.appendingPathComponent("A/IMG.heic").path)
+        XCTAssertEqual(firstOutput.path, output.appendingPathComponent("A/IMG.live.heic").path)
         XCTAssertEqual(secondOutput, firstOutput)
     }
 

--- a/Tests/XDRemuxCLITests/MotionPhotoBatchPlannerTests.swift
+++ b/Tests/XDRemuxCLITests/MotionPhotoBatchPlannerTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import XDRemuxCLI
 
 final class MotionPhotoBatchPlannerTests: XCTestCase {
-    func testDuplicateBasenamesRemainDistinctAndStableAcrossSubsetRuns() throws {
+    func testDuplicateBasenamesPreserveRelativeDirectoriesAcrossSubsetRuns() throws {
         let root = URL(fileURLWithPath: "/tmp/xdremux-input", isDirectory: true)
         let output = URL(fileURLWithPath: "/tmp/xdremux-output", isDirectory: true)
         let a = root.appendingPathComponent("A/IMG.jpg")
@@ -25,17 +25,15 @@ final class MotionPhotoBatchPlannerTests: XCTestCase {
             outputDirectoryURL: output
         )
 
-        XCTAssertNotEqual(aOutput, bOutput)
+        XCTAssertEqual(aOutput.path, output.appendingPathComponent("A/IMG.heic").path)
+        XCTAssertEqual(bOutput.path, output.appendingPathComponent("B/IMG.heic").path)
         XCTAssertEqual(bOutput, bSubsetOutput)
-        XCTAssertTrue(aOutput.lastPathComponent.hasPrefix("IMG~"))
-        XCTAssertTrue(bOutput.lastPathComponent.hasPrefix("IMG~"))
-        XCTAssertEqual(aOutput.pathExtension, "heic")
     }
 
-    func testSameRelativePathInDifferentInputRootsCannotAliasSharedOutputDirectory() {
+    func testAbsoluteInputRootDoesNotLeakIntoOutputName() {
         let firstRoot = URL(fileURLWithPath: "/tmp/xdremux-root-one", isDirectory: true)
         let secondRoot = URL(fileURLWithPath: "/tmp/xdremux-root-two", isDirectory: true)
-        let output = URL(fileURLWithPath: "/tmp/xdremux-shared-output", isDirectory: true)
+        let output = URL(fileURLWithPath: "/tmp/xdremux-output", isDirectory: true)
         let first = firstRoot.appendingPathComponent("A/IMG.jpg")
         let second = secondRoot.appendingPathComponent("A/IMG.jpg")
 
@@ -50,23 +48,23 @@ final class MotionPhotoBatchPlannerTests: XCTestCase {
             outputDirectoryURL: output
         )
 
-        XCTAssertNotEqual(firstOutput, secondOutput)
+        XCTAssertEqual(firstOutput.path, output.appendingPathComponent("A/IMG.heic").path)
+        XCTAssertEqual(secondOutput, firstOutput)
     }
 
-    func testHEIFMotionPhotoUsesSeparateLiveNamespace() {
+    func testHEIFMotionPhotoUsesReadableLiveFilenameInsideRelativeDirectory() {
         let root = URL(fileURLWithPath: "/tmp/xdremux-input", isDirectory: true)
         let output = URL(fileURLWithPath: "/tmp/xdremux-output", isDirectory: true)
-        let input = root.appendingPathComponent("IMG.heic")
+        let input = root.appendingPathComponent("Trips/IMG.heic")
         let planned = MotionPhotoBatchPlanner.outputImageURL(
             for: input,
             inputRootURL: root,
             outputDirectoryURL: output
         )
-        XCTAssertTrue(planned.lastPathComponent.hasPrefix("IMG.live~"))
-        XCTAssertEqual(planned.pathExtension, "heic")
+        XCTAssertEqual(planned.path, output.appendingPathComponent("Trips/IMG.live.heic").path)
     }
 
-    func testPlannerRejectsDuplicateDestinationInsteadOfRenumberingByOrder() {
+    func testPlannerRejectsDuplicateDestination() {
         let first = URL(fileURLWithPath: "/tmp/a.jpg")
         let second = URL(fileURLWithPath: "/tmp/b.jpg")
         let output = URL(fileURLWithPath: "/tmp/result.heic")

--- a/Tests/test_python_live_photo_batch_reliability.py
+++ b/Tests/test_python_live_photo_batch_reliability.py
@@ -28,14 +28,9 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
             b.parent.mkdir(parents=True)
             a.write_bytes(b"a")
             b.write_bytes(b"b")
-
-            a_output = planned_output_image(a, root, output)
-            b_output = planned_output_image(b, root, output)
-            b_subset_output = planned_output_image(b, root, output)
-
-            self.assertEqual(a_output, output / "A" / "IMG.live.heic")
-            self.assertEqual(b_output, output / "B" / "IMG.live.heic")
-            self.assertEqual(b_output, b_subset_output)
+            self.assertEqual(planned_output_image(a, root, output), output / "A" / "IMG.motion.heic")
+            self.assertEqual(planned_output_image(b, root, output), output / "B" / "IMG.motion.heic")
+            self.assertEqual(planned_output_image(b, root, output), planned_output_image(b, root, output))
 
     def test_jpeg_batch_output_does_not_use_sibling_source_heic_name(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -47,7 +42,20 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
             sibling_heic.write_bytes(b"heic")
             planned = planned_output_image(source, root, root)
             self.assertNotEqual(planned, sibling_heic)
-            self.assertEqual(planned, root / "A" / "IMG.live.heic")
+            self.assertEqual(planned, root / "A" / "IMG.motion.heic")
+
+    def test_same_stem_jpeg_and_heif_inputs_have_distinct_outputs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "input"
+            output = Path(tmp) / "output"
+            jpeg = root / "A" / "IMG.jpg"
+            heif = root / "A" / "IMG.heic"
+            jpeg.parent.mkdir(parents=True)
+            jpeg.write_bytes(b"jpeg")
+            heif.write_bytes(b"heif")
+            self.assertEqual(planned_output_image(jpeg, root, output), output / "A" / "IMG.motion.heic")
+            self.assertEqual(planned_output_image(heif, root, output), output / "A" / "IMG.live.heic")
+            self.assertNotEqual(planned_output_image(jpeg, root, output), planned_output_image(heif, root, output))
 
     def test_absolute_input_root_does_not_leak_into_output_name(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -61,10 +69,7 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
             second.parent.mkdir(parents=True)
             first.write_bytes(b"first")
             second.write_bytes(b"second")
-            self.assertEqual(
-                planned_output_image(first, first_root, output),
-                planned_output_image(second, second_root, output),
-            )
+            self.assertEqual(planned_output_image(first, first_root, output), planned_output_image(second, second_root, output))
 
     def test_heif_motion_photo_uses_readable_live_filename(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -98,37 +103,11 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
             video = image.with_suffix(".mov")
             signature = source_signature(source)
             checkpoint = output / ".state.jsonl"
-
             with StateWriter(checkpoint) as writer:
-                writer.append(
-                    source=source,
-                    input_root=root,
-                    image=image,
-                    video=video,
-                    status="success",
-                    signature=signature,
-                    asset_identifier="ASSET-1",
-                )
-
+                writer.append(source=source, input_root=root, image=image, video=video, status="success", signature=signature, asset_identifier="ASSET-1")
             prior = load_state(checkpoint)[str(source.resolve())]
-            self.assertTrue(
-                provenance_allows_reuse(
-                    prior,
-                    signature,
-                    image,
-                    video,
-                    lambda i, v, identifier: identifier == "ASSET-1",
-                )
-            )
-            self.assertFalse(
-                provenance_allows_reuse(
-                    prior,
-                    signature,
-                    image,
-                    video,
-                    lambda i, v, identifier: False,
-                )
-            )
+            self.assertTrue(provenance_allows_reuse(prior, signature, image, video, lambda i, v, identifier: identifier == "ASSET-1"))
+            self.assertFalse(provenance_allows_reuse(prior, signature, image, video, lambda i, v, identifier: False))
 
     def test_pr18_camel_case_checkpoint_migrates_without_hash_dependency(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -142,22 +121,7 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
             image = planned_output_image(source, root, output)
             video = image.with_suffix(".mov")
             checkpoint = output / ".state.jsonl"
-            checkpoint.write_text(
-                json.dumps({
-                    "kind": "item",
-                    "inputPath": str(source.resolve()),
-                    "sourceRelativePath": "IMG.jpg",
-                    "outputImagePath": str(image.resolve()),
-                    "outputVideoPath": str(video.resolve()),
-                    "status": "success",
-                    "inputSize": signature.size,
-                    "inputMtimeNs": signature.mtime_ns,
-                    "inputSHA256": "deadbeef",
-                    "assetIdentifier": "ASSET-OLD",
-                    "error": None,
-                }) + "\n",
-                encoding="utf-8",
-            )
+            checkpoint.write_text(json.dumps({"kind":"item","inputPath":str(source.resolve()),"sourceRelativePath":"IMG.jpg","outputImagePath":str(image.resolve()),"outputVideoPath":str(video.resolve()),"status":"success","inputSize":signature.size,"inputMtimeNs":signature.mtime_ns,"inputSHA256":"deadbeef","assetIdentifier":"ASSET-OLD","error":None}) + "\n", encoding="utf-8")
             prior = load_state(checkpoint)[str(source.resolve())]
             self.assertTrue(prior.matches_source(signature))
             self.assertEqual(prior.asset_identifier, "ASSET-OLD")
@@ -174,24 +138,13 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
             image = planned_output_image(source, root, output)
             video = image.with_suffix(".mov")
             checkpoint = output / ".state.jsonl"
-
             with StateWriter(checkpoint) as writer:
-                writer.append(
-                    source=source,
-                    input_root=root,
-                    image=image,
-                    video=video,
-                    status="success",
-                    signature=signature,
-                    asset_identifier="ASSET-1",
-                )
-
+                writer.append(source=source, input_root=root, image=image, video=video, status="success", signature=signature, asset_identifier="ASSET-1")
             records = [json.loads(line) for line in checkpoint.read_text(encoding="utf-8").splitlines()]
             self.assertEqual(records[0]["schema_version"], 1)
-            item = records[1]
-            self.assertEqual(item["input_path"], str(source.resolve()))
-            self.assertNotIn("inputPath", item)
-            self.assertNotIn("inputSHA256", item)
+            self.assertEqual(records[1]["input_path"], str(source.resolve()))
+            self.assertNotIn("inputPath", records[1])
+            self.assertNotIn("inputSHA256", records[1])
 
     def test_custom_checkpoint_path_stays_separate_from_legacy_batch_checkpoint(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/Tests/test_python_live_photo_batch_reliability.py
+++ b/Tests/test_python_live_photo_batch_reliability.py
@@ -18,7 +18,7 @@ from xdremux_py.live_photo_batch import (
 
 
 class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
-    def test_duplicate_basenames_have_stable_distinct_outputs_across_subset_rerun(self):
+    def test_duplicate_basenames_preserve_relative_directories_across_subset_rerun(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "input"
             output = Path(tmp) / "output"
@@ -33,52 +33,48 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
             b_output = planned_output_image(b, root, output)
             b_subset_output = planned_output_image(b, root, output)
 
-            self.assertNotEqual(a_output, b_output)
+            self.assertEqual(a_output, output / "A" / "IMG.heic")
+            self.assertEqual(b_output, output / "B" / "IMG.heic")
             self.assertEqual(b_output, b_subset_output)
-            self.assertTrue(a_output.name.startswith("IMG~"))
-            self.assertTrue(b_output.name.startswith("IMG~"))
 
-    def test_same_relative_path_in_different_input_roots_cannot_alias_shared_output(self):
+    def test_absolute_input_root_does_not_leak_into_output_name(self):
         with tempfile.TemporaryDirectory() as tmp:
             base = Path(tmp)
             first_root = base / "root-one"
             second_root = base / "root-two"
-            output = base / "shared-output"
+            output = base / "output"
             first = first_root / "A" / "IMG.jpg"
             second = second_root / "A" / "IMG.jpg"
             first.parent.mkdir(parents=True)
             second.parent.mkdir(parents=True)
             first.write_bytes(b"first")
             second.write_bytes(b"second")
-
-            self.assertNotEqual(
+            self.assertEqual(
                 planned_output_image(first, first_root, output),
                 planned_output_image(second, second_root, output),
             )
 
-    def test_heif_motion_photo_uses_live_namespace_and_stable_token(self):
+    def test_heif_motion_photo_uses_readable_live_filename(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "input"
-            root.mkdir()
-            source = root / "same.heic"
+            source = root / "Trips" / "same.heic"
+            source.parent.mkdir(parents=True)
             source.write_bytes(b"heif")
             output = planned_output_image(source, root, Path(tmp) / "output")
-            self.assertTrue(output.name.startswith("same.live~"))
-            self.assertTrue(output.name.endswith(".heic"))
+            self.assertEqual(output, Path(tmp) / "output" / "Trips" / "same.live.heic")
 
-    def test_content_hash_detects_change_even_when_size_and_mtime_are_preserved(self):
+    def test_source_signature_uses_size_and_mtime(self):
         with tempfile.TemporaryDirectory() as tmp:
             source = Path(tmp) / "source.jpg"
             source.write_bytes(b"AAAA")
             before = source_signature(source)
-            source.write_bytes(b"BBBB")
-            os.utime(source, ns=(before.mtime_ns, before.mtime_ns))
+            new_mtime = before.mtime_ns + 10_000_000_000
+            os.utime(source, ns=(new_mtime, new_mtime))
             after = source_signature(source)
             self.assertEqual(before.size, after.size)
-            self.assertEqual(before.mtime_ns, after.mtime_ns)
-            self.assertNotEqual(before.sha256, after.sha256)
+            self.assertNotEqual(before.mtime_ns, after.mtime_ns)
 
-    def test_state_requires_source_hash_outputs_asset_identifier_and_pair_match(self):
+    def test_state_reuse_requires_source_metadata_outputs_and_pair_match(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "input"
             output = Path(tmp) / "output"
@@ -121,19 +117,40 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
                     lambda i, v, identifier: False,
                 )
             )
-            source.write_bytes(b"SOURCE")
-            changed = source_signature(source)
-            self.assertFalse(
-                provenance_allows_reuse(
-                    prior,
-                    changed,
-                    image,
-                    video,
-                    lambda i, v, identifier: True,
-                )
-            )
 
-    def test_python_writer_uses_swift_checkpoint_wire_schema(self):
+    def test_pr18_camel_case_checkpoint_migrates_without_hash_dependency(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "input"
+            output = Path(tmp) / "output"
+            root.mkdir()
+            output.mkdir()
+            source = root / "IMG.jpg"
+            source.write_bytes(b"source")
+            signature = source_signature(source)
+            image = planned_output_image(source, root, output)
+            video = image.with_suffix(".mov")
+            checkpoint = output / ".state.jsonl"
+            checkpoint.write_text(
+                json.dumps({
+                    "kind": "item",
+                    "inputPath": str(source.resolve()),
+                    "sourceRelativePath": "IMG.jpg",
+                    "outputImagePath": str(image.resolve()),
+                    "outputVideoPath": str(video.resolve()),
+                    "status": "success",
+                    "inputSize": signature.size,
+                    "inputMtimeNs": signature.mtime_ns,
+                    "inputSHA256": "deadbeef",
+                    "assetIdentifier": "ASSET-OLD",
+                    "error": None,
+                }) + "\n",
+                encoding="utf-8",
+            )
+            prior = load_state(checkpoint)[str(source.resolve())]
+            self.assertTrue(prior.matches_source(signature))
+            self.assertEqual(prior.asset_identifier, "ASSET-OLD")
+
+    def test_new_python_checkpoint_is_runtime_local_not_swift_wire_schema(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "input"
             output = Path(tmp) / "output"
@@ -158,31 +175,25 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
                 )
 
             records = [json.loads(line) for line in checkpoint.read_text(encoding="utf-8").splitlines()]
-            self.assertEqual(records[0]["schemaVersion"], 2)
+            self.assertEqual(records[0]["schema_version"], 1)
             item = records[1]
-            self.assertEqual(item["inputPath"], str(source.resolve()))
-            self.assertEqual(item["sourceRelativePath"], "IMG.jpg")
-            self.assertEqual(item["inputSHA256"], signature.sha256)
-            self.assertEqual(item["assetIdentifier"], "ASSET-1")
-            self.assertNotIn("input_path", item)
-            self.assertNotIn("input_sha256", item)
+            self.assertEqual(item["input_path"], str(source.resolve()))
+            self.assertNotIn("inputPath", item)
+            self.assertNotIn("inputSHA256", item)
 
-    def test_custom_checkpoint_path_matches_swift_motion_photo_suffix_contract(self):
+    def test_custom_checkpoint_path_stays_separate_from_legacy_batch_checkpoint(self):
         with tempfile.TemporaryDirectory() as tmp:
             output = Path(tmp) / "output"
             requested = Path(tmp) / "state.jsonl"
-            self.assertEqual(
-                state_path(output, requested),
-                requested.parent / "state.jsonl.motion-photo",
-            )
+            self.assertEqual(state_path(output, requested), requested.parent / "state.jsonl.motion-photo")
 
-    def test_hidden_transaction_temp_is_never_discovered_as_user_input(self):
+    def test_hidden_publication_temp_is_never_discovered_as_user_input(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             visible = root / "IMG.heic"
             hidden_temp = root / ".IMG.abc123.tmp.heic"
             visible.write_bytes(b"visible")
-            hidden_temp.write_bytes(b"transaction-temp")
+            hidden_temp.write_bytes(b"publication-temp")
             self.assertEqual(_default_batch_candidates(root), [visible])
 
     def test_normal_output_collision_fails_before_any_write(self):
@@ -193,18 +204,6 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
             output = root / "output" / "IMG.heic"
             with self.assertRaisesRegex(ValueError, "planned ProXDR output collision"):
                 _validate_unique_normal_plan([(first, output), (second, output)])
-
-    def test_schema_one_style_entry_without_digest_is_not_trusted(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            checkpoint = Path(tmp) / "state.jsonl"
-            checkpoint.write_text(
-                '{"kind":"header","schema_version":1}\n'
-                '{"kind":"item","input_path":"/tmp/a.jpg","output_image_path":"/tmp/a.heic",'
-                '"output_video_path":"/tmp/a.mov","status":"success","input_size":1,'
-                '"input_mtime_ns":1,"error":null}\n',
-                encoding="utf-8",
-            )
-            self.assertEqual(load_state(checkpoint), {})
 
 
 if __name__ == "__main__":

--- a/Tests/test_python_live_photo_batch_reliability.py
+++ b/Tests/test_python_live_photo_batch_reliability.py
@@ -33,9 +33,21 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
             b_output = planned_output_image(b, root, output)
             b_subset_output = planned_output_image(b, root, output)
 
-            self.assertEqual(a_output, output / "A" / "IMG.heic")
-            self.assertEqual(b_output, output / "B" / "IMG.heic")
+            self.assertEqual(a_output, output / "A" / "IMG.live.heic")
+            self.assertEqual(b_output, output / "B" / "IMG.live.heic")
             self.assertEqual(b_output, b_subset_output)
+
+    def test_jpeg_batch_output_does_not_use_sibling_source_heic_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "input"
+            source = root / "A" / "IMG.jpg"
+            source.parent.mkdir(parents=True)
+            source.write_bytes(b"jpeg")
+            sibling_heic = root / "A" / "IMG.heic"
+            sibling_heic.write_bytes(b"heic")
+            planned = planned_output_image(source, root, root)
+            self.assertNotEqual(planned, sibling_heic)
+            self.assertEqual(planned, root / "A" / "IMG.live.heic")
 
     def test_absolute_input_root_does_not_leak_into_output_name(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/xdremux_py/live_photo_batch.py
+++ b/xdremux_py/live_photo_batch.py
@@ -110,8 +110,7 @@ def relative_source_path(source: Path, input_root: Path) -> Path:
 def planned_output_image(source: Path, input_root: Path, output_directory: Path) -> Path:
     source = Path(source)
     relative = relative_source_path(source, input_root)
-    stem = source.stem + (".live" if source.suffix.lower() in {".heic", ".heif"} else "")
-    return Path(output_directory) / relative.parent / f"{stem}.heic"
+    return Path(output_directory) / relative.parent / f"{source.stem}.live.heic"
 
 
 def validate_unique_plan(outputs: list[tuple[Path, Path]]) -> None:

--- a/xdremux_py/live_photo_batch.py
+++ b/xdremux_py/live_photo_batch.py
@@ -110,7 +110,8 @@ def relative_source_path(source: Path, input_root: Path) -> Path:
 def planned_output_image(source: Path, input_root: Path, output_directory: Path) -> Path:
     source = Path(source)
     relative = relative_source_path(source, input_root)
-    return Path(output_directory) / relative.parent / f"{source.stem}.live.heic"
+    kind_suffix = "live" if source.suffix.lower() in {".heic", ".heif"} else "motion"
+    return Path(output_directory) / relative.parent / f"{source.stem}.{kind_suffix}.heic"
 
 
 def validate_unique_plan(outputs: list[tuple[Path, Path]]) -> None:

--- a/xdremux_py/live_photo_batch.py
+++ b/xdremux_py/live_photo_batch.py
@@ -1,21 +1,14 @@
-"""Stable output planning and provenance for Python Motion Photo batch conversion.
-
-The JSONL wire schema intentionally matches the Swift CLI (camelCase field names). Both runtimes
-can therefore reuse the same durable provenance file without weakening skip/resume checks.
-"""
+"""Readable Motion Photo batch output planning and local resume state."""
 
 from __future__ import annotations
 
-import hashlib
 import json
-import os
-import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 1
 DEFAULT_STATE_NAME = ".xdremux-motion-photo-checkpoint.jsonl"
 
 
@@ -23,27 +16,22 @@ DEFAULT_STATE_NAME = ".xdremux-motion-photo-checkpoint.jsonl"
 class SourceSignature:
     size: int
     mtime_ns: int
-    sha256: str
 
 
 @dataclass(frozen=True)
 class BatchStateItem:
     kind: str
     input_path: str
-    relative_source_path: str | None
     output_image_path: str
     output_video_path: str
     status: str
     input_size: int | None
     input_mtime_ns: int | None
-    input_sha256: str | None
     asset_identifier: str | None
     error: str | None = None
 
     def matches_source(self, signature: SourceSignature) -> bool:
-        # Size is a cheap corruption guard; SHA-256 is the source identity. mtime is retained for
-        # diagnostics but touching/copying an unchanged source does not invalidate provenance.
-        return self.input_size == signature.size and self.input_sha256 == signature.sha256
+        return self.input_size == signature.size and self.input_mtime_ns == signature.mtime_ns
 
     def matches_outputs(self, image: Path, video: Path) -> bool:
         return (
@@ -60,111 +48,85 @@ class BatchStateItem:
         )
 
     def to_wire(self) -> dict[str, object]:
-        """Canonical schema shared with Swift MotionPhotoBatchCheckpoint.Item."""
         return {
             "kind": self.kind,
-            "inputPath": self.input_path,
-            "sourceRelativePath": self.relative_source_path,
-            "outputImagePath": self.output_image_path,
-            "outputVideoPath": self.output_video_path,
+            "input_path": self.input_path,
+            "output_image_path": self.output_image_path,
+            "output_video_path": self.output_video_path,
             "status": self.status,
-            "inputSize": self.input_size,
-            "inputMtimeNs": self.input_mtime_ns,
-            "inputSHA256": self.input_sha256,
-            "assetIdentifier": self.asset_identifier,
+            "input_size": self.input_size,
+            "input_mtime_ns": self.input_mtime_ns,
+            "asset_identifier": self.asset_identifier,
             "error": self.error,
         }
 
     @classmethod
     def from_wire(cls, raw: dict[str, object]) -> "BatchStateItem" | None:
-        """Read canonical camelCase and the short-lived Python snake_case schema fail-closed."""
-        def value(camel: str, snake: str):
-            return raw[camel] if camel in raw else raw.get(snake)
+        # Accept PR #18's camelCase records as a one-way migration path, but new state is intentionally
+        # runtime-local and uses ordinary Python field names.
+        def value(snake: str, camel: str):
+            return raw[snake] if snake in raw else raw.get(camel)
 
         try:
-            input_path = value("inputPath", "input_path")
-            image_path = value("outputImagePath", "output_image_path")
-            video_path = value("outputVideoPath", "output_video_path")
+            input_path = value("input_path", "inputPath")
+            image_path = value("output_image_path", "outputImagePath")
+            video_path = value("output_video_path", "outputVideoPath")
             status = raw.get("status")
             if not all(isinstance(item, str) and item for item in (input_path, image_path, video_path, status)):
                 return None
+            input_size = value("input_size", "inputSize")
+            input_mtime_ns = value("input_mtime_ns", "inputMtimeNs")
             return cls(
                 kind="item",
                 input_path=input_path,
-                relative_source_path=value("sourceRelativePath", "relative_source_path") if isinstance(value("sourceRelativePath", "relative_source_path"), str) else None,
                 output_image_path=image_path,
                 output_video_path=video_path,
                 status=status,
-                input_size=int(value("inputSize", "input_size")) if value("inputSize", "input_size") is not None else None,
-                input_mtime_ns=int(value("inputMtimeNs", "input_mtime_ns")) if value("inputMtimeNs", "input_mtime_ns") is not None else None,
-                input_sha256=value("inputSHA256", "input_sha256") if isinstance(value("inputSHA256", "input_sha256"), str) else None,
-                asset_identifier=value("assetIdentifier", "asset_identifier") if isinstance(value("assetIdentifier", "asset_identifier"), str) else None,
+                input_size=int(input_size) if input_size is not None else None,
+                input_mtime_ns=int(input_mtime_ns) if input_mtime_ns is not None else None,
+                asset_identifier=value("asset_identifier", "assetIdentifier") if isinstance(value("asset_identifier", "assetIdentifier"), str) else None,
                 error=value("error", "error") if isinstance(value("error", "error"), str) else None,
             )
         except (TypeError, ValueError):
             return None
 
 
-def source_signature(path: Path, chunk_size: int = 1024 * 1024) -> SourceSignature:
-    path = Path(path)
-    stat = path.stat()
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        while True:
-            chunk = handle.read(chunk_size)
-            if not chunk:
-                break
-            digest.update(chunk)
-    return SourceSignature(size=stat.st_size, mtime_ns=stat.st_mtime_ns, sha256=digest.hexdigest())
+def source_signature(path: Path) -> SourceSignature:
+    stat = Path(path).stat()
+    return SourceSignature(size=stat.st_size, mtime_ns=stat.st_mtime_ns)
 
 
-def relative_source_path(source: Path, input_root: Path) -> str:
+def relative_source_path(source: Path, input_root: Path) -> Path:
     source = Path(source).resolve()
     input_root = Path(input_root).resolve()
     try:
-        relative = source.relative_to(input_root).as_posix()
+        return source.relative_to(input_root)
     except ValueError:
-        # Explicit globs should normally stay below input_root. If a caller supplies an unusual
-        # path, hashing the absolute path is still deterministic and cannot alias another source.
-        relative = source.as_posix()
-    return unicodedata.normalize("NFC", relative)
-
-
-def stable_source_token(source: Path, input_root: Path, length: int = 32) -> str:
-    """Return a 128-bit token namespaced by canonical root plus normalized relative path."""
-    root = Path(input_root).resolve()
-    root_identity = unicodedata.normalize("NFC", root.as_posix())
-    relative = relative_source_path(source, root)
-    identity = root_identity + "\0" + relative
-    return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:length]
+        # Discovery normally keeps inputs below input_root. A readable basename fallback keeps this
+        # helper total; validate_unique_plan() still rejects collisions within one invocation.
+        return Path(source.name)
 
 
 def planned_output_image(source: Path, input_root: Path, output_directory: Path) -> Path:
-    """Return a stable Motion Photo output independent of the current batch membership/order."""
     source = Path(source)
-    output_directory = Path(output_directory)
-    token = stable_source_token(source, input_root)
+    relative = relative_source_path(source, input_root)
     stem = source.stem + (".live" if source.suffix.lower() in {".heic", ".heif"} else "")
-    return output_directory / f"{stem}~{token}.heic"
+    return Path(output_directory) / relative.parent / f"{stem}.heic"
 
 
 def validate_unique_plan(outputs: list[tuple[Path, Path]]) -> None:
-    """Fail closed on the practically-impossible deterministic-token/path collision."""
     seen: dict[str, Path] = {}
     for source, output in outputs:
         key = str(Path(output).resolve())
         prior = seen.get(key)
         if prior is not None and prior.resolve() != Path(source).resolve():
-            raise ValueError(f"stable Motion Photo output collision: {prior} and {source} -> {output}")
+            raise ValueError(f"Motion Photo output collision: {prior} and {source} -> {output}")
         seen[key] = Path(source)
 
 
 def state_path(output_dir: Path, requested: Path | None = None) -> Path:
     if requested is not None:
         requested = Path(requested)
-        # Swift keeps the Motion Photo state separate from the legacy ProXDR batch checkpoint by
-        # appending this suffix to a user-specified checkpoint path. Mirror that contract exactly so
-        # either runtime can resume the other's batch state.
         return requested.parent / f"{requested.name}.motion-photo"
     return Path(output_dir) / DEFAULT_STATE_NAME
 
@@ -182,19 +144,12 @@ def load_state(path: Path) -> dict[str, BatchStateItem]:
             try:
                 raw = json.loads(line)
             except json.JSONDecodeError:
-                # A power loss may leave a truncated final JSONL record. Ignoring an unreadable
-                # provenance record is safe because it can only force a rebuild, never a reuse.
                 continue
             if not isinstance(raw, dict) or raw.get("kind") != "item":
                 continue
             item = BatchStateItem.from_wire(raw)
-            if item is None:
-                continue
-            # Schema-1 entries did not contain a content digest/asset identifier and therefore are
-            # deliberately not trusted as provenance for --skip-existing.
-            if not item.input_sha256 or not item.asset_identifier:
-                continue
-            state[item.input_path] = item
+            if item is not None:
+                state[item.input_path] = item
     return state
 
 
@@ -205,12 +160,11 @@ class StateWriter:
         new_file = not self.path.exists() or self.path.stat().st_size == 0
         self._handle = self.path.open("a", encoding="utf-8", newline="\n")
         if new_file:
-            self._append({"kind": "header", "schemaVersion": SCHEMA_VERSION})
+            self._append({"kind": "header", "schema_version": SCHEMA_VERSION})
 
     def _append(self, value: dict[str, object]) -> None:
         self._handle.write(json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n")
         self._handle.flush()
-        os.fsync(self._handle.fileno())
 
     def append(
         self,
@@ -224,16 +178,15 @@ class StateWriter:
         asset_identifier: str | None,
         error: str | None = None,
     ) -> None:
+        del input_root  # Kept in the call signature to avoid coupling the CLI to checkpoint internals.
         item = BatchStateItem(
             kind="item",
             input_path=str(Path(source).resolve()),
-            relative_source_path=relative_source_path(source, input_root),
             output_image_path=str(Path(image).resolve()),
             output_video_path=str(Path(video).resolve()),
             status=status,
             input_size=signature.size,
             input_mtime_ns=signature.mtime_ns,
-            input_sha256=signature.sha256,
             asset_identifier=asset_identifier,
             error=error,
         )
@@ -242,7 +195,6 @@ class StateWriter:
     def close(self) -> None:
         if not self._handle.closed:
             self._handle.flush()
-            os.fsync(self._handle.fileno())
             self._handle.close()
 
     def __enter__(self) -> "StateWriter":
@@ -259,6 +211,9 @@ def provenance_allows_reuse(
     video: Path,
     pair_matches_identifier: Callable[[Path, Path, str], bool],
 ) -> bool:
+    # The function name stays for CLI source compatibility in this focused refactor. Reuse is now
+    # driven by cheap file metadata + the saved output paths; the asset identifier only confirms that
+    # the existing pair is the pair recorded by this local checkpoint.
     if prior is None or not prior.reusable(signature, image, video) or prior.asset_identifier is None:
         return False
     return pair_matches_identifier(image, video, prior.asset_identifier)


### PR DESCRIPTION
Remove the opaque content-hash namespace and cross-runtime checkpoint schema while preserving the batch safety intent.

- preserve each source path relative to `--input-dir` in the output tree, so duplicate basenames in different directories remain distinct without hashed filenames
- use readable source-kind suffixes: JPEG/JPG Motion Photo -> `<stem>.motion.heic`, HEIC/HEIF Motion Photo -> `<stem>.live.heic`; this also keeps same-stem JPEG and HEIF inputs distinct and avoids overwriting a normal sibling `<stem>.heic`
- reduce source signatures from full-file SHA-256 to size + mtime metadata
- keep output-path checks, pair validation, and the saved Apple asset identifier as a local resume guard
- stop requiring Swift and Python to emit the same checkpoint wire format; both can still read PR #18 records as a one-way migration path
- stop fsyncing every checkpoint record; an interrupted final record simply causes that source to be rebuilt
- keep collision checks within one batch and keep generated Live Photo stills out of legacy ProXDR discovery

Deliberately reduced guarantees: resume is no longer forensic provenance. A source whose bytes are changed while both file size and mtime are deliberately preserved can be considered unchanged. Independent input roots processed in separate runs no longer receive a hidden root hash namespace; the relative path and source-kind suffix are the user-visible identity instead.

This PR is stacked on #19 so it changes only batch naming/resume behavior, not the publication mechanism.