### PR TITLE
Feature/vendor live photo geometry

### DIFF
--- a/.github/workflows/motion-photo-real-fixtures.yml
+++ b/.github/workflows/motion-photo-real-fixtures.yml
@@ -10,6 +10,7 @@ on:
       - "Tests/**/*MotionPhoto*.swift"
       - "Tests/**/*LivePhoto*.swift"
       - "fixtures/**"
+      - "scripts/build_live_photo_device_validation.sh"
       - ".github/workflows/motion-photo-real-fixtures.yml"
 
 jobs:
@@ -74,6 +75,15 @@ jobs:
           echo "tests=passed" >> artifacts/motion-photo-real-fixture-status.txt
           echo "photoKit=passed" >> artifacts/motion-photo-real-fixture-status.txt
 
+      - name: Build importable ColorOS 16 and Samsung Live Photo pairs
+        shell: bash
+        run: |
+          swift build -c release --product xdremux
+          XDREMUX_BIN=".build/release/xdremux" \
+            bash scripts/build_live_photo_device_validation.sh \
+              "$FIXTURE_ROOT" \
+              artifacts/live-photo-device-validation
+
       - name: Run historical OPPO characterization when present
         shell: bash
         env:
@@ -100,3 +110,12 @@ jobs:
             artifacts/motion-photo-real-fixture-status.txt
             artifacts/motion-photo-real-fixtures.log
             artifacts/motion-photo-historical-oppo.log
+
+      - name: Upload device-validation Live Photo pairs
+        if: success()
+        uses: actions/upload-artifact@v7
+        with:
+          name: live-photo-device-validation-${{ github.sha }}
+          if-no-files-found: error
+          retention-days: 14
+          path: artifacts/live-photo-device-validation

--- a/.github/workflows/motion-photo-real-fixtures.yml
+++ b/.github/workflows/motion-photo-real-fixtures.yml
@@ -2,6 +2,18 @@ name: Motion Photo Real Fixture Gate
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - "feature/vendor-live-photo-geometry"
+    paths:
+      - "Sources/XDRemuxCore/MotionPhoto/**"
+      - "Sources/XDRemuxAppleFeatures/LivePhoto/**"
+      - "Sources/XDRemuxCLI/Commands/MotionPhoto*.swift"
+      - "Tests/**/*MotionPhoto*.swift"
+      - "Tests/**/*LivePhoto*.swift"
+      - "fixtures/**"
+      - "scripts/build_live_photo_device_validation.sh"
+      - ".github/workflows/motion-photo-real-fixtures.yml"
   pull_request:
     paths:
       - "Sources/XDRemuxCore/MotionPhoto/**"

--- a/.github/workflows/motion-photo-real-fixtures.yml
+++ b/.github/workflows/motion-photo-real-fixtures.yml
@@ -90,11 +90,9 @@ jobs:
       - name: Build importable ColorOS 16 and Samsung Live Photo pairs
         shell: bash
         run: |
-          swift build -c release --product xdremux
-          XDREMUX_BIN=".build/release/xdremux" \
-            bash scripts/build_live_photo_device_validation.sh \
-              "$FIXTURE_ROOT" \
-              artifacts/live-photo-device-validation
+          bash scripts/build_live_photo_device_validation.sh \
+            "$FIXTURE_ROOT" \
+            artifacts/live-photo-device-validation
 
       - name: Run historical OPPO characterization when present
         shell: bash

--- a/.github/workflows/vendor-live-photo-geometry-branch.yml
+++ b/.github/workflows/vendor-live-photo-geometry-branch.yml
@@ -1,0 +1,65 @@
+name: Vendor Live Photo Geometry Branch Verification
+
+on:
+  push:
+    branches:
+      - feature/vendor-live-photo-geometry
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: macos-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Run exact-HEAD agent completion gate
+        shell: bash
+        run: |
+          cat > "$RUNNER_TEMP/vendor-live-photo-geometry-verification.json" <<JSON
+          {
+            "schema_version": 1,
+            "scope": "Offline ColorOS 16 and Samsung Live Photo geometry contracts with compressed video passthrough",
+            "checks": [
+              {
+                "name": "swift-package-build",
+                "kind": "static",
+                "command": ["swift", "build"],
+                "timeout_seconds": 900
+              },
+              {
+                "name": "swift-package-regression-suite",
+                "kind": "regression",
+                "command": ["swift", "test"],
+                "timeout_seconds": 1800
+              },
+              {
+                "name": "real-motion-photo-fixture-gate",
+                "kind": "integration",
+                "command": ["swift", "test", "--filter", "UploadedMotionPhotoFixtureGateTests"],
+                "timeout_seconds": 2400,
+                "env": {
+                  "XDREMUX_MOTION_PHOTO_FIXTURE_ROOT": "${GITHUB_WORKSPACE}/fixtures"
+                }
+              }
+            ]
+          }
+          JSON
+
+          python3 scripts/agent_completion_gate.py run \
+            --base origin/main \
+            --plan "$RUNNER_TEMP/vendor-live-photo-geometry-verification.json"
+
+          python3 scripts/agent_completion_gate.py verify \
+            ".codex/verification-receipts/$(git rev-parse HEAD).json"
+
+      - name: Upload verification receipt
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: vendor-live-photo-geometry-verification-${{ github.sha }}
+          path: .codex/verification-receipts/*.json
+          if-no-files-found: ignore
+          retention-days: 14

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoConversionEngine.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoConversionEngine.swift
@@ -94,11 +94,16 @@ public enum AppleLivePhotoConversionEngine {
             from: inputURL,
             to: stillSourceURL
         )
-        let primaryVideoRange = try OppoMotionPhotoStreamResolver.primaryVideoRange(for: asset)
+
+        let streamLayout = try MotionPhotoVideoStreamLayoutResolver.resolve(for: asset)
         try MotionPhotoPayloadExtractor.copy(
-            range: primaryVideoRange,
+            range: streamLayout.primary.range,
             from: inputURL,
             to: videoSourceURL
+        )
+        let geometryPlan = try VendorLivePhotoGeometryPolicy.plan(
+            for: asset,
+            stillResourceURL: stillSourceURL
         )
 
         let timeline = try await AppleLivePhotoTimelineResolver.resolve(
@@ -131,7 +136,8 @@ public enum AppleLivePhotoConversionEngine {
             outputURL: temporaryVideoURL,
             assetIdentifier: assetIdentifier,
             stillImageTime: timeline.stillImageTime,
-            oppoMetadata: asset.vendorMetadata
+            oppoMetadata: asset.vendorMetadata,
+            stillImageReferenceDimensions: geometryPlan?.stillReferenceDimensions
         )
 
         let expectedTransform = asset.vendorMetadata.flatMap(OppoLivePhotoAlignment.transformMatrix) != nil
@@ -163,8 +169,19 @@ public enum AppleLivePhotoConversionEngine {
                 "XMP still time \(formatMicroseconds(xmp)) s differs from OPPO coverFramePts \(formatMicroseconds(cover)) s; selected \(timeline.source.rawValue)."
             )
         }
-        if let metadata = asset.vendorMetadata, metadata.streamCount >= 2 {
-            diagnostics.append("OPPO dual-stream input detected; selected Stream 1 for Apple paired video.")
+        if let geometryPlan {
+            switch geometryPlan.kind {
+            case .colorOS16:
+                diagnostics.append(
+                    "ColorOS 16 geometry scope enabled: Stream 1 is the paired MOV and \(geometryPlan.streamLayout.auxiliaryGeometry.count) auxiliary stream(s) remain analysis-only."
+                )
+            case .samsung:
+                diagnostics.append(
+                    "Samsung geometry scope enabled: semantic Motion Photo video remains the only paired stream; vendor BMFF/SEFD regions are not treated as auxiliary video."
+                )
+            }
+        } else if let metadata = asset.vendorMetadata, metadata.streamCount >= 2 {
+            diagnostics.append("OPPO multi-stream input detected outside the ColorOS 16 geometry policy; selected the semantic primary stream only.")
         }
         if asset.sourceKind == .androidHeifMotionPhotoV1 {
             diagnostics.append("HEIF Motion Photo mpvd payload extracted without trailing vendor boxes.")

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoStillWriter.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoStillWriter.swift
@@ -64,6 +64,23 @@ public enum AppleLivePhotoStillWriter {
         }
     }
 
+    /// Returns the encoded still-image pixel dimensions used by Core Media's Live Photo transform
+    /// reference-dimensions metadata. Orientation remains a separate image property and is preserved
+    /// by the still writer, so this reports the underlying raster width and height without swapping.
+    public static func pixelDimensions(in imageURL: URL) -> [Float]? {
+        guard let source = CGImageSourceCreateWithURL(
+            imageURL as CFURL,
+            [kCGImageSourceShouldCache: false] as CFDictionary
+        ),
+        let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any],
+        let width = (properties[kCGImagePropertyPixelWidth as String] as? NSNumber)?.floatValue,
+        let height = (properties[kCGImagePropertyPixelHeight as String] as? NSNumber)?.floatValue,
+        width > 0, height > 0 else {
+            return nil
+        }
+        return [width, height]
+    }
+
     public static func assetIdentifier(in imageURL: URL) -> String? {
         let options = [kCGImageSourceShouldCache: false] as CFDictionary
         guard let source = CGImageSourceCreateWithURL(imageURL as CFURL, options),

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoVideoWriter.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoVideoWriter.swift
@@ -15,7 +15,8 @@ public enum AppleLivePhotoVideoWriter {
         outputURL: URL,
         assetIdentifier: String,
         stillImageTime: CMTime,
-        oppoMetadata: OppoMotionPhotoMetadata? = nil
+        oppoMetadata: OppoMotionPhotoMetadata? = nil,
+        stillImageReferenceDimensions: [Float]? = nil
     ) async throws {
         let asset = AVURLAsset(url: videoInputURL)
         guard let videoTrack = try await asset.loadTracks(withMediaType: .video).first else {
@@ -88,7 +89,11 @@ public enum AppleLivePhotoVideoWriter {
         writer.metadata = [contentIdentifierMetadata(assetIdentifier)]
 
         let transform = oppoMetadata.flatMap(OppoLivePhotoAlignment.transformMatrix)
-        let referenceDimensions = oppoMetadata.flatMap(OppoLivePhotoAlignment.referenceDimensions)
+        let referenceDimensions = transformReferenceDimensions(
+            transform: transform,
+            requestedStillImageDimensions: stillImageReferenceDimensions,
+            oppoMetadata: oppoMetadata
+        )
         let metadataSetup = try makeTimedMetadataSetup(
             includeTransform: transform != nil,
             includeReferenceDimensions: transform != nil && referenceDimensions != nil
@@ -171,6 +176,20 @@ public enum AppleLivePhotoVideoWriter {
             }
         }
         return nil
+    }
+
+    static func transformReferenceDimensions(
+        transform: [Double]?,
+        requestedStillImageDimensions: [Float]?,
+        oppoMetadata: OppoMotionPhotoMetadata?
+    ) -> [Float]? {
+        guard transform != nil else { return nil }
+        if let requestedStillImageDimensions,
+           requestedStillImageDimensions.count == 2,
+           requestedStillImageDimensions.allSatisfy({ $0.isFinite && $0 > 0 }) {
+            return requestedStillImageDimensions
+        }
+        return oppoMetadata.flatMap(OppoLivePhotoAlignment.referenceDimensions)
     }
 
     private static func contentIdentifierMetadata(_ assetIdentifier: String) -> AVMetadataItem {

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/Oppo/OppoLivePhotoAlignment.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/Oppo/OppoLivePhotoAlignment.swift
@@ -2,13 +2,14 @@ import Foundation
 import XDRemuxCore
 
 public enum OppoLivePhotoAlignment {
-    private static let colorOS16EISCompensationScale = 0.90
+    private static let legacyColorOS16EISCompensationScale = 0.90
 
     public static func transformMatrix(for metadata: OppoMotionPhotoMetadata) -> [Double]? {
         if metadata.version >= 1 {
+            let scale = colorOS16EISCompensationScale(for: metadata)
             var result: [Double] = [
-                colorOS16EISCompensationScale, 0, 0,
-                0, colorOS16EISCompensationScale, 0,
+                scale.x, 0, 0,
+                0, scale.y, 0,
                 0, 0, 1,
             ]
             if let crop = metadata.photoCropMatrix,
@@ -40,6 +41,25 @@ public enum OppoLivePhotoAlignment {
         return isIdentity(result) ? nil : result
     }
 
+    /// Normalizes the two OPPO crop-factor conventions seen in real data to an Apple-facing scale.
+    /// ColorOS 16 `photoEisCropFactor` commonly stores values greater than one (for example 1.11),
+    /// while older `eisCropFactor` samples can already store a direct scale below one. In either
+    /// representation the normalized result is constrained to `(0, 1]` and never enlarges the FOV.
+    static func colorOS16EISCompensationScale(
+        for metadata: OppoMotionPhotoMetadata
+    ) -> (x: Double, y: Double) {
+        if let scale = normalizedScale(metadata.photoEisCropFactor) {
+            return scale
+        }
+        if let scale = normalizedScale(metadata.eisCropFactor) {
+            return scale
+        }
+        return (
+            legacyColorOS16EISCompensationScale,
+            legacyColorOS16EISCompensationScale
+        )
+    }
+
     public static func encodeForApple(_ matrix: [Double]) -> Data {
         guard matrix.count == 9 else { return Data() }
         var output = Data(capacity: 72)
@@ -50,6 +70,9 @@ public enum OppoLivePhotoAlignment {
         return output
     }
 
+    /// Compatibility fallback for direct writer callers. Production conversion passes the actual
+    /// still-image pixel dimensions because Core Media defines the reference dimensions as the
+    /// dimensions of the Live Photo still, not the video raster.
     public static func referenceDimensions(for metadata: OppoMotionPhotoMetadata) -> [Float]? {
         guard let width = metadata.videoWidth, let height = metadata.videoHeight,
               width > 0, height > 0 else { return nil }
@@ -92,5 +115,23 @@ public enum OppoLivePhotoAlignment {
             (f*g-d*i)*inv, (a*i-c*g)*inv, (c*d-a*f)*inv,
             (d*h-e*g)*inv, (b*g-a*h)*inv, (a*e-b*d)*inv,
         ]
+    }
+
+    private static func normalizedScale(_ factors: [Double]?) -> (x: Double, y: Double)? {
+        guard let factors, !factors.isEmpty else { return nil }
+        let rawX = factors[0]
+        let rawY = factors.count >= 2 ? factors[1] : rawX
+        guard let x = normalizedAxisScale(rawX),
+              let y = normalizedAxisScale(rawY) else {
+            return nil
+        }
+        return (x, y)
+    }
+
+    private static func normalizedAxisScale(_ value: Double) -> Double? {
+        guard value.isFinite, value > 0 else { return nil }
+        let scale = value > 1 ? 1.0 / value : value
+        guard scale.isFinite, scale > 0, scale <= 1 else { return nil }
+        return scale
     }
 }

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/VendorLivePhotoGeometryPolicy.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/VendorLivePhotoGeometryPolicy.swift
@@ -1,0 +1,77 @@
+import Foundation
+import ImageIO
+import XDRemuxCore
+
+/// Vendor families for which XDRemux has explicit Live Photo geometry evidence.
+///
+/// Keep this list intentionally narrow. A generic Android Motion Photo is not opted into geometry
+/// metadata just because its container happens to have multiple BMFF-looking regions.
+enum VendorLivePhotoGeometryKind: String, Sendable, Equatable {
+    case colorOS16
+    case samsung
+}
+
+struct VendorLivePhotoGeometryPlan: Sendable, Equatable {
+    let kind: VendorLivePhotoGeometryKind
+    let streamLayout: MotionPhotoVideoStreamLayout
+    let stillReferenceDimensions: [Float]?
+}
+
+enum VendorLivePhotoGeometryPolicy {
+    static func plan(
+        for asset: MotionPhotoAsset,
+        stillResourceURL: URL
+    ) throws -> VendorLivePhotoGeometryPlan? {
+        let layout = try MotionPhotoVideoStreamLayoutResolver.resolve(for: asset)
+
+        if asset.sourceKind == .oppoLivePhoto,
+           let metadata = asset.vendorMetadata,
+           metadata.version >= 1,
+           metadata.streamCount >= 2,
+           !layout.auxiliaryGeometry.isEmpty {
+            return VendorLivePhotoGeometryPlan(
+                kind: .colorOS16,
+                streamLayout: layout,
+                stillReferenceDimensions: AppleLivePhotoStillWriter.pixelDimensions(in: stillResourceURL)
+            )
+        }
+
+        if isSamsungMotionPhoto(asset: asset, stillResourceURL: stillResourceURL) {
+            return VendorLivePhotoGeometryPlan(
+                kind: .samsung,
+                streamLayout: layout,
+                stillReferenceDimensions: AppleLivePhotoStillWriter.pixelDimensions(in: stillResourceURL)
+            )
+        }
+
+        return nil
+    }
+
+    static func isSamsungMotionPhoto(
+        asset: MotionPhotoAsset,
+        stillResourceURL: URL
+    ) -> Bool {
+        guard asset.sourceKind == .androidMotionPhotoV1
+                || asset.sourceKind == .androidHeifMotionPhotoV1 else {
+            return false
+        }
+        guard let source = CGImageSourceCreateWithURL(
+            stillResourceURL as CFURL,
+            [kCGImageSourceShouldCache: false] as CFDictionary
+        ),
+        let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any] else {
+            return false
+        }
+
+        if let make = properties[kCGImagePropertyTIFFMake as String] as? String,
+           make.localizedCaseInsensitiveContains("samsung") {
+            return true
+        }
+        if let tiff = properties[kCGImagePropertyTIFFDictionary as String] as? [String: Any],
+           let make = tiff[kCGImagePropertyTIFFMake as String] as? String,
+           make.localizedCaseInsensitiveContains("samsung") {
+            return true
+        }
+        return false
+    }
+}

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/VendorLivePhotoGeometryPolicy.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/VendorLivePhotoGeometryPolicy.swift
@@ -63,15 +63,18 @@ enum VendorLivePhotoGeometryPolicy {
             return false
         }
 
-        if let make = properties[kCGImagePropertyTIFFMake as String] as? String,
-           make.localizedCaseInsensitiveContains("samsung") {
+        if isSamsungMake(properties[kCGImagePropertyTIFFMake as String] as? String) {
             return true
         }
         if let tiff = properties[kCGImagePropertyTIFFDictionary as String] as? [String: Any],
-           let make = tiff[kCGImagePropertyTIFFMake as String] as? String,
-           make.localizedCaseInsensitiveContains("samsung") {
+           isSamsungMake(tiff[kCGImagePropertyTIFFMake as String] as? String) {
             return true
         }
         return false
+    }
+
+    static func isSamsungMake(_ make: String?) -> Bool {
+        guard let make else { return false }
+        return make.localizedCaseInsensitiveContains("samsung")
     }
 }

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/VendorLivePhotoVisionHomography.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/VendorLivePhotoVisionHomography.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import ImageIO
 import Vision
 
 /// Public Vision primitive used by vendor-specific Motion Photo geometry analyzers.

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/VendorLivePhotoVisionHomography.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/VendorLivePhotoVisionHomography.swift
@@ -1,0 +1,80 @@
+import CoreGraphics
+import Foundation
+import Vision
+
+/// Public Vision primitive used by vendor-specific Motion Photo geometry analyzers.
+///
+/// Vision defines the returned registration as the transform that morphs the floating/target image
+/// into the reference image. XDRemux deliberately keeps that convention explicit here rather than
+/// relabeling the matrix as an Apple Live Photo Track 4 or Track 5 transform. Those metadata formats
+/// have additional coordinate/reference conventions that must be validated independently.
+public struct VendorLivePhotoVisionHomography: Sendable, Equatable {
+    public let floatingToReference: [Double]
+
+    public init(floatingToReference: [Double]) {
+        self.floatingToReference = floatingToReference
+    }
+}
+
+public enum VendorLivePhotoVisionHomographyEstimator {
+    public enum Error: Swift.Error, LocalizedError {
+        case noAlignmentObservation
+        case invalidHomography
+
+        public var errorDescription: String? {
+            switch self {
+            case .noAlignmentObservation:
+                return "Vision did not produce a homographic alignment observation."
+            case .invalidHomography:
+                return "Vision produced a non-finite or degenerate homography."
+            }
+        }
+    }
+
+    /// Estimates a projective transform from `floatingImage` into `referenceImage`.
+    ///
+    /// The returned nine values are row-major. No Apple metadata normalization, inversion, reference
+    /// dimension conversion, or orientation compensation is applied after Vision's registration.
+    public static func estimate(
+        referenceImage: CGImage,
+        floatingImage: CGImage,
+        referenceOrientation: CGImagePropertyOrientation = .up,
+        floatingOrientation: CGImagePropertyOrientation = .up
+    ) throws -> VendorLivePhotoVisionHomography {
+        let request = VNHomographicImageRegistrationRequest(
+            targetedCGImage: floatingImage,
+            orientation: floatingOrientation,
+            options: [:]
+        )
+        let handler = VNImageRequestHandler(
+            cgImage: referenceImage,
+            orientation: referenceOrientation,
+            options: [:]
+        )
+        try handler.perform([request])
+        guard let observation = request.results?.first as? VNImageHomographicAlignmentObservation else {
+            throw Error.noAlignmentObservation
+        }
+
+        let transform = observation.warpTransform
+        // simd_float3x3 is column-major. Reorder by rows so the serialized Swift array is unambiguous.
+        var matrix = [
+            Double(transform[0][0]), Double(transform[1][0]), Double(transform[2][0]),
+            Double(transform[0][1]), Double(transform[1][1]), Double(transform[2][1]),
+            Double(transform[0][2]), Double(transform[1][2]), Double(transform[2][2]),
+        ]
+        guard matrix.allSatisfy(\.isFinite),
+              abs(matrix[8]) > 1e-12 else {
+            throw Error.invalidHomography
+        }
+
+        // Homographies are scale invariant. Normalize the representation only; this does not alter
+        // the geometric mapping and makes diagnostics/comparisons deterministic.
+        let normalization = matrix[8]
+        matrix = matrix.map { $0 / normalization }
+        guard matrix.allSatisfy(\.isFinite) else {
+            throw Error.invalidHomography
+        }
+        return VendorLivePhotoVisionHomography(floatingToReference: matrix)
+    }
+}

--- a/Sources/XDRemuxCore/MotionPhoto/MotionPhotoModels.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/MotionPhotoModels.swift
@@ -59,6 +59,11 @@ public struct OppoMotionPhotoMetadata: Sendable, Equatable {
     public let videoHeight: Int?
     public let originPhotoWidth: Int?
     public let originPhotoHeight: Int?
+    /// ColorOS 16 field observed on current devices. Values are commonly crop factors greater than
+    /// one (for example 1.11), so Apple-facing compensation uses their reciprocal.
+    public let photoEisCropFactor: [Double]?
+    /// Older/alternate OPPO field. Existing samples can encode either a direct scale below one or
+    /// a crop factor above one, so consumers must normalize its convention rather than assume one.
     public let eisCropFactor: [Double]?
     public let photoCropFactor: Double?
     public let streamCount: Int
@@ -74,6 +79,7 @@ public struct OppoMotionPhotoMetadata: Sendable, Equatable {
         videoHeight: Int? = nil,
         originPhotoWidth: Int? = nil,
         originPhotoHeight: Int? = nil,
+        photoEisCropFactor: [Double]? = nil,
         eisCropFactor: [Double]? = nil,
         photoCropFactor: Double? = nil,
         streamCount: Int = 1
@@ -88,6 +94,7 @@ public struct OppoMotionPhotoMetadata: Sendable, Equatable {
         self.videoHeight = videoHeight
         self.originPhotoWidth = originPhotoWidth
         self.originPhotoHeight = originPhotoHeight
+        self.photoEisCropFactor = photoEisCropFactor
         self.eisCropFactor = eisCropFactor
         self.photoCropFactor = photoCropFactor
         self.streamCount = max(1, streamCount)

--- a/Sources/XDRemuxCore/MotionPhoto/MotionPhotoVideoStreamLayout.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/MotionPhotoVideoStreamLayout.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Semantic role of one ISO-BMFF stream embedded in a Motion Photo resource.
+///
+/// The Apple paired movie always uses ``primary``. An ``auxiliaryGeometry`` stream is analysis-only:
+/// it may provide a wider or differently stabilized view for geometry estimation, but its compressed
+/// samples are never copied into the paired Live Photo MOV.
+public enum MotionPhotoVideoStreamRole: String, Sendable, Equatable {
+    case primary
+    case auxiliaryGeometry
+}
+
+public struct MotionPhotoVideoStream: Sendable, Equatable {
+    public let index: Int
+    public let role: MotionPhotoVideoStreamRole
+    public let range: MotionPhotoByteRange
+
+    public init(index: Int, role: MotionPhotoVideoStreamRole, range: MotionPhotoByteRange) {
+        self.index = index
+        self.role = role
+        self.range = range
+    }
+}
+
+public struct MotionPhotoVideoStreamLayout: Sendable, Equatable {
+    public let primary: MotionPhotoVideoStream
+    public let auxiliaryGeometry: [MotionPhotoVideoStream]
+
+    public init(primary: MotionPhotoVideoStream, auxiliaryGeometry: [MotionPhotoVideoStream] = []) {
+        self.primary = primary
+        self.auxiliaryGeometry = auxiliaryGeometry
+    }
+
+    public var allStreams: [MotionPhotoVideoStream] {
+        [primary] + auxiliaryGeometry
+    }
+}
+
+/// Resolves the semantic video streams that XDRemux is allowed to consume.
+///
+/// Only layouts demonstrated by real fixtures belong here. The current dual-stream rule is the
+/// ColorOS 16 OPPO layout: the penultimate `ftyp` starts Stream 1 (the paired movie) and the final
+/// `ftyp` starts Stream 2 (an analysis-only auxiliary view). Generic Android/Samsung Motion Photo
+/// resources remain a single primary stream even if unrelated vendor bytes happen to resemble BMFF.
+/// Future vendors can add a new evidence-backed case without changing downstream geometry APIs.
+public enum MotionPhotoVideoStreamLayoutResolver {
+    public static func resolve(for asset: MotionPhotoAsset) throws -> MotionPhotoVideoStreamLayout {
+        guard asset.sourceKind == .oppoLivePhoto,
+              (asset.vendorMetadata?.streamCount ?? 1) >= 2 else {
+            return MotionPhotoVideoStreamLayout(
+                primary: MotionPhotoVideoStream(
+                    index: 0,
+                    role: .primary,
+                    range: asset.videoResourceRange
+                )
+            )
+        }
+
+        let offsets = try ISOBaseMediaStreamScanner.ftypBoxOffsets(
+            in: asset.sourceURL,
+            range: asset.videoResourceRange
+        )
+        guard offsets.count >= 2 else {
+            return MotionPhotoVideoStreamLayout(
+                primary: MotionPhotoVideoStream(
+                    index: 0,
+                    role: .primary,
+                    range: asset.videoResourceRange
+                )
+            )
+        }
+
+        let stream1Start = offsets[offsets.count - 2]
+        let stream2Start = offsets[offsets.count - 1]
+        guard stream1Start >= asset.videoResourceRange.lowerBound,
+              stream2Start > stream1Start,
+              stream2Start < asset.videoResourceRange.upperBound else {
+            throw MotionPhotoParsingError.invalidVideoPayload
+        }
+
+        let primaryRange = try MotionPhotoByteRange(
+            lowerBound: stream1Start,
+            upperBound: stream2Start
+        )
+        let auxiliaryRange = try MotionPhotoByteRange(
+            lowerBound: stream2Start,
+            upperBound: asset.videoResourceRange.upperBound
+        )
+        return MotionPhotoVideoStreamLayout(
+            primary: MotionPhotoVideoStream(index: 0, role: .primary, range: primaryRange),
+            auxiliaryGeometry: [
+                MotionPhotoVideoStream(index: 1, role: .auxiliaryGeometry, range: auxiliaryRange)
+            ]
+        )
+    }
+}

--- a/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoLpexParser.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoLpexParser.swift
@@ -118,6 +118,7 @@ public enum OppoLpexParser {
 
         let videoSize = size(dictionary["videoSize"])
         let originPhotoSize = size(dictionary["originPhotoSize"])
+        let photoEisCropFactor = numberArray(dictionary["photoEisCropFactor"], maxCount: 8)
         let eisCropFactor = numberArray(dictionary["eisCropFactor"], maxCount: 8)
         let photoCropFactor = double(dictionary["photoCropFactor"])
 
@@ -132,6 +133,7 @@ public enum OppoLpexParser {
             videoHeight: videoSize?.1,
             originPhotoWidth: originPhotoSize?.0,
             originPhotoHeight: originPhotoSize?.1,
+            photoEisCropFactor: photoEisCropFactor,
             eisCropFactor: eisCropFactor,
             photoCropFactor: photoCropFactor
         )

--- a/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoFallbackParser.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoFallbackParser.swift
@@ -47,6 +47,7 @@ public enum OppoMotionPhotoFallbackParser {
             videoHeight: rawMetadata.videoHeight,
             originPhotoWidth: rawMetadata.originPhotoWidth,
             originPhotoHeight: rawMetadata.originPhotoHeight,
+            photoEisCropFactor: rawMetadata.photoEisCropFactor,
             eisCropFactor: rawMetadata.eisCropFactor,
             photoCropFactor: rawMetadata.photoCropFactor,
             streamCount: streamCount

--- a/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoParser.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoParser.swift
@@ -63,6 +63,7 @@ public enum OppoMotionPhotoParser {
             videoHeight: metadata.videoHeight,
             originPhotoWidth: metadata.originPhotoWidth,
             originPhotoHeight: metadata.originPhotoHeight,
+            photoEisCropFactor: metadata.photoEisCropFactor,
             eisCropFactor: metadata.eisCropFactor,
             photoCropFactor: metadata.photoCropFactor,
             streamCount: streamCount

--- a/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoStreamResolver.swift
+++ b/Sources/XDRemuxCore/MotionPhoto/Oppo/OppoMotionPhotoStreamResolver.swift
@@ -2,26 +2,20 @@ import Foundation
 
 public enum OppoMotionPhotoStreamResolver {
     /// Returns the primary OPPO Live Photo video stream. ColorOS 16 commonly stores two
-    /// concatenated BMFF streams; the penultimate ftyp starts Stream 1 and the last starts Stream 2.
-    /// This preserves the behavior of LivePhotoToolbox without making generic Android parsing
-    /// depend on OPPO's dual-stream convention.
+    /// concatenated BMFF streams; Stream 1 is the Apple paired movie and Stream 2 is retained only
+    /// as an auxiliary geometry source. The shared layout resolver owns the topology so downstream
+    /// code does not need another OPPO-only interpretation of the same bytes.
     public static func primaryVideoRange(for asset: MotionPhotoAsset) throws -> MotionPhotoByteRange {
-        guard asset.sourceKind == .oppoLivePhoto,
-              (asset.vendorMetadata?.streamCount ?? 1) >= 2 else {
-            return asset.videoResourceRange
-        }
-        let offsets = try ISOBaseMediaStreamScanner.ftypBoxOffsets(
-            in: asset.sourceURL,
-            range: asset.videoResourceRange
-        )
-        guard offsets.count >= 2 else { return asset.videoResourceRange }
-        let stream1Start = offsets[offsets.count - 2]
-        let stream2Start = offsets[offsets.count - 1]
-        guard stream1Start >= asset.videoResourceRange.lowerBound,
-              stream2Start > stream1Start,
-              stream2Start <= asset.videoResourceRange.upperBound else {
-            throw MotionPhotoParsingError.invalidVideoPayload
-        }
-        return try MotionPhotoByteRange(lowerBound: stream1Start, upperBound: stream2Start)
+        try MotionPhotoVideoStreamLayoutResolver.resolve(for: asset).primary.range
+    }
+
+    /// Returns analysis-only auxiliary video resources when the vendor layout is proven.
+    /// Current real fixtures expose one such stream for ColorOS 16 and none for Samsung.
+    public static func auxiliaryGeometryVideoRanges(
+        for asset: MotionPhotoAsset
+    ) throws -> [MotionPhotoByteRange] {
+        try MotionPhotoVideoStreamLayoutResolver.resolve(for: asset)
+            .auxiliaryGeometry
+            .map(\.range)
     }
 }

--- a/Tests/XDRemuxAppleFeaturesTests/LivePhotoDeviceValidationBundleTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/LivePhotoDeviceValidationBundleTests.swift
@@ -30,6 +30,7 @@ final class LivePhotoDeviceValidationBundleTests: XCTestCase {
             requirePhotoKitValidation: false
         )
         let expectedVideoURL = AppleLivePhotoConversionEngine.companionVideoURL(for: outputImageURL)
+        let videoAssetIdentifier = await AppleLivePhotoVideoWriter.contentIdentifier(in: result.videoURL)
 
         XCTAssertEqual(result.imageURL.standardizedFileURL, outputImageURL)
         XCTAssertEqual(result.videoURL.standardizedFileURL, expectedVideoURL.standardizedFileURL)
@@ -48,7 +49,7 @@ final class LivePhotoDeviceValidationBundleTests: XCTestCase {
             "published still lost the conversion asset identifier"
         )
         XCTAssertEqual(
-            await AppleLivePhotoVideoWriter.contentIdentifier(in: result.videoURL),
+            videoAssetIdentifier,
             result.assetIdentifier,
             "published MOV lost the conversion asset identifier"
         )

--- a/Tests/XDRemuxAppleFeaturesTests/LivePhotoDeviceValidationBundleTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/LivePhotoDeviceValidationBundleTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import XCTest
+@testable import XDRemuxAppleFeatures
+
+/// Actions-only harness for producing a real-device validation pair without repeating the expensive
+/// PhotoKit lifecycle check for every artifact. The strict real-fixture gate runs immediately before
+/// this harness and validates the same production converter through PhotoKit. This test still calls
+/// the production conversion engine and therefore retains its structural, metadata, gain-map,
+/// compressed-video/audio passthrough, and transactional validation.
+final class LivePhotoDeviceValidationBundleTests: XCTestCase {
+    func testGeneratePairUsingProductionConverterWithoutRepeatedPhotoKitLoad() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let sourcePath = environment["XDREMUX_DEVICE_VALIDATION_SOURCE"],
+              !sourcePath.isEmpty,
+              let outputPath = environment["XDREMUX_DEVICE_VALIDATION_OUTPUT"],
+              !outputPath.isEmpty else {
+            throw XCTSkip("device-validation source/output environment is not configured")
+        }
+
+        let sourceURL = URL(fileURLWithPath: sourcePath).standardizedFileURL
+        let outputImageURL = URL(fileURLWithPath: outputPath).standardizedFileURL
+        guard FileManager.default.fileExists(atPath: sourceURL.path) else {
+            XCTFail("device-validation source does not exist: \(sourceURL.path)")
+            return
+        }
+
+        let result = try await AppleLivePhotoConversionEngine.convertAsync(
+            inputURL: sourceURL,
+            outputImageURL: outputImageURL,
+            requirePhotoKitValidation: false
+        )
+        let expectedVideoURL = AppleLivePhotoConversionEngine.companionVideoURL(for: outputImageURL)
+
+        XCTAssertEqual(result.imageURL.standardizedFileURL, outputImageURL)
+        XCTAssertEqual(result.videoURL.standardizedFileURL, expectedVideoURL.standardizedFileURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.imageURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.videoURL.path))
+        XCTAssertTrue(
+            AppleLivePhotoValidator.isValidPair(
+                imageURL: result.imageURL,
+                videoURL: result.videoURL
+            ),
+            "production converter did not publish a structurally valid Live Photo pair"
+        )
+        XCTAssertEqual(
+            AppleLivePhotoStillWriter.assetIdentifier(in: result.imageURL),
+            result.assetIdentifier,
+            "published still lost the conversion asset identifier"
+        )
+        XCTAssertEqual(
+            await AppleLivePhotoVideoWriter.contentIdentifier(in: result.videoURL),
+            result.assetIdentifier,
+            "published MOV lost the conversion asset identifier"
+        )
+    }
+}

--- a/Tests/XDRemuxAppleFeaturesTests/LivePhotoWriterIntegrationTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/LivePhotoWriterIntegrationTests.swift
@@ -37,7 +37,7 @@ final class LivePhotoWriterIntegrationTests: XCTestCase {
         let sourceMP4 = directory.appendingPathComponent("source.mp4")
         let outputHEIC = directory.appendingPathComponent("output.heic")
         let outputMOV = directory.appendingPathComponent("output.mov")
-        try createJPEG(at: sourceJPEG, width: 64, height: 48)
+        try createJPEG(at: sourceJPEG, width: 80, height: 60)
         try await createCompressedVideo(
             at: sourceMP4,
             codec: .hevc,
@@ -69,7 +69,8 @@ final class LivePhotoWriterIntegrationTests: XCTestCase {
             outputURL: outputMOV,
             assetIdentifier: identifier,
             stillImageTime: stillTime,
-            oppoMetadata: metadata
+            oppoMetadata: metadata,
+            stillImageReferenceDimensions: [80, 60]
         )
 
         let report = try await AppleLivePhotoValidator.validate(
@@ -86,6 +87,10 @@ final class LivePhotoWriterIntegrationTests: XCTestCase {
         )
         XCTAssertTrue(report.hasTransform)
         XCTAssertTrue(report.hasTransformReferenceDimensions)
+
+        let dimensions = try await readTransformReferenceDimensions(from: outputMOV)
+        XCTAssertEqual(dimensions?.width ?? -1, 80, accuracy: 1e-6)
+        XCTAssertEqual(dimensions?.height ?? -1, 60, accuracy: 1e-6)
     }
 
     private func assertSyntheticPair(
@@ -151,6 +156,39 @@ final class LivePhotoWriterIntegrationTests: XCTestCase {
             )
         }
         XCTAssertFalse(report.hasAudio)
+    }
+
+    private func readTransformReferenceDimensions(from videoURL: URL) async throws -> CGSize? {
+        let asset = AVURLAsset(url: videoURL)
+        let metadataTracks = try await asset.loadTracks(withMediaType: .metadata)
+        for track in metadataTracks {
+            let reader = try AVAssetReader(asset: asset)
+            let output = AVAssetReaderTrackOutput(track: track, outputSettings: nil)
+            guard reader.canAdd(output) else { continue }
+            reader.add(output)
+            let adaptor = AVAssetReaderOutputMetadataAdaptor(assetReaderTrackOutput: output)
+            guard reader.startReading() else { continue }
+
+            while let group = adaptor.nextTimedMetadataGroup() {
+                for item in group.items {
+                    let key: String?
+                    if let string = item.key as? String {
+                        key = string
+                    } else if let string = item.key as? NSString {
+                        key = string as String
+                    } else {
+                        key = item.identifier?.rawValue.split(separator: "/").last.map(String.init)
+                    }
+                    guard key == "com.apple.quicktime.live-photo-still-image-transform-reference-dimensions" else {
+                        continue
+                    }
+                    if let value = item.value as? NSValue {
+                        return value.sizeValue
+                    }
+                }
+            }
+        }
+        return nil
     }
 
     private func createJPEG(at url: URL, width: Int, height: Int) throws {

--- a/Tests/XDRemuxAppleFeaturesTests/OppoLivePhotoAlignmentTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/OppoLivePhotoAlignmentTests.swift
@@ -3,7 +3,7 @@ import XDRemuxCore
 @testable import XDRemuxAppleFeatures
 
 final class OppoLivePhotoAlignmentTests: XCTestCase {
-    func testColorOS16AppliesEISCompensationAfterIdentityVendorMatrices() throws {
+    func testColorOS16AppliesLegacyEISCompensationWhenNoFactorExists() throws {
         let identity: [Double] = [1, 0, 0, 0, 1, 0, 0, 0, 1]
         let metadata = OppoMotionPhotoMetadata(
             coverFramePtsUs: 1_000_000,
@@ -19,6 +19,70 @@ final class OppoLivePhotoAlignmentTests: XCTestCase {
         XCTAssertEqual(matrix[4], 0.90, accuracy: 1e-12)
         XCTAssertEqual(matrix[8], 1.0, accuracy: 1e-12)
         XCTAssertEqual(OppoLivePhotoAlignment.referenceDimensions(for: metadata), [1728, 1296])
+    }
+
+    func testColorOS16UsesReciprocalPhotoEisCropFactor() throws {
+        let metadata = OppoMotionPhotoMetadata(
+            version: 1,
+            photoEisCropFactor: [1.11, 1.12]
+        )
+        let matrix = try XCTUnwrap(OppoLivePhotoAlignment.transformMatrix(for: metadata))
+        XCTAssertEqual(matrix[0], 1.0 / 1.11, accuracy: 1e-12)
+        XCTAssertEqual(matrix[4], 1.0 / 1.12, accuracy: 1e-12)
+        XCTAssertEqual(matrix[8], 1.0, accuracy: 1e-12)
+    }
+
+    func testColorOS16AcceptsLegacyDirectScaleBelowOne() throws {
+        let metadata = OppoMotionPhotoMetadata(
+            version: 1,
+            eisCropFactor: [0.91, 0.92]
+        )
+        let matrix = try XCTUnwrap(OppoLivePhotoAlignment.transformMatrix(for: metadata))
+        XCTAssertEqual(matrix[0], 0.91, accuracy: 1e-12)
+        XCTAssertEqual(matrix[4], 0.92, accuracy: 1e-12)
+    }
+
+    func testPhotoEisCropFactorWinsOverLegacyEisFactor() throws {
+        let metadata = OppoMotionPhotoMetadata(
+            version: 1,
+            photoEisCropFactor: [1.11, 1.11],
+            eisCropFactor: [0.8, 0.8]
+        )
+        let scale = OppoLivePhotoAlignment.colorOS16EISCompensationScale(for: metadata)
+        XCTAssertEqual(scale.x, 1.0 / 1.11, accuracy: 1e-12)
+        XCTAssertEqual(scale.y, 1.0 / 1.11, accuracy: 1e-12)
+    }
+
+    func testWriterReferenceDimensionsPreferActualStillRaster() {
+        let metadata = OppoMotionPhotoMetadata(
+            version: 1,
+            videoWidth: 1728,
+            videoHeight: 1296
+        )
+        let transform: [Double] = [0.9, 0, 0, 0, 0.9, 0, 0, 0, 1]
+        XCTAssertEqual(
+            AppleLivePhotoVideoWriter.transformReferenceDimensions(
+                transform: transform,
+                requestedStillImageDimensions: [4096, 3072],
+                oppoMetadata: metadata
+            ),
+            [4096, 3072]
+        )
+        XCTAssertEqual(
+            AppleLivePhotoVideoWriter.transformReferenceDimensions(
+                transform: transform,
+                requestedStillImageDimensions: nil,
+                oppoMetadata: metadata
+            ),
+            [1728, 1296]
+        )
+        XCTAssertNil(
+            AppleLivePhotoVideoWriter.transformReferenceDimensions(
+                transform: nil,
+                requestedStillImageDimensions: [4096, 3072],
+                oppoMetadata: metadata
+            )
+        )
     }
 
     func testColorOS15UsesClosestCoverFrameAndInvertsMatrix() throws {

--- a/Tests/XDRemuxAppleFeaturesTests/UploadedMotionPhotoFixtureGateTests+VendorGeometry.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/UploadedMotionPhotoFixtureGateTests+VendorGeometry.swift
@@ -1,0 +1,72 @@
+import Foundation
+import XCTest
+import XDRemuxCore
+@testable import XDRemuxAppleFeatures
+
+/// Vendor-geometry assertions intentionally share the strict fixture-test name prefix so the
+/// existing `swift test --filter UploadedMotionPhotoFixtureGateTests` CI lane executes them.
+final class UploadedMotionPhotoFixtureGateTestsVendorGeometry: XCTestCase {
+    private struct ExpectedPlan {
+        let relativePath: String
+        let kind: VendorLivePhotoGeometryKind?
+        let auxiliaryCount: Int
+    }
+
+    func testStrictFixturesGateVendorGeometryScopeAndStreamRoles() throws {
+        guard let rootPath = ProcessInfo.processInfo.environment["XDREMUX_MOTION_PHOTO_FIXTURE_ROOT"],
+              !rootPath.isEmpty else {
+            throw XCTSkip("XDREMUX_MOTION_PHOTO_FIXTURE_ROOT is not configured")
+        }
+        let root = URL(fileURLWithPath: rootPath, isDirectory: true)
+        let expectations: [ExpectedPlan] = [
+            .init(relativePath: "IMG20260710191114_ColorOS_16.jpg", kind: .colorOS16, auxiliaryCount: 1),
+            .init(relativePath: "IMG20260801190843_ColorOS_16.jpg", kind: .colorOS16, auxiliaryCount: 1),
+            .init(relativePath: "20260312_135609..heic", kind: .samsung, auxiliaryCount: 0),
+            .init(relativePath: "20260312_135610..heic", kind: .samsung, auxiliaryCount: 0),
+            .init(relativePath: "20260312_135625..jpg", kind: .samsung, auxiliaryCount: 0),
+            .init(relativePath: "20260312_135627..jpg", kind: .samsung, auxiliaryCount: 0),
+            .init(relativePath: "IMG20250502131605.jpg", kind: nil, auxiliaryCount: 0),
+            .init(relativePath: "IMG20250502131608.jpg", kind: nil, auxiliaryCount: 0),
+            .init(relativePath: "IMG20250819170327.jpg", kind: nil, auxiliaryCount: 0),
+        ]
+
+        for expected in expectations {
+            let inputURL = root.appendingPathComponent(expected.relativePath)
+            XCTAssertTrue(FileManager.default.fileExists(atPath: inputURL.path), expected.relativePath)
+            let asset = try XCTUnwrap(
+                OppoMotionPhotoParser.parse(url: inputURL),
+                "fixture did not parse: \(expected.relativePath)"
+            )
+
+            let scratch = FileManager.default.temporaryDirectory
+                .appendingPathComponent("xdremux-vendor-geometry-fixture-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: scratch) }
+            let stillExtension = asset.sourceKind == .androidHeifMotionPhotoV1 ? "heic" : "jpg"
+            let stillURL = scratch.appendingPathComponent("still.\(stillExtension)")
+            try MotionPhotoPayloadExtractor.copy(
+                range: asset.stillResourceRange,
+                from: inputURL,
+                to: stillURL
+            )
+
+            let plan = try VendorLivePhotoGeometryPolicy.plan(for: asset, stillResourceURL: stillURL)
+            XCTAssertEqual(plan?.kind, expected.kind, expected.relativePath)
+            XCTAssertEqual(plan?.streamLayout.auxiliaryGeometry.count ?? 0, expected.auxiliaryCount, expected.relativePath)
+
+            if expected.kind != nil {
+                XCTAssertNotNil(plan?.stillReferenceDimensions, expected.relativePath)
+            }
+            if expected.kind == .samsung {
+                XCTAssertEqual(plan?.streamLayout.primary.range, asset.videoResourceRange, expected.relativePath)
+            }
+        }
+    }
+
+    func testSamsungMakeGateIsCaseInsensitiveButNarrow() {
+        XCTAssertTrue(VendorLivePhotoGeometryPolicy.isSamsungMake("SAMSUNG"))
+        XCTAssertTrue(VendorLivePhotoGeometryPolicy.isSamsungMake("Samsung Electronics"))
+        XCTAssertFalse(VendorLivePhotoGeometryPolicy.isSamsungMake("OPPO"))
+        XCTAssertFalse(VendorLivePhotoGeometryPolicy.isSamsungMake(nil))
+    }
+}

--- a/Tests/XDRemuxAppleFeaturesTests/VendorLivePhotoVisionHomographyTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/VendorLivePhotoVisionHomographyTests.swift
@@ -1,0 +1,79 @@
+import CoreGraphics
+import XCTest
+@testable import XDRemuxAppleFeatures
+
+final class VendorLivePhotoVisionHomographyTests: XCTestCase {
+    func testIdenticalTexturedImagesProduceNormalizedNearIdentityHomography() throws {
+        let image = try makeTexturedImage(width: 256, height: 192)
+        let result = try VendorLivePhotoVisionHomographyEstimator.estimate(
+            referenceImage: image,
+            floatingImage: image
+        )
+        let matrix = result.floatingToReference
+
+        XCTAssertEqual(matrix.count, 9)
+        XCTAssertTrue(matrix.allSatisfy(\.isFinite))
+        XCTAssertEqual(matrix[8], 1.0, accuracy: 1e-9)
+        XCTAssertEqual(matrix[0], 1.0, accuracy: 1e-3)
+        XCTAssertEqual(matrix[4], 1.0, accuracy: 1e-3)
+        XCTAssertEqual(matrix[1], 0.0, accuracy: 1e-3)
+        XCTAssertEqual(matrix[3], 0.0, accuracy: 1e-3)
+        XCTAssertEqual(matrix[2], 0.0, accuracy: 0.5)
+        XCTAssertEqual(matrix[5], 0.0, accuracy: 0.5)
+        XCTAssertEqual(matrix[6], 0.0, accuracy: 1e-5)
+        XCTAssertEqual(matrix[7], 0.0, accuracy: 1e-5)
+    }
+
+    private func makeTexturedImage(width: Int, height: Int) throws -> CGImage {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            throw TestError.cannotCreateImage
+        }
+
+        context.setFillColor(CGColor(gray: 0.12, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+        for row in 0..<12 {
+            for column in 0..<16 {
+                let seed = row * 17 + column * 31
+                let red = CGFloat((seed * 13) % 255) / 255.0
+                let green = CGFloat((seed * 29 + 41) % 255) / 255.0
+                let blue = CGFloat((seed * 47 + 83) % 255) / 255.0
+                context.setFillColor(CGColor(red: red, green: green, blue: blue, alpha: 1))
+                context.fill(
+                    CGRect(
+                        x: column * 16 + (row % 3),
+                        y: row * 16 + (column % 5),
+                        width: 10 + (seed % 6),
+                        height: 9 + ((seed / 3) % 7)
+                    )
+                )
+            }
+        }
+
+        context.setStrokeColor(CGColor(gray: 0.95, alpha: 1))
+        context.setLineWidth(3)
+        context.move(to: CGPoint(x: 11, y: 17))
+        context.addLine(to: CGPoint(x: width - 19, y: height - 23))
+        context.move(to: CGPoint(x: width - 31, y: 13))
+        context.addLine(to: CGPoint(x: 23, y: height - 29))
+        context.strokePath()
+
+        guard let image = context.makeImage() else {
+            throw TestError.cannotCreateImage
+        }
+        return image
+    }
+
+    private enum TestError: Error {
+        case cannotCreateImage
+    }
+}

--- a/Tests/XDRemuxCoreTests/OppoDualStreamMotionPhotoTests.swift
+++ b/Tests/XDRemuxCoreTests/OppoDualStreamMotionPhotoTests.swift
@@ -77,6 +77,28 @@ final class OppoDualStreamMotionPhotoTests: XCTestCase {
         )
     }
 
+    func testGenericAndroidLayoutNeverInventsAuxiliaryStream() throws {
+        let primaryRange = try MotionPhotoByteRange(lowerBound: 100, upperBound: 200)
+        let stillRange = try MotionPhotoByteRange(lowerBound: 0, upperBound: 100)
+        let asset = MotionPhotoAsset(
+            sourceURL: URL(fileURLWithPath: "/tmp/not-read-for-single-stream-layout.jpg"),
+            sourceKind: .androidMotionPhotoV1,
+            items: [
+                MotionPhotoItem(mime: "image/jpeg", semantic: "Primary", length: 0, padding: 0),
+                MotionPhotoItem(mime: "video/mp4", semantic: "MotionPhoto", length: 100, padding: 0),
+            ],
+            stillResourceRange: stillRange,
+            videoResourceRange: primaryRange,
+            presentationTimestampUs: nil,
+            presentationSource: nil
+        )
+
+        let layout = try MotionPhotoVideoStreamLayoutResolver.resolve(for: asset)
+        XCTAssertEqual(layout.primary.range, primaryRange)
+        XCTAssertEqual(layout.primary.role, .primary)
+        XCTAssertTrue(layout.auxiliaryGeometry.isEmpty)
+    }
+
     private func assertDualStreamAsset(
         url: URL,
         stream1Start: Int64,
@@ -99,6 +121,18 @@ final class OppoDualStreamMotionPhotoTests: XCTestCase {
         let primary = try OppoMotionPhotoStreamResolver.primaryVideoRange(for: asset)
         XCTAssertEqual(primary.lowerBound, stream1Start)
         XCTAssertEqual(primary.upperBound, stream2Start)
+
+        let layout = try MotionPhotoVideoStreamLayoutResolver.resolve(for: asset)
+        XCTAssertEqual(layout.primary.range, primary)
+        XCTAssertEqual(layout.primary.role, .primary)
+        XCTAssertEqual(layout.auxiliaryGeometry.count, 1)
+        XCTAssertEqual(layout.auxiliaryGeometry[0].role, .auxiliaryGeometry)
+        XCTAssertEqual(layout.auxiliaryGeometry[0].range.lowerBound, stream2Start)
+        XCTAssertEqual(layout.auxiliaryGeometry[0].range.upperBound, asset.videoResourceRange.upperBound)
+        XCTAssertEqual(
+            try OppoMotionPhotoStreamResolver.auxiliaryGeometryVideoRanges(for: asset),
+            layout.auxiliaryGeometry.map(\.range)
+        )
     }
 
     private func fakeMP4(brand: String, payloadByte: UInt8) -> Data {

--- a/Tests/XDRemuxCoreTests/OppoMotionPhotoMetadataTests.swift
+++ b/Tests/XDRemuxCoreTests/OppoMotionPhotoMetadataTests.swift
@@ -24,6 +24,19 @@ final class OppoMotionPhotoMetadataTests: XCTestCase {
         XCTAssertEqual(metadata.originPhotoWidth, 4096)
         XCTAssertEqual(metadata.originPhotoHeight, 3072)
         XCTAssertEqual(metadata.photoCropFactor, 0.9)
+        XCTAssertEqual(metadata.eisCropFactor ?? [], [0.9, 0.9])
+        XCTAssertNil(metadata.photoEisCropFactor)
+    }
+
+    func testParsesPhotoEisCropFactorWithoutConflatingLegacyField() throws {
+        let json = """
+        {"version":1,"coverFramePts":1634640,
+         "photoEisCropFactor":[1.11,1.12],"eisCropFactor":[0.90,0.91]}
+        """
+        let payload = Data("lpexLivePhotoExtension \(json)".utf8)
+        let metadata = try XCTUnwrap(OppoLpexParser.parseFirstObject(in: payload))
+        XCTAssertEqual(metadata.photoEisCropFactor ?? [], [1.11, 1.12])
+        XCTAssertEqual(metadata.eisCropFactor ?? [], [0.90, 0.91])
     }
 
     func testRejectsNonFiniteMatrix() throws {

--- a/docs/validation/vendor-live-photo-geometry.md
+++ b/docs/validation/vendor-live-photo-geometry.md
@@ -1,0 +1,109 @@
+# Vendor Live Photo Geometry: ColorOS 16 and Samsung
+
+This document records the evidence boundary for XDRemux's metadata-only Live Photo geometry work.
+The production goal is to preserve the source motion-video bitstream and improve Apple Live Photo
+geometry metadata without baking blur, scaling, or other raster changes into the video.
+
+## Scope
+
+The new geometry policy is intentionally limited to two fixture-backed vendor families:
+
+- **ColorOS 16 / OPPO dual-stream Motion Photo**: current strict fixtures contain two concatenated
+  ISO-BMFF streams. Stream 1 is the paired motion video. Stream 2 is exposed as an
+  `auxiliaryGeometry` resource for analysis only and is never copied into the Apple paired MOV.
+- **Samsung Motion Photo**: current JPEG and HEIF strict fixtures contain one semantic motion-video
+  resource. BMFF-looking bytes in Samsung JPEG static resources and trailing `sefd` data in Samsung
+  HEIF resources are vendor data, not an inferred second video stream. They must not be promoted to
+  `auxiliaryGeometry` without new fixture evidence.
+
+Other Android Motion Photo inputs remain outside this geometry policy. The generic
+`MotionPhotoVideoStreamLayout` API allows another vendor to add an evidence-backed auxiliary stream
+later without changing downstream geometry consumers.
+
+## Implemented contracts
+
+### Compressed video stays passthrough
+
+`AppleLivePhotoVideoWriter` reads and writes compressed video/audio with nil output settings. The
+existing `AppleLivePhotoValidator` hashes exact compressed sample storage ranges before and after
+remuxing. A conversion that changes encoded video or audio payload bytes fails validation.
+
+No blur border, canvas expansion, EIS warp, or Vision transform is rendered into video pixels by
+this feature.
+
+### ColorOS 16 EIS FOV normalization
+
+The parser now preserves `photoEisCropFactor` separately from the older `eisCropFactor` field.
+This matters because the two observed conventions are not interchangeable:
+
+- a crop factor greater than one, such as `1.11`, normalizes to an Apple-facing FOV scale of
+  `1 / 1.11 = 0.9009009009...`;
+- a direct scale below or equal to one, such as `0.90`, remains `0.90`.
+
+`photoEisCropFactor` has priority when both fields are present. Invalid, non-finite, or non-positive
+values are rejected. The existing `0.90` ColorOS 16 compatibility fallback remains only for samples
+that have no usable factor.
+
+### Track 5 reference dimensions use the still raster
+
+Core Media defines the Live Photo still-image-transform reference dimensions as the dimensions of
+the Live Photo still image. Vendor-scoped conversion therefore passes the actual extracted still
+raster dimensions to `AppleLivePhotoVideoWriter` instead of treating the OPPO video raster as the
+production reference dimensions. The old OPPO video-size path remains only as a direct-call
+compatibility fallback when no still dimensions were supplied.
+
+The actual Track 5 transform source is otherwise unchanged by this branch: XDRemux only writes an
+OPPO transform that the existing alignment implementation can derive from vendor metadata.
+
+## Deliberately not written yet
+
+The following data is useful research evidence but is **not production-writable on this branch**:
+
+1. `mdta/com.apple.quicktime.live-photo-info` Track 4 generated from Vision. The recovered Apple v3
+   payload contains a per-frame stabilized trajectory homography, but the Vision-to-Apple coordinate
+   convention, mapping direction, reference dimensions, orientation handling, and normalization have
+   not been closed across native Apple samples.
+2. `AVAppleMakerNote_StillImageProcessingHomography`. Firmware analysis connects this class of still
+   processing metadata to Photos vitality transforms, but its third-party writable MakerNote layout
+   and coordinate contract are private and not yet proven.
+3. Vision homographies as a replacement for Track 5. Existing Codex experiments successfully
+   estimate ColorOS Stream 1/Stream 2/still relationships, but those experiments explicitly treat the
+   matrices as diagnostics until the Apple metadata convention is independently validated.
+4. Synthetic motion-blur vectors or blur radii. Photos owns its horizontal-scroll/vitality blur
+   state; XDRemux does not inflate motion metadata to force a visual effect.
+
+This is intentional: writing a structurally plausible private payload is not evidence that Photos
+interprets it correctly.
+
+## Fixture gates
+
+The strict real-fixture lane now additionally asserts:
+
+- both ColorOS 16 fixtures resolve one primary stream plus one `auxiliaryGeometry` stream;
+- current Samsung JPEG/HEIF fixtures enter the Samsung geometry scope but expose zero auxiliary
+  video streams;
+- representative ColorOS 15 fixtures do not enter the new vendor geometry policy;
+- vendor-scoped plans can read the actual still raster dimensions.
+
+Synthetic tests additionally cover:
+
+- semantic primary/auxiliary byte ranges;
+- generic Android inputs never invent an auxiliary stream;
+- `1.11 -> 1/1.11` ColorOS normalization;
+- direct sub-unity legacy factors;
+- `photoEisCropFactor` precedence;
+- still-image dimensions taking priority over video dimensions for Track 5 metadata.
+
+## Device validation still required
+
+The intended Photos.app experiment remains an A/B matrix rather than an offline acceptance claim:
+
+- baseline current conversion;
+- corrected public Track 5 geometry;
+- future Track 4 candidate only after its coordinate mapping is closed;
+- future still-processing-homography candidate only after its writable MakerNote contract is closed;
+- combined candidate.
+
+Horizontal swipe/vitality blur, geometry movement, and cover settling are device-dependent Photos
+behavior. Offline parsing, PhotoKit construction, and compressed-payload equality cannot prove those
+visual effects. Device evidence must remain a separate acceptance gate.

--- a/docs/validation/vendor-live-photo-geometry.md
+++ b/docs/validation/vendor-live-photo-geometry.md
@@ -55,6 +55,18 @@ compatibility fallback when no still dimensions were supplied.
 The actual Track 5 transform source is otherwise unchanged by this branch: XDRemux only writes an
 OPPO transform that the existing alignment implementation can derive from vendor metadata.
 
+### Vision registration is available as an analysis primitive
+
+`VendorLivePhotoVisionHomographyEstimator` exposes the same public Vision homographic registration
+primitive needed by ColorOS Stream 1/Stream 2/still analysis and by future auxiliary-stream vendors.
+It returns a finite, normalized row-major `floatingToReference` matrix and deliberately retains
+Vision's mapping direction in the API name. A synthetic high-texture identity-registration test
+checks both the Vision call and the SIMD-to-row-major conversion.
+
+This estimator is not connected to Apple metadata writing. A caller may use it for diagnostics or
+for offline trajectory research without silently crossing the still-unverified Apple coordinate
+boundary.
+
 ## Deliberately not written yet
 
 The following data is useful research evidence but is **not production-writable on this branch**:
@@ -92,7 +104,9 @@ Synthetic tests additionally cover:
 - `1.11 -> 1/1.11` ColorOS normalization;
 - direct sub-unity legacy factors;
 - `photoEisCropFactor` precedence;
-- still-image dimensions taking priority over video dimensions for Track 5 metadata.
+- still-image dimensions taking priority over video dimensions for Track 5 metadata;
+- Track 5 reference dimensions surviving an AVFoundation write/read round trip;
+- Vision identity registration producing a normalized near-identity homography.
 
 ## Device validation still required
 

--- a/scripts/build_live_photo_device_validation.sh
+++ b/scripts/build_live_photo_device_validation.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fixture_root="${1:-fixtures}"
+output_root="${2:-artifacts/live-photo-device-validation}"
+xdremux_bin="${XDREMUX_BIN:-.build/release/xdremux}"
+
+if [[ ! -x "$xdremux_bin" ]]; then
+  swift build -c release --product xdremux
+fi
+
+rm -rf "$output_root"
+mkdir -p "$output_root"
+
+# Keep this list deliberately narrow. The device-validation bundle is for the vendor paths whose
+# Live Photo geometry is under active validation, not a mirror of every generic Motion Photo
+# fixture. R002/R003 are byte-identical duplicates of the two Samsung HEIF inputs and therefore do
+# not add device-level coverage.
+cases=(
+  "ColorOS16|IMG20260710191114_ColorOS_16.jpg"
+  "ColorOS16|IMG20260801190843_ColorOS_16.jpg"
+  "Samsung-JPEG|20260312_135625..jpg"
+  "Samsung-JPEG|20260312_135627..jpg"
+  "Samsung-HEIF|20260312_135609..heic"
+  "Samsung-HEIF|20260312_135610..heic"
+)
+
+sources_tsv="$output_root/sources.tsv"
+printf 'vendor\tsource\toutput_stem\n' > "$sources_tsv"
+
+for entry in "${cases[@]}"; do
+  vendor="${entry%%|*}"
+  filename="${entry#*|}"
+  source="$fixture_root/$filename"
+  if [[ ! -f "$source" ]]; then
+    echo "missing required device-validation fixture: $source" >&2
+    exit 1
+  fi
+
+  stem="${filename%.*}"
+  # The supplied Samsung fixture names contain a deliberate extra dot before the extension. Keep
+  # the source filename untouched while using a filesystem-friendly output stem.
+  output_stem="${stem%.}"
+  case_dir="$output_root/$vendor/$output_stem"
+  mkdir -p "$case_dir"
+
+  output_heic="$case_dir/$output_stem.heic"
+  output_mov="$case_dir/$output_stem.mov"
+  "$xdremux_bin" convert \
+    --input "$source" \
+    --output "$output_heic" \
+    2>&1 | tee "$case_dir/conversion.log"
+
+  if [[ ! -s "$output_heic" || ! -s "$output_mov" ]]; then
+    echo "converter did not produce a complete Live Photo pair for $filename" >&2
+    exit 1
+  fi
+
+  printf '%s\t%s\t%s\n' "$vendor" "$filename" "$output_stem" >> "$sources_tsv"
+done
+
+python3 - "$fixture_root" "$output_root" <<'PY'
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+import sys
+
+fixture_root = pathlib.Path(sys.argv[1])
+output_root = pathlib.Path(sys.argv[2])
+
+
+def sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+rows = []
+with (output_root / "sources.tsv").open("r", encoding="utf-8") as stream:
+    next(stream)
+    for line in stream:
+        vendor, source_name, output_stem = line.rstrip("\n").split("\t")
+        case_dir = output_root / vendor / output_stem
+        heic = case_dir / f"{output_stem}.heic"
+        mov = case_dir / f"{output_stem}.mov"
+        source = fixture_root / source_name
+        rows.append(
+            {
+                "vendor": vendor,
+                "source": source_name,
+                "source_sha256": sha256(source),
+                "pair": {
+                    "still": str(heic.relative_to(output_root)),
+                    "still_size": heic.stat().st_size,
+                    "still_sha256": sha256(heic),
+                    "motion": str(mov.relative_to(output_root)),
+                    "motion_size": mov.stat().st_size,
+                    "motion_sha256": sha256(mov),
+                },
+            }
+        )
+
+manifest = {
+    "schema_version": 1,
+    "purpose": "Real-device Apple Photos validation for XDRemux Motion Photo conversion",
+    "pair_count": len(rows),
+    "pairs": rows,
+}
+(output_root / "manifest.json").write_text(
+    json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+
+readme = """# Live Photo device-validation bundle
+
+Each leaf directory contains one same-basename `.heic` + `.mov` pair produced by XDRemux from a
+real repository fixture. The converter writes the shared Live Photo asset identifier and
+still-image-time metadata; the MOV path uses compressed-sample passthrough rather than video
+re-encoding.
+
+This archive is intentionally limited to the active ColorOS 16 and Samsung validation corpus.
+`R002_...` and `R003_...` are omitted because they are byte-identical duplicates of the included
+Samsung HEIF fixtures.
+
+## Import for device testing
+
+A Live Photo is a paired resource, not a single standalone file format. Keep each `.heic` and
+`.mov` together and with the same basename. The most reliable manual route is to select both files
+for one pair together in macOS Photos, confirm that Photos recognizes one Live Photo asset, and
+then sync it to the iPhone through iCloud Photos or AirDrop from Photos. If a PhotoKit-based XDRemux
+importer is available, it can instead add the two paired resources directly on the device.
+
+`manifest.json` records the source identity and SHA-256 of every generated resource so a device
+observation can be tied back to the exact CI output.
+"""
+(output_root / "README.md").write_text(readme, encoding="utf-8")
+PY
+
+rm -f "$sources_tsv"

--- a/scripts/build_live_photo_device_validation.sh
+++ b/scripts/build_live_photo_device_validation.sh
@@ -3,11 +3,6 @@ set -euo pipefail
 
 fixture_root="${1:-fixtures}"
 output_root="${2:-artifacts/live-photo-device-validation}"
-xdremux_bin="${XDREMUX_BIN:-.build/release/xdremux}"
-
-if [[ ! -x "$xdremux_bin" ]]; then
-  swift build -c release --product xdremux
-fi
 
 rm -rf "$output_root"
 mkdir -p "$output_root"
@@ -46,10 +41,16 @@ for entry in "${cases[@]}"; do
 
   output_heic="$case_dir/$output_stem.heic"
   output_mov="$case_dir/$output_stem.mov"
-  "$xdremux_bin" convert \
-    --input "$source" \
-    --output "$output_heic" \
-    2>&1 | tee "$case_dir/conversion.log"
+
+  # The preceding real-fixture CI gate already exercises the same production converter through
+  # PhotoKit for all 14 repository fixtures. Repeating PHLivePhoto loading once per downloadable
+  # artifact is both redundant and susceptible to runner lifecycle timeouts. This dedicated test
+  # harness calls AppleLivePhotoConversionEngine with requirePhotoKitValidation=false while keeping
+  # every other production validation, including compressed sample byte equality.
+  XDREMUX_DEVICE_VALIDATION_SOURCE="$source" \
+  XDREMUX_DEVICE_VALIDATION_OUTPUT="$output_heic" \
+    swift test --filter LivePhotoDeviceValidationBundleTests \
+      2>&1 | tee "$case_dir/conversion.log"
 
   if [[ ! -s "$output_heic" || ! -s "$output_mov" ]]; then
     echo "converter did not produce a complete Live Photo pair for $filename" >&2
@@ -124,6 +125,11 @@ re-encoding.
 This archive is intentionally limited to the active ColorOS 16 and Samsung validation corpus.
 `R002_...` and `R003_...` are omitted because they are byte-identical duplicates of the included
 Samsung HEIF fixtures.
+
+The CI lane first validates all 14 real fixtures through PhotoKit. Pair generation then reuses the
+same production converter with only the repeated PhotoKit load disabled; structural metadata,
+gain-map preservation, source immutability, and exact compressed video/audio sample checks remain
+enforced by the production validator.
 
 ## Import for device testing
 


### PR DESCRIPTION
## Scope

Metadata-only Apple Live Photo geometry work for fixture-backed **ColorOS 16** and **Samsung** Motion Photos. The paired MOV keeps the source primary video/audio compressed samples in passthrough form; no blur, EIS warp, canvas expansion, or other raster modification is baked into the video.

## Implemented

- Generic `primary` + optional `auxiliaryGeometry` stream layout.
  - ColorOS 16 strict fixtures: Stream 1 = paired MOV, Stream 2 = analysis-only auxiliary geometry stream.
  - Current Samsung JPEG/HEIF fixtures remain single-video-stream; BMFF-looking static vendor data / trailing `sefd` are not promoted to a second video stream.
- Separate parsing for ColorOS `photoEisCropFactor` vs legacy `eisCropFactor`.
  - e.g. `1.11 -> 1 / 1.11` FOV scale.
- Live Photo Track 5 reference dimensions use the actual still raster dimensions for vendor-scoped production conversion.
- Public Vision homographic-registration primitive is available for offline Stream1/Stream2/still research, but is not written into private Apple metadata.
- Existing AVFoundation compressed video/audio passthrough remains enforced by `AppleLivePhotoValidator` sample-byte equality checks.
- Real-fixture vendor scoping/regression tests and an exact-HEAD agent completion workflow.

## Deliberately not synthesized

The branch does **not** generate `com.apple.quicktime.live-photo-info` Track 4 from Vision and does **not** write `AVAppleMakerNote_StillImageProcessingHomography`. The recovered field semantics are useful, but the Vision-to-Apple coordinate/normalization/orientation convention and the writable private MakerNote contract are not closed strongly enough to write production metadata without guessing.

## Verification

Exact branch HEAD: `48dd2a5d8921b5d87c04c14ae57dc5756261bd19`

Passed on GitHub Actions:

- `swift build`
- full `swift test`
- strict 14-file real Motion Photo fixture integration gate
- PhotoKit construction for the real fixture corpus
- ColorOS 16 / Samsung vendor-scope and stream-role gates
- compressed sample passthrough validation
- exact-HEAD completion receipt verification

## iPhone / Photos device-validation artifact

The real-fixture workflow also generates a downloadable artifact from the same production converter:

`live-photo-device-validation-a5fb0431a9e9c0d0ad470547e1f7b36e3b1deac8`

Artifact ID: `9134442923`

It contains 6 unique same-basename `.heic + .mov` pairs plus a SHA-256 manifest:

- 2 × ColorOS 16
- 2 × Samsung JPEG Motion Photo
- 2 × Samsung HEIF Motion Photo

`R002/R003` are omitted because they are byte-identical duplicates of the included Samsung HEIF samples.

The workflow first validates all real fixtures through PhotoKit. Artifact generation then calls the same production conversion engine with only the redundant second PhotoKit load disabled, avoiding hosted-runner PhotoKit lifecycle timeouts while keeping the converter's structural, gain-map, metadata, source-integrity, and compressed-sample checks.

The remaining acceptance item is intentionally device-only: import these pairs into Apple Photos and evaluate horizontal swipe/Vitality geometry, runtime blur behavior, and cover settling. Offline CI cannot prove that private Photos UI behavior.