### PR TITLE
Improve ColorOS Live Photo cover and vitality alignment metadata

### DIFF
--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoConversionEngine.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoConversionEngine.swift
@@ -105,6 +105,26 @@ public enum AppleLivePhotoConversionEngine {
             for: asset,
             stillResourceURL: stillSourceURL
         )
+        var geometryPreparationDiagnostics: [String] = []
+        let auxiliaryVideoURL: URL?
+        if let auxiliary = geometryPlan?.streamLayout.auxiliaryGeometry.first {
+            let extractedURL = scratch.appendingPathComponent("auxiliary-geometry.mp4")
+            do {
+                try MotionPhotoPayloadExtractor.copy(
+                    range: auxiliary.range,
+                    from: inputURL,
+                    to: extractedURL
+                )
+                auxiliaryVideoURL = extractedURL
+            } catch {
+                auxiliaryVideoURL = nil
+                geometryPreparationDiagnostics.append(
+                    "Auxiliary geometry extraction failed; retained the metadata-only fallback: \(error.localizedDescription)"
+                )
+            }
+        } else {
+            auxiliaryVideoURL = nil
+        }
 
         let timeline = try await AppleLivePhotoTimelineResolver.resolve(
             videoURL: videoSourceURL,
@@ -125,6 +145,14 @@ public enum AppleLivePhotoConversionEngine {
         let sourceHadGainMap = AppleLivePhotoStillWriter.hasGainMap(stillSourceURL)
         let sourceAsset = AVURLAsset(url: videoSourceURL)
         let sourceHadAudio = !(try await sourceAsset.loadTracks(withMediaType: .audio)).isEmpty
+        let transformResolution = await VendorLivePhotoStillTransformResolver.resolve(.init(
+            asset: asset,
+            geometryPlan: geometryPlan,
+            primaryVideoURL: videoSourceURL,
+            auxiliaryVideoURL: auxiliaryVideoURL,
+            stillImageURL: stillSourceURL,
+            stillImageTime: timeline.stillImageTime
+        ))
 
         try AppleLivePhotoStillWriter.write(
             stillInputURL: stillSourceURL,
@@ -137,10 +165,10 @@ public enum AppleLivePhotoConversionEngine {
             assetIdentifier: assetIdentifier,
             stillImageTime: timeline.stillImageTime,
             oppoMetadata: asset.vendorMetadata,
-            stillImageReferenceDimensions: geometryPlan?.stillReferenceDimensions
+            stillImageTransform: transformResolution.transform
         )
 
-        let expectedTransform = asset.vendorMetadata.flatMap(OppoLivePhotoAlignment.transformMatrix) != nil
+        let expectedTransform = transformResolution.transform != nil
         _ = try await AppleLivePhotoValidator.validate(
             imageURL: temporaryImageURL,
             videoURL: temporaryVideoURL,
@@ -151,6 +179,7 @@ public enum AppleLivePhotoConversionEngine {
             sourceHadAudio: sourceHadAudio,
             sourceHadGainMap: sourceHadGainMap,
             expectsOppoTransform: expectedTransform,
+            expectedStillImageTransform: transformResolution.transform,
             requirePhotoKitLoad: requirePhotoKitValidation
         )
 
@@ -162,6 +191,8 @@ public enum AppleLivePhotoConversionEngine {
         )
 
         var diagnostics: [String] = []
+        diagnostics.append(contentsOf: geometryPreparationDiagnostics)
+        diagnostics.append(contentsOf: transformResolution.diagnostics)
         if let xmp = asset.presentationTimestampUs,
            let cover = asset.vendorMetadata?.coverFramePtsUs,
            xmp != cover {

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoStillTransform.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoStillTransform.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public struct AppleLivePhotoStillTransform: Sendable, Equatable {
+    public enum Source: String, Sendable, Equatable {
+        case colorOS16VisionTrajectory
+        case oppoMetadata
+    }
+
+    public let matrix: [Double]
+    public let referenceDimensions: [Float]
+    public let source: Source
+
+    public init?(
+        matrix: [Double],
+        referenceDimensions: [Float],
+        source: Source
+    ) {
+        guard matrix.count == 9,
+              matrix.allSatisfy(\.isFinite),
+              abs(matrix[8]) > 1e-12,
+              referenceDimensions.count == 2,
+              referenceDimensions.allSatisfy({ $0.isFinite && $0 > 0 }) else {
+            return nil
+        }
+        self.matrix = matrix.map { $0 / matrix[8] }
+        self.referenceDimensions = referenceDimensions
+        self.source = source
+    }
+}

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoValidator.swift
@@ -14,6 +14,9 @@ public struct AppleLivePhotoValidationReport: Sendable {
     public let hasGainMap: Bool
     public let hasTransform: Bool
     public let hasTransformReferenceDimensions: Bool
+    public let stillImageTransform: [Double]?
+    public let stillImageTransformReferenceDimensions: [Float]?
+    public let vitalityTransformLimitingAllowed: Bool
 }
 
 public enum AppleLivePhotoValidator {
@@ -31,6 +34,7 @@ public enum AppleLivePhotoValidator {
         sourceHadAudio: Bool? = nil,
         sourceHadGainMap: Bool? = nil,
         expectsOppoTransform: Bool = false,
+        expectedStillImageTransform: AppleLivePhotoStillTransform? = nil,
         requirePhotoKitLoad: Bool = true
     ) async throws -> AppleLivePhotoValidationReport {
         guard FileManager.default.fileExists(atPath: imageURL.path) else {
@@ -121,6 +125,32 @@ public enum AppleLivePhotoValidator {
         if timed.hasTransform, !timed.hasTransformReferenceDimensions {
             throw AppleLivePhotoError.pairValidationFailed("Live Photo transform is missing reference dimensions")
         }
+        let vitalityTransformLimitingAllowed = await AppleLivePhotoVideoWriter
+            .vitalityTransformLimitingAllowed(in: videoURL)
+        if let expectedStillImageTransform {
+            guard let storedMatrix = timed.transform,
+                  approximatelyEqual(storedMatrix, expectedStillImageTransform.matrix, tolerance: 1e-9) else {
+                throw AppleLivePhotoError.pairValidationFailed(
+                    "stored Live Photo transform differs from the selected transform"
+                )
+            }
+            guard let storedDimensions = timed.transformReferenceDimensions,
+                  approximatelyEqual(
+                    storedDimensions.map(Double.init),
+                    expectedStillImageTransform.referenceDimensions.map(Double.init),
+                    tolerance: 1e-6
+                  ) else {
+                throw AppleLivePhotoError.pairValidationFailed(
+                    "stored Live Photo transform reference dimensions differ from the selected dimensions"
+                )
+            }
+            if expectedStillImageTransform.source == .colorOS16VisionTrajectory,
+               !vitalityTransformLimitingAllowed {
+                throw AppleLivePhotoError.pairValidationFailed(
+                    "Vision-selected Live Photo transform is missing the vitality limiting flag"
+                )
+            }
+        }
 
         if requirePhotoKitLoad {
             try validateWithPhotoKit(imageURL: imageURL, videoURL: videoURL)
@@ -132,7 +162,10 @@ public enum AppleLivePhotoValidator {
             hasAudio: hasAudio,
             hasGainMap: hasGainMap,
             hasTransform: timed.hasTransform,
-            hasTransformReferenceDimensions: timed.hasTransformReferenceDimensions
+            hasTransformReferenceDimensions: timed.hasTransformReferenceDimensions,
+            stillImageTransform: timed.transform,
+            stillImageTransformReferenceDimensions: timed.transformReferenceDimensions,
+            vitalityTransformLimitingAllowed: vitalityTransformLimitingAllowed
         )
     }
 
@@ -160,6 +193,8 @@ public enum AppleLivePhotoValidator {
         var stillImageTimes: [CMTime] = []
         var hasTransform = false
         var hasTransformReferenceDimensions = false
+        var transform: [Double]?
+        var transformReferenceDimensions: [Float]?
     }
 
     private struct StillGeometry: Equatable {
@@ -338,8 +373,17 @@ public enum AppleLivePhotoValidator {
                         summary.stillImageTimes.append(group.timeRange.start)
                     } else if key == transformKey {
                         summary.hasTransform = true
+                        if let values = try? await item.load(.value) as? [NSNumber] {
+                            summary.transform = values.map(\.doubleValue)
+                        } else if let values = try? await item.load(.value) as? NSArray {
+                            summary.transform = values.compactMap { ($0 as? NSNumber)?.doubleValue }
+                        }
                     } else if key == transformReferenceDimensionsKey {
                         summary.hasTransformReferenceDimensions = true
+                        if let value = try? await item.load(.value) as? NSValue {
+                            let size = value.sizeValue
+                            summary.transformReferenceDimensions = [Float(size.width), Float(size.height)]
+                        }
                     }
                 }
             }
@@ -350,6 +394,15 @@ public enum AppleLivePhotoValidator {
             }
         }
         return summary
+    }
+
+    private static func approximatelyEqual(
+        _ lhs: [Double],
+        _ rhs: [Double],
+        tolerance: Double
+    ) -> Bool {
+        lhs.count == rhs.count
+            && zip(lhs, rhs).allSatisfy { abs($0 - $1) <= tolerance }
     }
 
     private static func metadataKey(_ item: AVMetadataItem) -> String? {

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoVideoWriter.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/AppleLivePhotoVideoWriter.swift
@@ -6,6 +6,8 @@ import XDRemuxCore
 public enum AppleLivePhotoVideoWriter {
     private static let quickTimeKeySpace = "mdta"
     private static let contentIdentifierKey = "com.apple.quicktime.content.identifier"
+    private static let vitalityTransformLimitingKey =
+        "com.apple.quicktime.limit-still-image-transform"
     private static let stillImageTimeKey = "com.apple.quicktime.still-image-time"
     private static let transformKey = "com.apple.quicktime.live-photo-still-image-transform"
     private static let transformReferenceDimensionsKey = "com.apple.quicktime.live-photo-still-image-transform-reference-dimensions"
@@ -16,7 +18,8 @@ public enum AppleLivePhotoVideoWriter {
         assetIdentifier: String,
         stillImageTime: CMTime,
         oppoMetadata: OppoMotionPhotoMetadata? = nil,
-        stillImageReferenceDimensions: [Float]? = nil
+        stillImageReferenceDimensions: [Float]? = nil,
+        stillImageTransform: AppleLivePhotoStillTransform? = nil
     ) async throws {
         let asset = AVURLAsset(url: videoInputURL)
         guard let videoTrack = try await asset.loadTracks(withMediaType: .video).first else {
@@ -86,14 +89,20 @@ public enum AppleLivePhotoVideoWriter {
             audioInput = input
         }
 
-        writer.metadata = [contentIdentifierMetadata(assetIdentifier)]
-
-        let transform = oppoMetadata.flatMap(OppoLivePhotoAlignment.transformMatrix)
-        let referenceDimensions = transformReferenceDimensions(
-            transform: transform,
+        let fallbackTransform = oppoMetadata.flatMap(OppoLivePhotoAlignment.transformMatrix)
+        let fallbackReferenceDimensions = transformReferenceDimensions(
+            transform: fallbackTransform,
             requestedStillImageDimensions: stillImageReferenceDimensions,
             oppoMetadata: oppoMetadata
         )
+        let transform = stillImageTransform?.matrix ?? fallbackTransform
+        let referenceDimensions = stillImageTransform?.referenceDimensions
+            ?? fallbackReferenceDimensions
+        var movieMetadata = [contentIdentifierMetadata(assetIdentifier)]
+        if stillImageTransform?.source == .colorOS16VisionTrajectory {
+            movieMetadata.append(vitalityTransformLimitingMetadata())
+        }
+        writer.metadata = movieMetadata
         let metadataSetup = try makeTimedMetadataSetup(
             includeTransform: transform != nil,
             includeReferenceDimensions: transform != nil && referenceDimensions != nil
@@ -178,6 +187,17 @@ public enum AppleLivePhotoVideoWriter {
         return nil
     }
 
+    public static func vitalityTransformLimitingAllowed(in videoURL: URL) async -> Bool {
+        let asset = AVURLAsset(url: videoURL)
+        guard let metadata = try? await asset.load(.metadata) else { return false }
+        for item in metadata where metadataKey(item) == vitalityTransformLimitingKey {
+            if let number = try? await item.load(.value) as? NSNumber {
+                return number.boolValue
+            }
+        }
+        return false
+    }
+
     static func transformReferenceDimensions(
         transform: [Double]?,
         requestedStillImageDimensions: [Float]?,
@@ -199,6 +219,29 @@ public enum AppleLivePhotoVideoWriter {
         item.value = assetIdentifier as NSString
         item.dataType = kCMMetadataBaseDataType_UTF8 as String
         return item
+    }
+
+    /// iOS Photos reads this movie-level flag through
+    /// `PFMetadataMovie.livePhotoVitalityLimitingAllowed`. PhotosUI forwards it as
+    /// `limitingAllowed` to `PUBrowsingIrisPlayer`, which permits the larger inset budget used
+    /// when applying a non-trivial still-image transform during horizontal-scroll vitality.
+    /// Restrict it to the fixture-gated Stream 1/Stream 2 Vision result; metadata-only fallbacks do
+    /// not have enough evidence to opt into the larger transform.
+    private static func vitalityTransformLimitingMetadata() -> AVMetadataItem {
+        let item = AVMutableMetadataItem()
+        item.key = vitalityTransformLimitingKey as NSString
+        item.keySpace = AVMetadataKeySpace(rawValue: quickTimeKeySpace)
+        item.value = NSNumber(value: Int8(1))
+        item.dataType = kCMMetadataBaseDataType_SInt8 as String
+        return item
+    }
+
+    private static func metadataKey(_ item: AVMetadataItem) -> String? {
+        if let key = item.key as? String { return key }
+        if let key = item.key as? NSString { return key as String }
+        guard let raw = item.identifier?.rawValue else { return nil }
+        let prefix = "\(quickTimeKeySpace)/"
+        return raw.hasPrefix(prefix) ? String(raw.dropFirst(prefix.count)) : raw
     }
 
     /// AVFoundation owns these callback objects and serializes access through the queues passed to

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/ColorOS16VisionCoverAlignment+Evidence.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/ColorOS16VisionCoverAlignment+Evidence.swift
@@ -1,0 +1,126 @@
+import CoreGraphics
+import Foundation
+
+extension ColorOS16VisionCoverAlignmentAnalyzer {
+    static func makeEvidence(_ inputs: Inputs) -> Evidence {
+        let coverFrames = inputs.primary.frames.filter {
+            abs($0.ptsSeconds - inputs.coverSeconds) <= coverWindowSeconds
+        }
+        let offset = inputs.coverSeconds - inputs.auxiliary.durationSeconds
+        let pairs = pairedFrames(
+            primary: inputs.primary.frames,
+            auxiliary: inputs.auxiliary.frames,
+            offset: offset
+        )
+        let stillMatrices = coverFrames.compactMap {
+            mappedMatrix(
+                floating: $0.image,
+                reference: inputs.still,
+                referenceDimensions: inputs.referenceDimensions
+            )
+        }.filter(isUsable)
+        let trajectoryMatrices = pairs.compactMap {
+            mappedMatrix(
+                floating: $0.primary.image,
+                reference: $0.auxiliary.image,
+                referenceDimensions: inputs.referenceDimensions
+            )
+        }.filter(isUsable)
+        let coverTrajectoryMatrices = pairs.compactMap { pair -> [Double]? in
+            guard abs(pair.primary.ptsSeconds - inputs.coverSeconds) <= coverWindowSeconds else {
+                return nil
+            }
+            return mappedMatrix(
+                floating: pair.primary.image,
+                reference: pair.auxiliary.image,
+                referenceDimensions: inputs.referenceDimensions
+            )
+        }.filter(isUsable)
+        return Evidence(
+            pairedFrameCount: pairs.count,
+            coverFrameCount: coverFrames.count,
+            stillMatrices: stillMatrices,
+            trajectoryMatrices: trajectoryMatrices,
+            coverTrajectoryMatrices: coverTrajectoryMatrices
+        )
+    }
+
+    static func makeAlignment(
+        evidence: Evidence,
+        referenceDimensions: [Float]
+    ) throws -> ColorOS16VisionCoverAlignment {
+        guard evidence.coverFrameCount >= 3,
+              evidence.stillMatrices.count >= 3,
+              let stillMedian = medianMatrix(evidence.stillMatrices),
+              evidence.coverTrajectoryMatrices.count >= 2,
+              let stream2Median = medianMatrix(evidence.coverTrajectoryMatrices) else {
+            throw ColorOS16VisionCoverAlignmentError.insufficientCoverEvidence
+        }
+        let requiredTrajectoryCount = max(
+            3,
+            Int(ceil(Double(evidence.pairedFrameCount) * 0.60))
+        )
+        guard evidence.trajectoryMatrices.count >= requiredTrajectoryCount,
+              matricesAgree(
+                stillMedian,
+                stream2Median,
+                referenceDimensions: referenceDimensions
+              ),
+              let transform = AppleLivePhotoStillTransform(
+                matrix: stillMedian,
+                referenceDimensions: referenceDimensions,
+                source: .colorOS16VisionTrajectory
+              ) else {
+            throw ColorOS16VisionCoverAlignmentError.inconsistentTrajectory
+        }
+        return ColorOS16VisionCoverAlignment(
+            transform: transform,
+            pairedFrameCount: evidence.pairedFrameCount,
+            usableTrajectoryFrameCount: evidence.trajectoryMatrices.count,
+            coverFrameCount: evidence.coverFrameCount,
+            usableCoverFrameCount: evidence.stillMatrices.count,
+            coverStream1ToStream2: stream2Median
+        )
+    }
+
+    private static func pairedFrames(
+        primary: [Frame],
+        auxiliary: [Frame],
+        offset: Double
+    ) -> [(primary: Frame, auxiliary: Frame)] {
+        primary.compactMap { primaryFrame in
+            guard let nearest = auxiliary.min(by: {
+                abs(($0.ptsSeconds + offset) - primaryFrame.ptsSeconds)
+                    < abs(($1.ptsSeconds + offset) - primaryFrame.ptsSeconds)
+            }) else { return nil }
+            let delta = abs((nearest.ptsSeconds + offset) - primaryFrame.ptsSeconds)
+            guard delta <= maximumPairDeltaSeconds else { return nil }
+            return (primaryFrame, nearest)
+        }
+    }
+
+    private static func mappedMatrix(
+        floating: CGImage,
+        reference: CGImage,
+        referenceDimensions: [Float]
+    ) -> [Double]? {
+        guard let estimate = try? VendorLivePhotoVisionHomographyEstimator.estimate(
+            referenceImage: reference,
+            floatingImage: floating
+        ) else { return nil }
+        return mapToReferenceDimensions(
+            estimate.floatingToReference,
+            floatingSize: CGSize(width: floating.width, height: floating.height),
+            referenceSize: CGSize(width: reference.width, height: reference.height),
+            outputReferenceDimensions: referenceDimensions
+        )
+    }
+
+    private static func isUsable(_ matrix: [Double]) -> Bool {
+        guard let value = metrics(matrix) else { return false }
+        return (0.5...1.5).contains(value.scaleX)
+            && (0.5...1.5).contains(value.scaleY)
+            && abs(value.perspectiveX) < 0.005
+            && abs(value.perspectiveY) < 0.005
+    }
+}

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/ColorOS16VisionCoverAlignment+Frames.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/ColorOS16VisionCoverAlignment+Frames.swift
@@ -1,0 +1,105 @@
+import CoreImage
+import Foundation
+@preconcurrency import AVFoundation
+import ImageIO
+
+extension ColorOS16VisionCoverAlignmentAnalyzer {
+    static func loadInputs(
+        primaryVideoURL: URL,
+        auxiliaryVideoURL: URL,
+        stillImageURL: URL,
+        stillImageTime: CMTime,
+        referenceDimensions: [Float]
+    ) async throws -> Inputs {
+        guard referenceDimensions.count == 2,
+              referenceDimensions.allSatisfy({ $0.isFinite && $0 > 0 }) else {
+            throw ColorOS16VisionCoverAlignmentError.insufficientCoverEvidence
+        }
+        guard let still = loadStill(stillImageURL) else {
+            throw ColorOS16VisionCoverAlignmentError.missingImage
+        }
+        let coverSeconds = CMTimeGetSeconds(stillImageTime)
+        guard coverSeconds.isFinite else {
+            throw ColorOS16VisionCoverAlignmentError.insufficientCoverEvidence
+        }
+        return try await Inputs(
+            primary: readFrames(primaryVideoURL),
+            auxiliary: readFrames(auxiliaryVideoURL),
+            still: still,
+            coverSeconds: coverSeconds,
+            referenceDimensions: referenceDimensions
+        )
+    }
+
+    private static func loadStill(_ url: URL) -> CGImage? {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else { return nil }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: maximumAnalysisDimension,
+            kCGImageSourceCreateThumbnailWithTransform: true
+        ]
+        return CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
+    }
+
+    private static func readFrames(_ url: URL) async throws -> VideoFrames {
+        let asset = AVURLAsset(url: url)
+        guard let track = try await asset.loadTracks(withMediaType: .video).first else {
+            throw ColorOS16VisionCoverAlignmentError.missingVideo
+        }
+        let preferredTransform = try await track.load(.preferredTransform)
+        let reader = try AVAssetReader(asset: asset)
+        let output = AVAssetReaderTrackOutput(track: track, outputSettings: [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
+        ])
+        output.alwaysCopiesSampleData = false
+        guard reader.canAdd(output) else {
+            throw ColorOS16VisionCoverAlignmentError.missingVideo
+        }
+        reader.add(output)
+        guard reader.startReading() else {
+            throw ColorOS16VisionCoverAlignmentError.missingVideo
+        }
+
+        let context = CIContext(options: [.cacheIntermediates: false])
+        var frames: [Frame] = []
+        var index = 0
+        while let sample = output.copyNextSampleBuffer() {
+            defer { index += 1 }
+            guard let buffer = CMSampleBufferGetImageBuffer(sample),
+                  let image = displayImage(
+                    buffer,
+                    preferredTransform: preferredTransform,
+                    context: context
+                  ) else { continue }
+            let pts = CMTimeGetSeconds(CMSampleBufferGetPresentationTimeStamp(sample))
+            guard pts.isFinite else { continue }
+            frames.append(Frame(index: index, ptsSeconds: pts, image: image))
+        }
+        guard !frames.isEmpty, reader.status != .failed else {
+            throw ColorOS16VisionCoverAlignmentError.missingVideo
+        }
+        let loadedDuration = CMTimeGetSeconds(try await asset.load(.duration))
+        let duration = loadedDuration.isFinite ? loadedDuration : (frames.last?.ptsSeconds ?? 0)
+        return VideoFrames(frames: frames, durationSeconds: duration)
+    }
+
+    private static func displayImage(
+        _ buffer: CVPixelBuffer,
+        preferredTransform: CGAffineTransform,
+        context: CIContext
+    ) -> CGImage? {
+        var image = CIImage(cvPixelBuffer: buffer).transformed(by: preferredTransform)
+        let transformedExtent = image.extent
+        image = image.transformed(by: CGAffineTransform(
+            translationX: -transformedExtent.minX,
+            y: -transformedExtent.minY
+        ))
+        let largest = max(image.extent.width, image.extent.height)
+        guard largest > 0 else { return nil }
+        let scale = min(1, CGFloat(maximumAnalysisDimension) / largest)
+        if scale < 1 {
+            image = image.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+        }
+        return context.createCGImage(image, from: image.extent)
+    }
+}

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/ColorOS16VisionCoverAlignment+Math.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/ColorOS16VisionCoverAlignment+Math.swift
@@ -1,0 +1,133 @@
+import CoreGraphics
+import Foundation
+
+extension ColorOS16VisionCoverAlignmentAnalyzer {
+    struct MatrixMetrics {
+        let scaleX: Double
+        let scaleY: Double
+        let rotationDegrees: Double
+        let translateX: Double
+        let translateY: Double
+        let perspectiveX: Double
+        let perspectiveY: Double
+    }
+
+    static func mapToReferenceDimensions(
+        _ matrix: [Double],
+        floatingSize: CGSize,
+        referenceSize: CGSize,
+        outputReferenceDimensions: [Float]
+    ) -> [Double]? {
+        guard matrix.count == 9,
+              matrix.allSatisfy(\.isFinite),
+              floatingSize.width > 0, floatingSize.height > 0,
+              referenceSize.width > 0, referenceSize.height > 0,
+              outputReferenceDimensions.count == 2,
+              outputReferenceDimensions.allSatisfy({ $0.isFinite && $0 > 0 }) else {
+            return nil
+        }
+        let outputWidth = Double(outputReferenceDimensions[0])
+        let outputHeight = Double(outputReferenceDimensions[1])
+        let floatingScale = diagonal(
+            horizontal: Double(floatingSize.width) / outputWidth,
+            vertical: Double(floatingSize.height) / outputHeight
+        )
+        let referenceScale = diagonal(
+            horizontal: Double(referenceSize.width) / outputWidth,
+            vertical: Double(referenceSize.height) / outputHeight
+        )
+        guard let inverseReferenceScale = invert3x3(referenceScale) else { return nil }
+        return normalize(
+            multiply(multiply(inverseReferenceScale, matrix), floatingScale)
+        )
+    }
+
+    static func medianMatrix(_ matrices: [[Double]]) -> [Double]? {
+        guard !matrices.isEmpty, matrices.allSatisfy({ $0.count == 9 }) else { return nil }
+        return normalize((0..<9).map { index in
+            let values = matrices.map { $0[index] }.sorted()
+            let middle = values.count / 2
+            return values.count.isMultiple(of: 2)
+                ? (values[middle - 1] + values[middle]) / 2
+                : values[middle]
+        })
+    }
+
+    static func matricesAgree(
+        _ lhs: [Double],
+        _ rhs: [Double],
+        referenceDimensions: [Float]
+    ) -> Bool {
+        guard referenceDimensions.count == 2,
+              let left = metrics(lhs),
+              let right = metrics(rhs) else { return false }
+        return abs(left.scaleX - right.scaleX) <= 0.04
+            && abs(left.scaleY - right.scaleY) <= 0.04
+            && abs(left.rotationDegrees - right.rotationDegrees) <= 1.5
+            && abs(left.translateX - right.translateX) <= 0.04 * Double(referenceDimensions[0])
+            && abs(left.translateY - right.translateY) <= 0.04 * Double(referenceDimensions[1])
+    }
+
+    static func metrics(_ matrix: [Double]) -> MatrixMetrics? {
+        guard matrix.count == 9, matrix.allSatisfy(\.isFinite) else { return nil }
+        return MatrixMetrics(
+            scaleX: hypot(matrix[0], matrix[3]),
+            scaleY: hypot(matrix[1], matrix[4]),
+            rotationDegrees: atan2(matrix[3], matrix[0]) * 180 / .pi,
+            translateX: matrix[2],
+            translateY: matrix[5],
+            perspectiveX: matrix[6],
+            perspectiveY: matrix[7]
+        )
+    }
+
+    private static func diagonal(horizontal: Double, vertical: Double) -> [Double] {
+        [horizontal, 0, 0, 0, vertical, 0, 0, 0, 1]
+    }
+
+    private static func normalize(_ matrix: [Double]) -> [Double]? {
+        guard matrix.count == 9,
+              matrix.allSatisfy(\.isFinite),
+              abs(matrix[8]) > 1e-12 else { return nil }
+        let result = matrix.map { $0 / matrix[8] }
+        return result.allSatisfy(\.isFinite) ? result : nil
+    }
+
+    private static func multiply(_ lhs: [Double], _ rhs: [Double]) -> [Double] {
+        guard lhs.count == 9, rhs.count == 9 else { return lhs }
+        return [
+            lhs[0]*rhs[0]+lhs[1]*rhs[3]+lhs[2]*rhs[6],
+            lhs[0]*rhs[1]+lhs[1]*rhs[4]+lhs[2]*rhs[7],
+            lhs[0]*rhs[2]+lhs[1]*rhs[5]+lhs[2]*rhs[8],
+            lhs[3]*rhs[0]+lhs[4]*rhs[3]+lhs[5]*rhs[6],
+            lhs[3]*rhs[1]+lhs[4]*rhs[4]+lhs[5]*rhs[7],
+            lhs[3]*rhs[2]+lhs[4]*rhs[5]+lhs[5]*rhs[8],
+            lhs[6]*rhs[0]+lhs[7]*rhs[3]+lhs[8]*rhs[6],
+            lhs[6]*rhs[1]+lhs[7]*rhs[4]+lhs[8]*rhs[7],
+            lhs[6]*rhs[2]+lhs[7]*rhs[5]+lhs[8]*rhs[8]
+        ]
+    }
+
+    private static func invert3x3(_ matrix: [Double]) -> [Double]? {
+        guard matrix.count == 9 else { return nil }
+        let first = matrix[0], second = matrix[1], third = matrix[2]
+        let fourth = matrix[3], fifth = matrix[4], sixth = matrix[5]
+        let seventh = matrix[6], eighth = matrix[7], ninth = matrix[8]
+        let determinant = first * (fifth*ninth-sixth*eighth)
+            - second * (fourth*ninth-sixth*seventh)
+            + third * (fourth*eighth-fifth*seventh)
+        guard determinant.isFinite, abs(determinant) > 1e-12 else { return nil }
+        let scale = 1 / determinant
+        return [
+            (fifth*ninth-sixth*eighth)*scale,
+            (third*eighth-second*ninth)*scale,
+            (second*sixth-third*fifth)*scale,
+            (sixth*seventh-fourth*ninth)*scale,
+            (first*ninth-third*seventh)*scale,
+            (third*fourth-first*sixth)*scale,
+            (fourth*eighth-fifth*seventh)*scale,
+            (second*seventh-first*eighth)*scale,
+            (first*fifth-second*fourth)*scale
+        ]
+    }
+}

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/ColorOS16VisionCoverAlignment.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/ColorOS16VisionCoverAlignment.swift
@@ -1,0 +1,86 @@
+import Foundation
+import CoreMedia
+
+enum ColorOS16VisionCoverAlignmentError: Error {
+    case missingImage
+    case missingVideo
+    case insufficientCoverEvidence
+    case inconsistentTrajectory
+}
+
+struct ColorOS16VisionCoverAlignment: Sendable, Equatable {
+    let transform: AppleLivePhotoStillTransform
+    let pairedFrameCount: Int
+    let usableTrajectoryFrameCount: Int
+    let coverFrameCount: Int
+    let usableCoverFrameCount: Int
+    let coverStream1ToStream2: [Double]
+
+    var diagnostic: String {
+        let matrix = transform.matrix.map { String(format: "%.6f", $0) }
+            .joined(separator: ",")
+        let dimensions = transform.referenceDimensions.map { String(format: "%.0f", $0) }
+            .joined(separator: "x")
+        let coverCounts = "\(usableCoverFrameCount)/\(coverFrameCount) cover frames"
+        let trajectoryCounts = "\(usableTrajectoryFrameCount)/\(pairedFrameCount) trajectory frames"
+        return [
+            "Vision Track5 cover alignment accepted",
+            "\(coverCounts) and \(trajectoryCounts) passed geometry gates",
+            "matrix=[\(matrix)]",
+            "reference=\(dimensions)"
+        ].joined(separator: "; ") + "."
+    }
+}
+
+enum ColorOS16VisionCoverAlignmentAnalyzer {
+    static let maximumAnalysisDimension = 1_600
+    static let coverWindowSeconds = 0.12
+    static let maximumPairDeltaSeconds = 0.06
+
+    struct Frame {
+        let index: Int
+        let ptsSeconds: Double
+        let image: CGImage
+    }
+
+    struct VideoFrames {
+        let frames: [Frame]
+        let durationSeconds: Double
+    }
+
+    struct Inputs {
+        let primary: VideoFrames
+        let auxiliary: VideoFrames
+        let still: CGImage
+        let coverSeconds: Double
+        let referenceDimensions: [Float]
+    }
+
+    struct Evidence {
+        let pairedFrameCount: Int
+        let coverFrameCount: Int
+        let stillMatrices: [[Double]]
+        let trajectoryMatrices: [[Double]]
+        let coverTrajectoryMatrices: [[Double]]
+    }
+
+    static func analyze(
+        primaryVideoURL: URL,
+        auxiliaryVideoURL: URL,
+        stillImageURL: URL,
+        stillImageTime: CMTime,
+        referenceDimensions: [Float]
+    ) async throws -> ColorOS16VisionCoverAlignment {
+        let inputs = try await loadInputs(
+            primaryVideoURL: primaryVideoURL,
+            auxiliaryVideoURL: auxiliaryVideoURL,
+            stillImageURL: stillImageURL,
+            stillImageTime: stillImageTime,
+            referenceDimensions: referenceDimensions
+        )
+        return try makeAlignment(
+            evidence: makeEvidence(inputs),
+            referenceDimensions: referenceDimensions
+        )
+    }
+}

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/VendorLivePhotoGeometryPolicy.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/VendorLivePhotoGeometryPolicy.swift
@@ -14,7 +14,7 @@ enum VendorLivePhotoGeometryKind: String, Sendable, Equatable {
 struct VendorLivePhotoGeometryPlan: Sendable, Equatable {
     let kind: VendorLivePhotoGeometryKind
     let streamLayout: MotionPhotoVideoStreamLayout
-    let stillReferenceDimensions: [Float]?
+    let stillRasterDimensions: [Float]?
 }
 
 enum VendorLivePhotoGeometryPolicy {
@@ -32,7 +32,7 @@ enum VendorLivePhotoGeometryPolicy {
             return VendorLivePhotoGeometryPlan(
                 kind: .colorOS16,
                 streamLayout: layout,
-                stillReferenceDimensions: AppleLivePhotoStillWriter.pixelDimensions(in: stillResourceURL)
+                stillRasterDimensions: AppleLivePhotoStillWriter.pixelDimensions(in: stillResourceURL)
             )
         }
 
@@ -40,7 +40,7 @@ enum VendorLivePhotoGeometryPolicy {
             return VendorLivePhotoGeometryPlan(
                 kind: .samsung,
                 streamLayout: layout,
-                stillReferenceDimensions: AppleLivePhotoStillWriter.pixelDimensions(in: stillResourceURL)
+                stillRasterDimensions: AppleLivePhotoStillWriter.pixelDimensions(in: stillResourceURL)
             )
         }
 

--- a/Sources/XDRemuxAppleFeatures/LivePhoto/VendorLivePhotoStillTransformResolver.swift
+++ b/Sources/XDRemuxAppleFeatures/LivePhoto/VendorLivePhotoStillTransformResolver.swift
@@ -1,0 +1,74 @@
+import Foundation
+import CoreMedia
+import XDRemuxCore
+
+struct VendorLivePhotoStillTransformResolution: Sendable, Equatable {
+    let transform: AppleLivePhotoStillTransform?
+    let diagnostics: [String]
+}
+
+enum VendorLivePhotoStillTransformResolver {
+    struct Request {
+        let asset: MotionPhotoAsset
+        let geometryPlan: VendorLivePhotoGeometryPlan?
+        let primaryVideoURL: URL
+        let auxiliaryVideoURL: URL?
+        let stillImageURL: URL
+        let stillImageTime: CMTime
+    }
+
+    static func resolve(_ request: Request) async -> VendorLivePhotoStillTransformResolution {
+        if request.geometryPlan?.kind == .colorOS16,
+           let auxiliaryVideoURL = request.auxiliaryVideoURL,
+           let referenceDimensions = request.asset.vendorMetadata.flatMap(
+            OppoLivePhotoAlignment.referenceDimensions
+           ) {
+            do {
+                let alignment = try await ColorOS16VisionCoverAlignmentAnalyzer.analyze(
+                    primaryVideoURL: request.primaryVideoURL,
+                    auxiliaryVideoURL: auxiliaryVideoURL,
+                    stillImageURL: request.stillImageURL,
+                    stillImageTime: request.stillImageTime,
+                    referenceDimensions: referenceDimensions
+                )
+                return VendorLivePhotoStillTransformResolution(
+                    transform: alignment.transform,
+                    diagnostics: [alignment.diagnostic]
+                )
+            } catch {
+                let fallback = metadataTransform(request.asset.vendorMetadata)
+                let fallbackDescription = fallback == nil
+                    ? "no Track5 transform"
+                    : "the OPPO metadata fallback"
+                let reason = String(describing: error)
+                return VendorLivePhotoStillTransformResolution(
+                    transform: fallback,
+                    diagnostics: [
+                        "Vision Stream 1/Stream 2 cover alignment was rejected "
+                            + "(\(reason)); used \(fallbackDescription)."
+                    ]
+                )
+            }
+        }
+
+        return VendorLivePhotoStillTransformResolution(
+            transform: metadataTransform(request.asset.vendorMetadata),
+            diagnostics: []
+        )
+    }
+
+    private static func metadataTransform(
+        _ metadata: OppoMotionPhotoMetadata?
+    ) -> AppleLivePhotoStillTransform? {
+        guard let metadata,
+              let matrix = OppoLivePhotoAlignment.transformMatrix(for: metadata),
+              let referenceDimensions = OppoLivePhotoAlignment.referenceDimensions(for: metadata) else {
+            return nil
+        }
+        return AppleLivePhotoStillTransform(
+            matrix: matrix,
+            referenceDimensions: referenceDimensions,
+            source: .oppoMetadata
+        )
+    }
+}

--- a/Tests/XDRemuxAppleFeaturesTests/ColorOS16VisionCoverAlignmentTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/ColorOS16VisionCoverAlignmentTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import CoreGraphics
+import XCTest
+import XDRemuxCore
+@testable import XDRemuxAppleFeatures
+
+final class ColorOS16VisionCoverAlignmentTests: XCTestCase {
+    func testReferenceMappingScalesTranslationIntoDeclaredAnalysisSpace() throws {
+        let mapped = try XCTUnwrap(
+            ColorOS16VisionCoverAlignmentAnalyzer.mapToReferenceDimensions(
+                [1, 0, 100, 0, 1, 50, 0, 0, 1],
+                floatingSize: CGSize(width: 1_600, height: 1_200),
+                referenceSize: CGSize(width: 1_600, height: 1_200),
+                outputReferenceDimensions: [1_920, 1_440]
+            )
+        )
+        XCTAssertEqual(mapped[0], 1, accuracy: 1e-12)
+        XCTAssertEqual(mapped[4], 1, accuracy: 1e-12)
+        XCTAssertEqual(mapped[2], 120, accuracy: 1e-12)
+        XCTAssertEqual(mapped[5], 60, accuracy: 1e-12)
+        XCTAssertEqual(mapped[8], 1, accuracy: 1e-12)
+    }
+
+    func testTrajectoryAgreementRejectsDifferentCoverGeometry() {
+        let still: [Double] = [0.902, -0.0046, 108.7, 0.0046, 0.9005, 81.3, 0, 0, 1]
+        let matchingStream2: [Double] = [0.9055, -0.0016, 105.3, 0.0052, 0.9041, 80.2, 0, 0, 1]
+        let conflictingStream2: [Double] = [1.15, 0, -180, 0, 1.15, 190, 0, 0, 1]
+
+        XCTAssertTrue(
+            ColorOS16VisionCoverAlignmentAnalyzer.matricesAgree(
+                still,
+                matchingStream2,
+                referenceDimensions: [1_920, 1_440]
+            )
+        )
+        XCTAssertFalse(
+            ColorOS16VisionCoverAlignmentAnalyzer.matricesAgree(
+                still,
+                conflictingStream2,
+                referenceDimensions: [1_920, 1_440]
+            )
+        )
+    }
+
+    func testStillTransformRejectsInvalidMatrixOrReferenceDimensions() {
+        XCTAssertNil(AppleLivePhotoStillTransform(
+            matrix: [1, 0, 0],
+            referenceDimensions: [1_920, 1_440],
+            source: .colorOS16VisionTrajectory
+        ))
+        XCTAssertNil(AppleLivePhotoStillTransform(
+            matrix: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+            referenceDimensions: [1_920, 0],
+            source: .colorOS16VisionTrajectory
+        ))
+    }
+
+    func testVerifiedColorOS16FixtureWritesVisionCoverTransformWithoutReencoding() async throws {
+        guard let path = ProcessInfo.processInfo.environment["XDREMUX_VISION_COVER_FIXTURE"],
+              !path.isEmpty else {
+            throw XCTSkip("XDREMUX_VISION_COVER_FIXTURE is not configured")
+        }
+        let inputURL = URL(fileURLWithPath: path)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: inputURL.path))
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-vision-cover-functional-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let outputHEIC = directory.appendingPathComponent("vision-cover.heic")
+
+        let result = try await AppleLivePhotoConversionEngine.convertAsync(
+            inputURL: inputURL,
+            outputImageURL: outputHEIC,
+            requirePhotoKitValidation: true
+        )
+        let report = try await AppleLivePhotoValidator.validate(
+            imageURL: result.imageURL,
+            videoURL: result.videoURL,
+            expectedAssetIdentifier: result.assetIdentifier,
+            expectedStillImageTime: result.stillImageTime,
+            requirePhotoKitLoad: true
+        )
+
+        let matrix = try XCTUnwrap(report.stillImageTransform)
+        let expected: [Double] = [
+            0.9019638784, -0.0046428046, 108.7131985,
+            0.0045975180, 0.9004663028, 81.3306202,
+            0.0000005604, 0.0000003985, 1
+        ]
+        for index in [0, 1, 3, 4, 6, 7, 8] {
+            XCTAssertEqual(matrix[index], expected[index], accuracy: 0.002, "matrix[\(index)]")
+        }
+        XCTAssertEqual(matrix[2], expected[2], accuracy: 3, "matrix[2]")
+        XCTAssertEqual(matrix[5], expected[5], accuracy: 3, "matrix[5]")
+        XCTAssertEqual(report.stillImageTransformReferenceDimensions ?? [], [1_920, 1_440])
+        XCTAssertTrue(report.vitalityTransformLimitingAllowed)
+        XCTAssertTrue(result.diagnostics.contains { $0.contains("Vision Track5 cover alignment accepted") })
+    }
+}

--- a/Tests/XDRemuxAppleFeaturesTests/LivePhotoWriterIntegrationTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/LivePhotoWriterIntegrationTests.swift
@@ -87,10 +87,66 @@ final class LivePhotoWriterIntegrationTests: XCTestCase {
         )
         XCTAssertTrue(report.hasTransform)
         XCTAssertTrue(report.hasTransformReferenceDimensions)
+        XCTAssertFalse(report.vitalityTransformLimitingAllowed)
 
         let dimensions = try await readTransformReferenceDimensions(from: outputMOV)
         XCTAssertEqual(dimensions?.width ?? -1, 80, accuracy: 1e-6)
         XCTAssertEqual(dimensions?.height ?? -1, 60, accuracy: 1e-6)
+    }
+
+    func testVisionTransformWritesVitalityLimitingFlagWithoutChangingCompressedVideo() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-livephoto-vitality-limit-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let sourceJPEG = directory.appendingPathComponent("source.jpg")
+        let sourceMP4 = directory.appendingPathComponent("source.mp4")
+        let outputHEIC = directory.appendingPathComponent("output.heic")
+        let outputMOV = directory.appendingPathComponent("output.mov")
+        try createJPEG(at: sourceJPEG, width: 80, height: 60)
+        try await createCompressedVideo(
+            at: sourceMP4,
+            codec: .hevc,
+            width: 64,
+            height: 48,
+            frameCount: 8
+        )
+
+        let identifier = UUID().uuidString
+        let stillTime = CMTime(value: 2, timescale: 30)
+        let transform = try XCTUnwrap(AppleLivePhotoStillTransform(
+            matrix: [0.9, 0, 6, 0, 0.9, 4, 0, 0, 1],
+            referenceDimensions: [64, 48],
+            source: .colorOS16VisionTrajectory
+        ))
+        try AppleLivePhotoStillWriter.write(
+            stillInputURL: sourceJPEG,
+            outputURL: outputHEIC,
+            assetIdentifier: identifier
+        )
+        try await AppleLivePhotoVideoWriter.write(
+            videoInputURL: sourceMP4,
+            outputURL: outputMOV,
+            assetIdentifier: identifier,
+            stillImageTime: stillTime,
+            stillImageTransform: transform
+        )
+
+        let report = try await AppleLivePhotoValidator.validate(
+            imageURL: outputHEIC,
+            videoURL: outputMOV,
+            expectedAssetIdentifier: identifier,
+            expectedStillImageTime: stillTime,
+            sourceStillURL: sourceJPEG,
+            sourceVideoURL: sourceMP4,
+            sourceHadAudio: false,
+            sourceHadGainMap: false,
+            expectsOppoTransform: true,
+            expectedStillImageTransform: transform,
+            requirePhotoKitLoad: true
+        )
+        XCTAssertTrue(report.vitalityTransformLimitingAllowed)
     }
 
     private func assertSyntheticPair(

--- a/Tests/XDRemuxAppleFeaturesTests/OppoLivePhotoAlignmentTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/OppoLivePhotoAlignmentTests.swift
@@ -53,7 +53,7 @@ final class OppoLivePhotoAlignmentTests: XCTestCase {
         XCTAssertEqual(scale.y, 1.0 / 1.11, accuracy: 1e-12)
     }
 
-    func testWriterReferenceDimensionsPreferActualStillRaster() {
+    func testWriterCompatibilityReferenceDimensionsPreferExplicitAnalysisSpace() {
         let metadata = OppoMotionPhotoMetadata(
             version: 1,
             videoWidth: 1728,

--- a/Tests/XDRemuxAppleFeaturesTests/UploadedMotionPhotoFixtureGateTests+VendorGeometry.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/UploadedMotionPhotoFixtureGateTests+VendorGeometry.swift
@@ -55,7 +55,7 @@ final class UploadedMotionPhotoFixtureGateTestsVendorGeometry: XCTestCase {
             XCTAssertEqual(plan?.streamLayout.auxiliaryGeometry.count ?? 0, expected.auxiliaryCount, expected.relativePath)
 
             if expected.kind != nil {
-                XCTAssertNotNil(plan?.stillReferenceDimensions, expected.relativePath)
+                XCTAssertNotNil(plan?.stillRasterDimensions, expected.relativePath)
             }
             if expected.kind == .samsung {
                 XCTAssertEqual(plan?.streamLayout.primary.range, asset.videoResourceRange, expected.relativePath)

--- a/docs/validation/vendor-live-photo-geometry.md
+++ b/docs/validation/vendor-live-photo-geometry.md
@@ -44,18 +44,21 @@ This matters because the two observed conventions are not interchangeable:
 values are rejected. The existing `0.90` ColorOS 16 compatibility fallback remains only for samples
 that have no usable factor.
 
-### Track 5 reference dimensions use the still raster
+### Track 5 reference dimensions describe the transform analysis space
 
-Core Media defines the Live Photo still-image-transform reference dimensions as the dimensions of
-the Live Photo still image. Vendor-scoped conversion therefore passes the actual extracted still
-raster dimensions to `AppleLivePhotoVideoWriter` instead of treating the OPPO video raster as the
-production reference dimensions. The old OPPO video-size path remains only as a direct-call
-compatibility fallback when no still dimensions were supplied.
+The macOS 26.5 Core Media header defines
+`kCMMetadataIdentifier_QuickTimeMetadataLivePhotoStillImageTransformReferenceDimensions` as the
+dimensions of the image used to generate the transform. It does not require the full still raster.
+For the validated ColorOS 16 path, Vision analyzes Stream 1, Stream 2, and the still in a common
+`1920×1440` coordinate space declared by OPPO metadata, so Track 5 records `1920×1440`. The full
+still raster is still measured for validation, but is not substituted for this transform-specific
+reference space.
 
-The actual Track 5 transform source is otherwise unchanged by this branch: XDRemux only writes an
-OPPO transform that the existing alignment implementation can derive from vendor metadata.
+Direct writer callers may continue to supply an explicit reference size. The production converter
+keeps matrix and dimensions together in `AppleLivePhotoStillTransform` so a pixel translation can
+never silently change coordinate systems.
 
-### Vision registration is available as an analysis primitive
+### Vision cover alignment is connected to Track 5 behind a trajectory gate
 
 `VendorLivePhotoVisionHomographyEstimator` exposes the same public Vision homographic registration
 primitive needed by ColorOS Stream 1/Stream 2/still analysis and by future auxiliary-stream vendors.
@@ -63,9 +66,29 @@ It returns a finite, normalized row-major `floatingToReference` matrix and delib
 Vision's mapping direction in the API name. A synthetic high-texture identity-registration test
 checks both the Vision call and the SIMD-to-row-major conversion.
 
-This estimator is not connected to Apple metadata writing. A caller may use it for diagnostics or
-for offline trajectory research without silently crossing the still-unverified Apple coordinate
-boundary.
+For a fixture-backed ColorOS 16 dual-stream input, the production converter now:
+
+1. decodes analysis frames only; the paired MOV still copies compressed Stream 1 samples exactly;
+2. anchors the end of Stream 2 to the resolved cover PTS, matching the observed ColorOS layout;
+3. estimates Stream 1-to-Stream 2 matrices across the overlapping trajectory;
+4. estimates Stream 1-to-still matrices in a `±0.12 s` cover window;
+5. accepts the median cover matrix only when at least 60 percent of paired trajectory frames pass
+   the geometry gate and the Stream 1-to-Stream 2 cover median agrees with the still median;
+6. writes that accepted median as Track 5 `live-photo-still-image-transform` with the same analysis
+   reference dimensions.
+7. writes movie-level `com.apple.quicktime.limit-still-image-transform = 1` only for that accepted
+   Vision result. iOS 26.5.2 Photos firmware reads this through
+   `PFMetadataMovie.livePhotoVitalityLimitingAllowed`, forwards it to
+   `PUBrowsingIrisPlayer` as `limitingAllowed`, and uses the larger allowed-inset budget before
+   deciding whether to disable the Track 5 vitality transform.
+
+If Vision, timing, or trajectory agreement fails, conversion falls back to the existing
+vendor-metadata transform instead of failing the Live Photo conversion. The selected matrix and
+reference dimensions are read back from the output MOV and compared numerically by the production
+validator.
+
+This is a static cover/settling transform. The Stream 1-to-Stream 2 trajectory is confidence
+evidence for selecting it; it is not serialized as a private per-frame Track 4 payload.
 
 ## Deliberately not written yet
 
@@ -78,10 +101,7 @@ The following data is useful research evidence but is **not production-writable 
 2. `AVAppleMakerNote_StillImageProcessingHomography`. Firmware analysis connects this class of still
    processing metadata to Photos vitality transforms, but its third-party writable MakerNote layout
    and coordinate contract are private and not yet proven.
-3. Vision homographies as a replacement for Track 5. Existing Codex experiments successfully
-   estimate ColorOS Stream 1/Stream 2/still relationships, but those experiments explicitly treat the
-   matrices as diagnostics until the Apple metadata convention is independently validated.
-4. Synthetic motion-blur vectors or blur radii. Photos owns its horizontal-scroll/vitality blur
+3. Synthetic motion-blur vectors or blur radii. Photos owns its horizontal-scroll/vitality blur
    state; XDRemux does not inflate motion metadata to force a visual effect.
 
 This is intentional: writing a structurally plausible private payload is not evidence that Photos
@@ -104,16 +124,28 @@ Synthetic tests additionally cover:
 - `1.11 -> 1/1.11` ColorOS normalization;
 - direct sub-unity legacy factors;
 - `photoEisCropFactor` precedence;
-- still-image dimensions taking priority over video dimensions for Track 5 metadata;
+- an explicit transform reference space taking priority over the legacy metadata fallback;
 - Track 5 reference dimensions surviving an AVFoundation write/read round trip;
 - Vision identity registration producing a normalized near-identity homography.
+
+The local verified ColorOS 16 functional gate additionally uses
+`IMG20260509190128.jpg` and checks the Photos-validated contract:
+
+- cover time approximately `1.36612 s`;
+- matrix approximately
+  `[0.901964, -0.004643, 108.713, 0.004598, 0.900466, 81.331, 0, 0, 1]`;
+- reference dimensions `1920×1440`;
+- PhotoKit pair construction succeeds;
+- compressed Stream 1 video and audio samples are byte-identical after remuxing.
+- the Vision-selected output reads back `limit-still-image-transform = 1`, while metadata-only
+  fallback transforms do not opt into that private vitality behavior.
 
 ## Device validation still required
 
 The intended Photos.app experiment remains an A/B matrix rather than an offline acceptance claim:
 
 - baseline current conversion;
-- corrected public Track 5 geometry;
+- corrected public Track 5 geometry selected from the Vision trajectory gate;
 - future Track 4 candidate only after its coordinate mapping is closed;
 - future still-processing-homography candidate only after its writable MakerNote contract is closed;
 - combined candidate.


### PR DESCRIPTION
Restore the verified Codex implementation that was left unpushed after PR #23: Vision-gated ColorOS 16 cover alignment, transform/reference-dimension readback validation, and the Photos vitality limiting mdta flag for accepted Vision transforms.