### PR TITLE
python: align OPPO still-image transform with Swift metadata fallback

### DIFF
--- a/Tests/XDRemuxAppleFeaturesTests/PythonLivePhotoOutputGateTests.swift
+++ b/Tests/XDRemuxAppleFeaturesTests/PythonLivePhotoOutputGateTests.swift
@@ -41,8 +41,18 @@ final class PythonLivePhotoOutputGateTests: XCTestCase {
                 "Swift reference parser rejected source fixture: \(entry.sourceFilename)"
             )
             XCTAssertEqual(sourceAsset.sourceKind.rawValue, entry.sourceKind, entry.sourceFilename)
-            let expectsTransform = sourceAsset.vendorMetadata
-                .flatMap(OppoLivePhotoAlignment.transformMatrix) != nil
+
+            let expectedTransform = sourceAsset.vendorMetadata.flatMap { metadata -> AppleLivePhotoStillTransform? in
+                guard let matrix = OppoLivePhotoAlignment.transformMatrix(for: metadata),
+                      let referenceDimensions = OppoLivePhotoAlignment.referenceDimensions(for: metadata) else {
+                    return nil
+                }
+                return AppleLivePhotoStillTransform(
+                    matrix: matrix,
+                    referenceDimensions: referenceDimensions,
+                    source: .oppoMetadata
+                )
+            }
             let expectedTime = CMTime(
                 seconds: entry.stillImageTimeSeconds,
                 preferredTimescale: 1_000_000
@@ -54,12 +64,33 @@ final class PythonLivePhotoOutputGateTests: XCTestCase {
                 expectedAssetIdentifier: entry.contentIdentifier,
                 expectedStillImageTime: expectedTime,
                 sourceHadGainMap: entry.expectsGainMap,
-                expectsOppoTransform: expectsTransform,
+                expectsOppoTransform: expectedTransform != nil,
+                expectedStillImageTransform: expectedTransform,
                 requirePhotoKitLoad: true
             )
             XCTAssertEqual(report.assetIdentifier, entry.contentIdentifier, entry.sourceFilename)
             XCTAssertEqual(report.hasGainMap, entry.expectsGainMap, entry.sourceFilename)
-            XCTAssertEqual(report.hasTransform, expectsTransform, entry.sourceFilename)
+            XCTAssertEqual(report.hasTransform, expectedTransform != nil, entry.sourceFilename)
+            XCTAssertEqual(
+                report.hasTransformReferenceDimensions,
+                expectedTransform != nil,
+                entry.sourceFilename
+            )
+            if let expectedTransform {
+                let storedMatrix = try XCTUnwrap(report.stillImageTransform, entry.sourceFilename)
+                XCTAssertEqual(storedMatrix.count, expectedTransform.matrix.count, entry.sourceFilename)
+                for (actual, expected) in zip(storedMatrix, expectedTransform.matrix) {
+                    XCTAssertEqual(actual, expected, accuracy: 1e-9, entry.sourceFilename)
+                }
+                let storedDimensions = try XCTUnwrap(
+                    report.stillImageTransformReferenceDimensions,
+                    entry.sourceFilename
+                )
+                XCTAssertEqual(storedDimensions.count, expectedTransform.referenceDimensions.count, entry.sourceFilename)
+                for (actual, expected) in zip(storedDimensions, expectedTransform.referenceDimensions) {
+                    XCTAssertEqual(actual, expected, accuracy: 1e-6, entry.sourceFilename)
+                }
+            }
         }
     }
 }

--- a/Tests/test_python_motion_photo.py
+++ b/Tests/test_python_motion_photo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import struct
 import tempfile
 import unittest
@@ -9,6 +10,7 @@ from xdremux_py.live_photo_mov import (
     _box,
     _full_box,
     media_payload_sha256,
+    oppo_transform,
     read_content_identifier,
     read_still_time,
     resolve_still_time,
@@ -16,7 +18,12 @@ from xdremux_py.live_photo_mov import (
     write_live_photo_movie,
 )
 from xdremux_py.live_photo_still import build_apple_makernote, parse_ultrahdr_metadata
-from xdremux_py.motion_photo import ByteRange, parse_android_motion_photo
+from xdremux_py.motion_photo import (
+    ByteRange,
+    OppoMetadata,
+    parse_android_motion_photo,
+    parse_oppo_lpex,
+)
 from xdremux_py.motion_video import strip_trailing_vendor_data
 
 
@@ -95,6 +102,82 @@ class PythonMotionPhotoTests(unittest.TestCase):
             self.assertEqual(asset.video_range.start, len(ftyp) + len(metadata) + 8)
             self.assertEqual(asset.video_range.end, len(ftyp) + len(metadata) + len(mpvd))
 
+    def test_lpex_parser_reads_photo_eis_crop_factor(self):
+        payload = {
+            "version": 1,
+            "photoEisCropFactor": [1.11, 1.12],
+            "eisCropFactor": [0.80, 0.81],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "coloros16.bin"
+            path.write_bytes(b"prefix-lpexLivePhotoExtension" + json.dumps(payload).encode() + b"-suffix")
+            metadata = parse_oppo_lpex(path)
+            self.assertIsNotNone(metadata)
+            assert metadata is not None
+            self.assertEqual(metadata.photo_eis_crop_factor, (1.11, 1.12))
+            self.assertEqual(metadata.eis_crop_factor, (0.80, 0.81))
+
+    def test_coloros16_uses_legacy_eis_compensation_when_no_factor_exists(self):
+        identity = (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+        matrix = oppo_transform(OppoMetadata(
+            version=1,
+            photo_crop_matrix=identity,
+            photo_eis_matrix=identity,
+        ))
+        self.assertIsNotNone(matrix)
+        assert matrix is not None
+        self.assertAlmostEqual(matrix[0], 0.90, places=12)
+        self.assertAlmostEqual(matrix[4], 0.90, places=12)
+        self.assertAlmostEqual(matrix[8], 1.0, places=12)
+
+    def test_coloros16_uses_reciprocal_photo_eis_crop_factor(self):
+        matrix = oppo_transform(OppoMetadata(
+            version=1,
+            photo_eis_crop_factor=(1.11, 1.12),
+        ))
+        self.assertIsNotNone(matrix)
+        assert matrix is not None
+        self.assertAlmostEqual(matrix[0], 1.0 / 1.11, places=12)
+        self.assertAlmostEqual(matrix[4], 1.0 / 1.12, places=12)
+        self.assertAlmostEqual(matrix[8], 1.0, places=12)
+
+    def test_coloros16_accepts_legacy_direct_scale_below_one(self):
+        matrix = oppo_transform(OppoMetadata(
+            version=1,
+            eis_crop_factor=(0.91, 0.92),
+        ))
+        self.assertIsNotNone(matrix)
+        assert matrix is not None
+        self.assertAlmostEqual(matrix[0], 0.91, places=12)
+        self.assertAlmostEqual(matrix[4], 0.92, places=12)
+
+    def test_photo_eis_crop_factor_wins_over_legacy_eis_factor(self):
+        matrix = oppo_transform(OppoMetadata(
+            version=1,
+            photo_eis_crop_factor=(1.11, 1.11),
+            eis_crop_factor=(0.80, 0.80),
+        ))
+        self.assertIsNotNone(matrix)
+        assert matrix is not None
+        self.assertAlmostEqual(matrix[0], 1.0 / 1.11, places=12)
+        self.assertAlmostEqual(matrix[4], 1.0 / 1.11, places=12)
+
+    def test_coloros15_uses_closest_cover_frame_and_inverts_matrix(self):
+        matrix = oppo_transform(OppoMetadata(
+            cover_frame_pts_us=1100,
+            version=0,
+            matrix_count=2,
+            matrices=(
+                (1000, (2.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 1.0)),
+                (2000, (4.0, 0.0, 0.0, 0.0, 4.0, 0.0, 0.0, 0.0, 1.0)),
+            ),
+        ))
+        self.assertIsNotNone(matrix)
+        assert matrix is not None
+        self.assertAlmostEqual(matrix[0], 0.5, places=12)
+        self.assertAlmostEqual(matrix[4], 0.5, places=12)
+        self.assertAlmostEqual(matrix[8], 1.0, places=12)
+
     def test_pure_python_mov_writer_preserves_media_and_writes_live_photo_metadata(self):
         with tempfile.TemporaryDirectory() as tmp:
             source = Path(tmp) / "source.mp4"
@@ -108,6 +191,27 @@ class PythonMotionPhotoTests(unittest.TestCase):
             self.assertAlmostEqual(read_still_time(output) or -1, 0.1, places=3)
             self.assertEqual(media_payload_sha256(output), source_hashes)
             validate_live_photo_movie(output, "ABC-123", resolved)
+
+    def test_pure_python_mov_writer_embeds_oppo_transform_without_reencoding_media(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "source.mp4"
+            output = Path(tmp) / "output.mov"
+            source.write_bytes(_fake_video())
+            source_hashes = media_payload_sha256(source)
+            metadata = OppoMetadata(
+                version=1,
+                photo_eis_crop_factor=(1.11, 1.12),
+                video_width=1728,
+                video_height=1296,
+            )
+            expected = oppo_transform(metadata)
+            self.assertIsNotNone(expected)
+            assert expected is not None
+            write_live_photo_movie(source, output, "ABC-123", 0.1, oppo_metadata=metadata)
+            payload = output.read_bytes()
+            self.assertIn(struct.pack(">9d", *expected), payload)
+            self.assertIn(struct.pack(">2f", 1728.0, 1296.0), payload)
+            self.assertEqual(media_payload_sha256(output), source_hashes)
 
     def test_trailing_vendor_bytes_are_removed_only_after_complete_bmff(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/xdremux_py/live_photo_mov.py
+++ b/xdremux_py/live_photo_mov.py
@@ -28,6 +28,7 @@ STILL_IMAGE_KEY = b"com.apple.quicktime.still-image-time"
 TRANSFORM_KEY = b"com.apple.quicktime.live-photo-still-image-transform"
 REFERENCE_DIMENSIONS_KEY = b"com.apple.quicktime.live-photo-still-image-transform-reference-dimensions"
 COPY_CHUNK_SIZE = 1 << 20
+LEGACY_COLOROS16_EIS_COMPENSATION_SCALE = 0.90
 
 
 class LivePhotoMovieError(ValueError):
@@ -273,11 +274,50 @@ def _multiply3(a: tuple[float, ...], b: tuple[float, ...]) -> tuple[float, ...]:
     return tuple(sum(a[r*3+k] * b[k*3+c] for k in range(3)) for r in range(3) for c in range(3))
 
 
+def _normalized_axis_scale(value: float) -> float | None:
+    if not math.isfinite(value) or value <= 0:
+        return None
+    scale = 1.0 / value if value > 1 else value
+    if not math.isfinite(scale) or scale <= 0 or scale > 1:
+        return None
+    return scale
+
+
+def _normalized_scale(factors: tuple[float, ...] | None) -> tuple[float, float] | None:
+    if not factors:
+        return None
+    raw_x = factors[0]
+    raw_y = factors[1] if len(factors) >= 2 else raw_x
+    x = _normalized_axis_scale(raw_x)
+    y = _normalized_axis_scale(raw_y)
+    if x is None or y is None:
+        return None
+    return x, y
+
+
+def _coloros16_eis_compensation_scale(metadata: OppoMetadata) -> tuple[float, float]:
+    return (
+        _normalized_scale(metadata.photo_eis_crop_factor)
+        or _normalized_scale(metadata.eis_crop_factor)
+        or (LEGACY_COLOROS16_EIS_COMPENSATION_SCALE, LEGACY_COLOROS16_EIS_COMPENSATION_SCALE)
+    )
+
+
+def _normalize_homography(matrix: tuple[float, ...]) -> tuple[float, ...] | None:
+    if len(matrix) != 9 or any(not math.isfinite(value) for value in matrix):
+        return None
+    denominator = matrix[8]
+    if abs(denominator) <= 1e-12:
+        return None
+    return tuple(value / denominator for value in matrix)
+
+
 def oppo_transform(metadata: OppoMetadata | None) -> tuple[float, ...] | None:
     if metadata is None:
         return None
     if metadata.version >= 1:
-        result = (0.90, 0.0, 0.0, 0.0, 0.90, 0.0, 0.0, 0.0, 1.0)
+        scale_x, scale_y = _coloros16_eis_compensation_scale(metadata)
+        result = (scale_x, 0.0, 0.0, 0.0, scale_y, 0.0, 0.0, 0.0, 1.0)
         if metadata.photo_crop_matrix and (inverse := _invert3(metadata.photo_crop_matrix)):
             result = _multiply3(result, inverse)
         if metadata.photo_eis_matrix and (inverse := _invert3(metadata.photo_eis_matrix)):
@@ -287,8 +327,11 @@ def oppo_transform(metadata: OppoMetadata | None) -> tuple[float, ...] | None:
             return None
         _, matrix = min(metadata.matrices, key=lambda pair: abs(pair[0] - metadata.cover_frame_pts_us))
         result = _invert3(matrix) or matrix
+    normalized = _normalize_homography(result)
+    if normalized is None:
+        return None
     identity = (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
-    return None if all(abs(x-y) <= 1e-6 for x, y in zip(result, identity)) else result
+    return None if all(abs(x-y) <= 1e-6 for x, y in zip(normalized, identity)) else normalized
 
 
 def _metadata_key_atom(local_id: int, name: bytes, type_code: int) -> bytes:

--- a/xdremux_py/motion_photo.py
+++ b/xdremux_py/motion_photo.py
@@ -65,10 +65,10 @@ class OppoMetadata:
     video_height: int | None = None
     origin_photo_width: int | None = None
     origin_photo_height: int | None = None
-    photo_eis_crop_factor: tuple[float, ...] | None = None
     eis_crop_factor: tuple[float, ...] | None = None
     photo_crop_factor: float | None = None
     stream_count: int = 1
+    photo_eis_crop_factor: tuple[float, ...] | None = None
 
 
 @dataclass(frozen=True)
@@ -527,10 +527,10 @@ def _parse_lpex_object(raw: bytes) -> OppoMetadata | None:
         video_height=vh,
         origin_photo_width=ow,
         origin_photo_height=oh,
-        photo_eis_crop_factor=_number_tuple(obj.get("photoEisCropFactor"), 8),
         eis_crop_factor=_number_tuple(obj.get("eisCropFactor"), 8),
         photo_crop_factor=photo_crop_factor,
         stream_count=1,
+        photo_eis_crop_factor=_number_tuple(obj.get("photoEisCropFactor"), 8),
     )
 
 

--- a/xdremux_py/motion_photo.py
+++ b/xdremux_py/motion_photo.py
@@ -461,9 +461,12 @@ def _number_tuple(value, limit: int) -> tuple[float, ...] | None:
     if not isinstance(value, list) or len(value) > limit:
         return None
     try:
-        return tuple(float(item) for item in value)
+        values = tuple(float(item) for item in value)
     except (TypeError, ValueError):
         return None
+    if any(not (-1e308 < item < 1e308) for item in values):
+        return None
+    return values
 
 
 def _parse_lpex_object(raw: bytes) -> OppoMetadata | None:

--- a/xdremux_py/motion_photo.py
+++ b/xdremux_py/motion_photo.py
@@ -65,6 +65,7 @@ class OppoMetadata:
     video_height: int | None = None
     origin_photo_width: int | None = None
     origin_photo_height: int | None = None
+    photo_eis_crop_factor: tuple[float, ...] | None = None
     eis_crop_factor: tuple[float, ...] | None = None
     photo_crop_factor: float | None = None
     stream_count: int = 1
@@ -523,6 +524,7 @@ def _parse_lpex_object(raw: bytes) -> OppoMetadata | None:
         video_height=vh,
         origin_photo_width=ow,
         origin_photo_height=oh,
+        photo_eis_crop_factor=_number_tuple(obj.get("photoEisCropFactor"), 8),
         eis_crop_factor=_number_tuple(obj.get("eisCropFactor"), 8),
         photo_crop_factor=photo_crop_factor,
         stream_count=1,


### PR DESCRIPTION
## Summary

Align the pure-Python Motion Photo → Apple Live Photo path with the Swift OPPO metadata fallback used when ColorOS 16 Vision alignment is unavailable.

The Python path remains cross-platform and does not introduce Vision, AVFoundation, CoreMedia, FFmpeg, ExifTool, or PyObjC dependencies. It derives the Apple Track 5 `com.apple.quicktime.live-photo-still-image-transform` directly from OPPO LPEX metadata and preserves compressed media payloads.

## Changes

- parse ColorOS `photoEisCropFactor` in the Python LPEX model
- match Swift ColorOS 16 EIS compensation priority:
  1. `photoEisCropFactor`
  2. legacy `eisCropFactor`
  3. `0.90` compatibility fallback
- normalize crop factors above 1 by reciprocal, matching `OppoLivePhotoAlignment`
- compose the scale with inverse `photoCropMatrix` and inverse `photoEisMatrix`
- normalize the resulting homography by `m[8]`
- preserve the existing ColorOS 15 closest-cover-frame matrix fallback
- reject non-finite crop-factor arrays to match the Swift parser
- preserve `OppoMetadata` positional constructor compatibility

## Validation

- Python unit coverage for:
  - legacy 0.90 fallback
  - reciprocal `photoEisCropFactor`
  - legacy direct scale below 1
  - `photoEisCropFactor` precedence
  - ColorOS 15 closest-cover-frame inverse
- writer integration test verifies Track 5 matrix/reference dimensions are embedded without changing compressed media payload hashes
- macOS Python-output gate now computes the expected transform with the Swift reference implementation and compares the actual stored Track 5 matrix and reference dimensions element-by-element

The PR is intentionally limited to the metadata fallback path; it does not port the Swift Vision trajectory analysis into Python.