### PR TITLE
Deduplicate Motion Photo real-fixture CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,10 @@ jobs:
           echo "::endgroup::"
           echo "MACOS_APP_RESULT=Passed" >> "$GITHUB_ENV"
 
-      # This bundle is the pre-existing ProXDR / Apple feature regression fixture set. Keep it
-      # separate from XDREMUX_FIXTURE_ARCHIVE_URL, which is reserved for the dedicated real
-      # Samsung/Xiaomi/OPPO/vivo Motion Photo gate.
-      - name: Prepare private fixtures
+      # This bundle is the pre-existing ProXDR / Apple-feature regression fixture set. Motion Photo
+      # real-fixture acceptance is owned by the dedicated Motion Photo workflows, so ordinary CI
+      # does not run those expensive conversions a second time.
+      - name: Prepare private regression fixtures
         shell: bash
         env:
           FIXTURE_ARCHIVE_URL: ${{ secrets.XDREMUX_REGRESSION_FIXTURE_ARCHIVE_URL }}
@@ -89,29 +89,6 @@ jobs:
           curl --fail --location --silent --show-error "$FIXTURE_ARCHIVE_URL" --output "$RUNNER_TEMP/xdremux-fixtures.zip"
           ditto -x -k "$RUNNER_TEMP/xdremux-fixtures.zip" "$RUNNER_TEMP/xdremux-fixtures"
           echo "FIXTURE_ROOT=$RUNNER_TEMP/xdremux-fixtures" >> "$GITHUB_ENV"
-
-      - name: Run private Motion Photo fixtures
-        shell: bash
-        run: |
-          if [[ -z "${FIXTURE_ROOT:-}" ]]; then
-            echo "MOTION_PHOTO_REAL_RESULT=Not configured" >> "$GITHUB_ENV"
-            exit 0
-          fi
-          C15="$(find "$FIXTURE_ROOT" -type f -name 'IMG20250425184722.jpg' -print -quit)"
-          C16="$(find "$FIXTURE_ROOT" -type f -name 'IMG20250901181353.jpg' -print -quit)"
-          if [[ -z "$C15" && -z "$C16" ]]; then
-            echo "MOTION_PHOTO_REAL_RESULT=Fixtures not present" >> "$GITHUB_ENV"
-            exit 0
-          fi
-          echo "::group::Real OPPO Motion Photo characterization and conversion"
-          XDREMUX_MOTION_PHOTO_FIXTURE_ROOT="$FIXTURE_ROOT" \
-            swift test --filter RealMotionPhotoFixtureTests 2>&1 | tee artifacts/motion-photo-real-fixtures.log
-          echo "::endgroup::"
-          if [[ -n "$C15" && -n "$C16" ]]; then
-            echo "MOTION_PHOTO_REAL_RESULT=Passed (ColorOS 15 + 16)" >> "$GITHUB_ENV"
-          else
-            echo "MOTION_PHOTO_REAL_RESULT=Passed available fixture; one generation absent" >> "$GITHUB_ENV"
-          fi
 
       - name: "[4/5] Run fixture conversions"
         shell: bash
@@ -192,7 +169,6 @@ jobs:
             echo "| Swift package build | ${SWIFT_BUILD_RESULT:-Failed} |"
             echo "| Unit tests | ${UNIT_TEST_RESULT:-Not run} |"
             echo "| macOS App build | ${MACOS_APP_RESULT:-Not run} |"
-            echo "| Real OPPO Motion Photo fixtures | ${MOTION_PHOTO_REAL_RESULT:-Not run} |"
             echo "| Standard ISO fixture | ${STANDARD_FIXTURE_RESULT:-Not run} |"
             echo "| OPPO compatibility fixture | ${OPPO_FIXTURE_RESULT:-Not run} |"
             echo "| Apple styles fixture | ${APPLE_STYLES_RESULT:-Not run} |"

--- a/.github/workflows/python-motion-photo-real-fixtures.yml
+++ b/.github/workflows/python-motion-photo-real-fixtures.yml
@@ -42,8 +42,7 @@ jobs:
 
       - name: Run portable Python tests
         shell: bash
-        run: |
-          python -m unittest discover -s Tests -p 'test_*.py' -v
+        run: python -m unittest discover -s Tests -p 'test_*.py' -v
 
       - name: Resolve private fixture archive
         shell: bash
@@ -60,13 +59,23 @@ jobs:
             --output "$RUNNER_TEMP/xdremux-fixtures.zip"
           unzip -q "$RUNNER_TEMP/xdremux-fixtures.zip" -d "$RUNNER_TEMP/xdremux-fixtures"
 
-      - name: Convert all real fixtures on Linux with pure Python
+      - name: Convert all real fixtures once on Linux
         shell: bash
         run: |
+          OUTPUT_ROOT="$RUNNER_TEMP/xdremux-python-live-photo-output"
+          mkdir -p "$OUTPUT_ROOT"
           python Tests/validation/verify_python_motion_photo_fixtures.py \
             --fixture-root "$RUNNER_TEMP/xdremux-fixtures" \
-            --output-root "$RUNNER_TEMP/xdremux-python-live-photo-output" \
-            --manifest "$RUNNER_TEMP/xdremux-python-live-photo-manifest.json"
+            --output-root "$OUTPUT_ROOT" \
+            --manifest "$OUTPUT_ROOT/manifest.json" \
+            2>&1 | tee "$OUTPUT_ROOT/conversion.log"
+
+      - name: Upload generated Live Photo pairs
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-live-photo-generated-pairs
+          if-no-files-found: error
+          path: ${{ runner.temp }}/xdremux-python-live-photo-output/
 
   apple-compatibility-oracle:
     needs: portable-python
@@ -83,27 +92,17 @@ jobs:
             echo "runner_os=$(sw_vers -productVersion)"
             echo "runner_build=$(sw_vers -buildVersion)"
             echo "arch=$(uname -m)"
-            echo "conversion_runtime=pure Python; Apple frameworks are validation-only"
+            echo "conversion_runtime=Linux pure Python"
+            echo "Apple frameworks=validation-only"
           } | tee artifacts/python-live-photo-runner.txt
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install Python package
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .
-
-      - name: Resolve private fixture archive
+      - name: Resolve private fixture archive for source-side validation
         shell: bash
         env:
           FIXTURE_ARCHIVE_URL: ${{ secrets.XDREMUX_FIXTURE_ARCHIVE_URL }}
         run: |
           if [[ -z "$FIXTURE_ARCHIVE_URL" ]]; then
-            echo "::error::XDREMUX_FIXTURE_ARCHIVE_URL is required for the strict Python gate"
+            echo "::error::XDREMUX_FIXTURE_ARCHIVE_URL is required for the PhotoKit oracle"
             exit 1
           fi
           mkdir -p "$RUNNER_TEMP/xdremux-fixtures"
@@ -112,22 +111,48 @@ jobs:
             --output "$RUNNER_TEMP/xdremux-fixtures.zip"
           ditto -x -k "$RUNNER_TEMP/xdremux-fixtures.zip" "$RUNNER_TEMP/xdremux-fixtures"
           echo "FIXTURE_ROOT=$RUNNER_TEMP/xdremux-fixtures" >> "$GITHUB_ENV"
-          echo "PYTHON_OUTPUT_ROOT=$RUNNER_TEMP/xdremux-python-live-photo-output" >> "$GITHUB_ENV"
-          echo "PYTHON_MANIFEST=$RUNNER_TEMP/xdremux-python-live-photo-manifest.json" >> "$GITHUB_ENV"
 
-      - name: Convert all real fixtures with pure Python
+      - name: Download Linux-generated Live Photo pairs
+        uses: actions/download-artifact@v8
+        with:
+          name: python-live-photo-generated-pairs
+          path: ${{ runner.temp }}/xdremux-python-live-photo-output
+
+      - name: Rebase artifact manifest paths for this runner
         shell: bash
         run: |
-          echo "::group::Pure Python Samsung / Xiaomi / OPPO / vivo conversion"
-          python Tests/validation/verify_python_motion_photo_fixtures.py \
-            --fixture-root "$FIXTURE_ROOT" \
-            --output-root "$PYTHON_OUTPUT_ROOT" \
-            --manifest "$PYTHON_MANIFEST" \
-            2>&1 | tee artifacts/python-motion-photo-real-fixtures.log
-          echo "::endgroup::"
-          cp "$PYTHON_MANIFEST" artifacts/python-live-photo-manifest.json
+          OUTPUT_ROOT="$RUNNER_TEMP/xdremux-python-live-photo-output"
+          MANIFEST="$OUTPUT_ROOT/manifest.json"
+          python3 - "$MANIFEST" "$FIXTURE_ROOT" "$OUTPUT_ROOT" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
 
-      - name: Validate Python outputs with macOS PhotoKit
+          manifest_path = Path(sys.argv[1])
+          fixture_root = Path(sys.argv[2])
+          output_root = Path(sys.argv[3])
+          data = json.loads(manifest_path.read_text(encoding="utf-8"))
+          by_name = {}
+          wanted = {entry["sourceFilename"] for entry in data["fixtures"]}
+          for candidate in fixture_root.rglob("*"):
+              if candidate.is_file() and candidate.name in wanted:
+                  if candidate.name in by_name and by_name[candidate.name] != candidate:
+                      raise RuntimeError(f"duplicate fixture filename: {candidate.name}")
+                  by_name[candidate.name] = candidate
+          missing = wanted - by_name.keys()
+          if missing:
+              raise RuntimeError("missing source fixtures: " + ", ".join(sorted(missing)))
+          for entry in data["fixtures"]:
+              entry["sourcePath"] = str(by_name[entry["sourceFilename"]])
+              entry["outputImagePath"] = str(output_root / Path(entry["outputImagePath"]).name)
+              entry["outputVideoPath"] = str(output_root / Path(entry["outputVideoPath"]).name)
+          manifest_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+          PY
+          cp "$MANIFEST" artifacts/python-live-photo-manifest.json
+          cp "$OUTPUT_ROOT/conversion.log" artifacts/python-motion-photo-real-fixtures.log
+          echo "PYTHON_MANIFEST=$MANIFEST" >> "$GITHUB_ENV"
+
+      - name: Validate Linux outputs with macOS PhotoKit
         shell: bash
         env:
           XDREMUX_PYTHON_LIVE_PHOTO_MANIFEST: ${{ env.PYTHON_MANIFEST }}
@@ -144,11 +169,11 @@ jobs:
           {
             echo "## Python Motion Photo → Apple Live Photo Gate"
             echo
-            echo "- Linux real-fixture conversion: required before this job"
-            echo "- macOS conversion runtime: pure Python/container code"
-            echo "- Apple frameworks: final structural/PhotoKit acceptance oracle only"
+            echo "- Linux real-fixture conversion: one authoritative generation pass"
+            echo "- macOS conversion: none"
+            echo "- Apple frameworks: structural/PhotoKit acceptance oracle only"
             if [[ -f artifacts/python-live-photo-manifest.json ]]; then
-              echo "- Real fixture manifest: produced"
+              echo "- Linux-generated artifact manifest: validated"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
Make each expensive real-fixture conversion authoritative instead of repeating it across jobs.

- pure-Python real fixtures are converted once on Linux
- upload those generated HEIC+MOV pairs as a GitHub Actions artifact
- macOS downloads the exact Linux-generated bytes and runs the existing structural + PhotoKit oracle against them
- keep source fixtures on macOS only for source-side metadata/transform validation; no Python reconversion occurs there
- use `actions/download-artifact@v8` for the cross-job artifact handoff
- remove the historical Motion Photo conversion step from ordinary XDRemux CI; dedicated Motion Photo workflows remain the real-fixture acceptance gates
- keep the standard ProXDR, OPPO-compatible, Photographic Styles, Portrait, and container-validation fixture checks in ordinary CI

The workflow itself has now exercised the intended topology successfully: the Linux job completed the portable test suite and one real-fixture generation pass, uploaded the outputs, the macOS job downloaded that artifact and rebased only manifest paths, and PhotoKit accepted those Linux-generated outputs without regenerating them on macOS.

This PR is stacked on #20 and changes only CI execution topology, not runtime conversion code or acceptance criteria.