### PR TITLE
feat: add asset-aware photo tag classification

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -47,7 +47,7 @@ Every option, default, and exit code is in the [CLI reference](docs/cli.en.md), 
 
 ## Sorting by shooting mode
 
-Reads the shooting mode recorded in each photo and copies it into the matching Chinese-named folder (`人像` portrait, `夜景` night, `大师模式` master mode, and so on). It only copies — sources are never modified or deleted:
+Keeps every recognized shooting-mode tag, then projects those tags onto one physical location. The first level is the asset type (`静态照片` static photo / `实况照片` Live Photo), and the second level is the primary shooting mode (`人像` portrait, `夜景` night, `大师模式` master mode, and so on). A Live Photo HEIC and MOV stay together in the same directory. It only copies — sources are never modified or deleted:
 
 ```bash
 swift run xdremux categorize --input photo_dump/ --output-dir categorized/ --dry-run
@@ -59,7 +59,7 @@ swift run xdremux categorize --input photo_dump/ --output-dir categorized/ --dry
 python3 xdremux/python/XDRemux.py categorize --input photo_dump/ --output-dir categorized/
 ```
 
-Photos whose mode cannot be read stay in the output root and are not counted as failures.
+Photos whose mode cannot be read go to `未分类` under their asset-type directory. An existing Apple Live Photo is moved as one asset only after its HEIC/JPEG and MOV pass pair-identity validation; an unrelated same-name MOV is never claimed. ProXDR, HDR, gain-map, depth, and vendor facts remain tags and do not add more physical folder levels.
 
 ## Apple Photographic Styles and portrait
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ swift build
 
 ## 按拍摄模式归档
 
-读出照片里记录的拍摄模式，把照片复制进对应的中文目录（`人像`、`夜景`、`大师模式` 等）。只复制，不修改也不删除源文件：
+分类器会保留照片上同时激活的多个拍摄标签，再把它们投影到唯一的物理目录。第一层按资产类型分为 `静态照片` / `实况照片`，第二层按主拍摄模式分为 `人像`、`夜景`、`大师模式` 等。实况照片的 HEIC 和 MOV 始终位于同一目录。只复制，不修改也不删除源文件：
 
 ```bash
 swift run xdremux categorize --input photo_dump/ --output-dir categorized/ --dry-run
@@ -59,7 +59,7 @@ swift run xdremux categorize --input photo_dump/ --output-dir categorized/ --dry
 python3 xdremux/python/XDRemux.py categorize --input photo_dump/ --output-dir categorized/
 ```
 
-读不出拍摄模式的照片会留在输出根目录，不算失败。
+读不出拍摄模式的照片会进入对应资产类型下的 `未分类`。已有的 Apple Live Photo 只有在 HEIC/JPEG 与 MOV 的内容标识等配对信息通过校验后，才会作为同一个资产一起移动；仅仅同名的随机 MOV 不会被认领。ProXDR、HDR、Gain Map、景深和厂商等属性只作为标签保留，不继续增加物理目录层级。
 
 ## Apple 摄影风格与人像
 

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoBatchPlanner.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoBatchPlanner.swift
@@ -1,62 +1,70 @@
-import CryptoKit
 import Foundation
 
-/// Stable Motion Photo batch naming. A destination is a pure function of the canonical batch root
-/// plus the source path relative to that root, so batch membership/order cannot remap a source and
-/// two different input roots cannot silently target the same persisted Live Photo name.
+/// User-facing Motion Photo naming policy.
+///
+/// Preserve the source basename whenever possible. Sequence suffixes are introduced only when the
+/// destination namespace has a real collision. Source identity remains in checkpoint/provenance;
+/// it is deliberately not exposed in the user's filename.
 enum MotionPhotoBatchPlanner {
     static func outputImageURL(
         for inputURL: URL,
-        inputRootURL: URL,
+        inputRootURL _: URL,
         outputDirectoryURL: URL
     ) -> URL {
         let source = inputURL.resolvingSymlinksInPath().standardizedFileURL
-        let root = inputRootURL.resolvingSymlinksInPath().standardizedFileURL
-        let rootIdentity = root.path.precomposedStringWithCanonicalMapping
-        let relativePath: String
-        let prefix = root.path.hasSuffix("/") ? root.path : root.path + "/"
-        if source.path.hasPrefix(prefix) {
-            relativePath = String(source.path.dropFirst(prefix.count)).precomposedStringWithCanonicalMapping
-        } else {
-            relativePath = source.path.precomposedStringWithCanonicalMapping
-        }
-
-        // Root namespace + relative path is equivalent to a canonical source identity while keeping
-        // the intent explicit. This prevents two independent input trees with the same A/IMG.jpg
-        // layout from overwriting each other when they share an output directory.
-        let identity = rootIdentity + "\u{0}" + relativePath
-        let digest = SHA256.hash(data: Data(identity.utf8))
-        // 128 bits keeps the filename compact while making accidental persisted-name collisions
-        // negligible. validateUnique() still fails closed if a collision is ever observed.
-        let token = digest.prefix(16).map { String(format: "%02x", $0) }.joined()
-        let ext = source.pathExtension.lowercased()
-        let sourceStem = source.deletingPathExtension().lastPathComponent
-        let stem = (ext == "heic" || ext == "heif") ? "\(sourceStem).live" : sourceStem
+        let stem = source.deletingPathExtension().lastPathComponent
         return outputDirectoryURL
-            .appendingPathComponent("\(stem)~\(token)")
+            .appendingPathComponent(stem)
             .appendingPathExtension("heic")
     }
 
-    static func validateUnique(_ items: [(input: URL, output: URL)]) throws {
-        var owners: [String: String] = [:]
-        for item in items {
-            let outputPath = item.output.standardizedFileURL.path
-            let inputPath = item.input.resolvingSymlinksInPath().standardizedFileURL.path
-            if let prior = owners[outputPath], prior != inputPath {
-                throw PlannerError.collision(first: prior, second: inputPath, output: outputPath)
-            }
-            owners[outputPath] = inputPath
-        }
+    static func numberedOutputImageURL(base: URL, sequence: Int) -> URL {
+        guard sequence > 1 else { return base }
+        let stem = base.deletingPathExtension().lastPathComponent
+        return base.deletingLastPathComponent()
+            .appendingPathComponent("\(stem) (\(sequence))")
+            .appendingPathExtension(base.pathExtension)
     }
 
-    enum PlannerError: LocalizedError {
-        case collision(first: String, second: String, output: String)
+    static func companionVideoURL(for imageURL: URL) -> URL {
+        imageURL.deletingPathExtension().appendingPathExtension("mov")
+    }
 
-        var errorDescription: String? {
-            switch self {
-            case let .collision(first, second, output):
-                return "stable Motion Photo output collision: \(first) and \(second) -> \(output)"
+    /// Reserves one HEIC+MOV namespace atomically. `candidateBelongsToSource` lets durable
+    /// provenance keep an existing name on rerun, while unrelated pre-existing files count as real
+    /// collisions and receive the next sequence number.
+    static func reserveOutputImageURL(
+        for inputURL: URL,
+        inputRootURL: URL,
+        outputDirectoryURL: URL,
+        reservedPaths: inout Set<String>,
+        candidateBelongsToSource: (URL, URL) -> Bool = { _, _ in false },
+        fileExists: (URL) -> Bool = { FileManager.default.fileExists(atPath: $0.path) }
+    ) -> URL {
+        let sourcePath = inputURL.resolvingSymlinksInPath().standardizedFileURL.path
+        let base = outputImageURL(
+            for: inputURL,
+            inputRootURL: inputRootURL,
+            outputDirectoryURL: outputDirectoryURL
+        )
+        var sequence = 1
+
+        while true {
+            let image = numberedOutputImageURL(base: base, sequence: sequence)
+            let video = companionVideoURL(for: image)
+            let imagePath = image.standardizedFileURL.path
+            let videoPath = video.standardizedFileURL.path
+            let plannedConflict = reservedPaths.contains(imagePath) || reservedPaths.contains(videoPath)
+            let sourceConflict = imagePath == sourcePath || videoPath == sourcePath
+            let belongsToSource = candidateBelongsToSource(image, video)
+            let filesystemConflict = !belongsToSource && (fileExists(image) || fileExists(video))
+
+            if !plannedConflict && !sourceConflict && !filesystemConflict {
+                reservedPaths.insert(imagePath)
+                reservedPaths.insert(videoPath)
+                return image
             }
+            sequence += 1
         }
     }
 }

--- a/Sources/XDRemuxCLI/Commands/MotionPhotoCLIIntegration.swift
+++ b/Sources/XDRemuxCLI/Commands/MotionPhotoCLIIntegration.swift
@@ -61,12 +61,17 @@ enum MotionPhotoCLIIntegration {
         let outputImageURL: URL
         if outputWasExplicit {
             outputImageURL = command.outputURL.standardizedFileURL
-        } else if isHEIC(inputURL) {
-            outputImageURL = inputURL.deletingPathExtension()
-                .appendingPathExtension("live")
-                .appendingPathExtension("heic")
         } else {
-            outputImageURL = inputURL.deletingPathExtension().appendingPathExtension("heic")
+            var reserved = Set<String>()
+            outputImageURL = MotionPhotoBatchPlanner.reserveOutputImageURL(
+                for: inputURL,
+                inputRootURL: inputURL.deletingLastPathComponent(),
+                outputDirectoryURL: inputURL.deletingLastPathComponent(),
+                reservedPaths: &reserved,
+                // Single-file conversion historically replaces its deterministic output on rerun.
+                // Ignore unrelated pre-existing outputs here; only protect the source path itself.
+                fileExists: { _ in false }
+            )
         }
         try validateLivePhotoOutputExtension(outputImageURL)
 
@@ -85,8 +90,8 @@ enum MotionPhotoCLIIntegration {
     }
 
     /// Plans the entire Motion Photo portion of a default batch before the first write. Explicit
-    /// --glob retains the old contract. Stable Motion Photo destination names are derived from the
-    /// source path relative to input-dir, never from the current batch ordering or membership.
+    /// --glob retains the old contract. User basenames are preserved; deterministic `(2)`, `(3)`, …
+    /// suffixes are introduced only when assets actually converge on the same destination namespace.
     private static func prepareDefaultBatch(_ rawArguments: [String]) throws -> Bool {
         guard !rawArguments.contains("--glob") else { return false }
 
@@ -377,15 +382,6 @@ enum MotionPhotoCLIIntegration {
         }
     }
 
-    private struct MotionBatchPlanningConflictError: LocalizedError {
-        let input: URL
-        let output: URL
-
-        var errorDescription: String? {
-            "stable Motion Photo destination for \(input.path) conflicts with another planned output: \(output.path)"
-        }
-    }
-
     private final class PendingBatchStore: @unchecked Sendable {
         private let lock = NSLock()
         private var pending: PendingBatch?
@@ -433,30 +429,23 @@ enum MotionPhotoCLIIntegration {
     ) throws -> [MotionBatchWorkItem] {
         let heicItems = makeHEICWorkItems(inputs: heicInputs, command: command)
         var reserved = Set(heicItems.map { $0.outputURL.standardizedFileURL.path })
-
-        let planned = inputs.sorted { $0.path < $1.path }.map { input -> (input: URL, output: URL) in
-            let output = MotionPhotoBatchPlanner.outputImageURL(
-                for: input,
-                inputRootURL: command.inputDirURL,
-                outputDirectoryURL: categorizedOutputDirectory(for: input, command: command)
-            )
-            return (input, output)
-        }
-        try MotionPhotoBatchPlanner.validateUnique(planned)
+        let checkpointState = try MotionPhotoBatchCheckpoint.load(
+            url: MotionPhotoBatchCheckpoint.resolvedURL(for: command)
+        )
 
         var result: [MotionBatchWorkItem] = []
-        for item in planned {
-            let imagePath = item.output.standardizedFileURL.path
-            let videoPath = AppleLivePhotoConversionEngine.companionVideoURL(for: item.output)
-                .standardizedFileURL.path
-            if reserved.contains(imagePath)
-                || reserved.contains(videoPath)
-                || imagePath == item.input.standardizedFileURL.path {
-                throw MotionBatchPlanningConflictError(input: item.input, output: item.output)
-            }
-            reserved.insert(imagePath)
-            reserved.insert(videoPath)
-            result.append(MotionBatchWorkItem(inputURL: item.input, outputImageURL: item.output))
+        for input in inputs.sorted(by: { $0.path < $1.path }) {
+            let prior = checkpointState[input.standardizedFileURL.path]
+            let output = MotionPhotoBatchPlanner.reserveOutputImageURL(
+                for: input,
+                inputRootURL: command.inputDirURL,
+                outputDirectoryURL: categorizedOutputDirectory(for: input, command: command),
+                reservedPaths: &reserved,
+                candidateBelongsToSource: { image, video in
+                    prior?.matchesOutputs(imageURL: image, videoURL: video) == true
+                }
+            )
+            result.append(MotionBatchWorkItem(inputURL: input, outputImageURL: output))
         }
         return result
     }

--- a/Sources/XDRemuxCLI/Commands/XDRemuxCommand.swift
+++ b/Sources/XDRemuxCLI/Commands/XDRemuxCommand.swift
@@ -469,6 +469,9 @@ enum XDRemuxCommand {
         let plan = try PhotoCategorizationEngine.makePlan(
             inputs: cmd.inputURLs,
             outputDirectory: cmd.outputDirURL,
+            livePhotoPairValidator: { imageURL, videoURL in
+                AppleLivePhotoValidator.isValidPair(imageURL: imageURL, videoURL: videoURL)
+            },
             fileManager: fileManager
         )
         let result = PhotoCategorizationEngine.execute(
@@ -478,14 +481,13 @@ enum XDRemuxCommand {
             fileManager: fileManager
         )
         for item in result.items {
-            let mode = item.classification.mode?.folderName
-                ?? "根目录 (\(item.classification.status.rawValue))"
+            let category = PhotoFolderProjection.relativeDirectory(for: item.classification)
             let detail = item.errorDescription.map { " error=\($0)" } ?? ""
-            print("\(item.disposition.rawValue) [\(mode)] \(item.sourceURL.path) -> \(item.destinationURL.path)\(detail)")
+            print("\(item.disposition.rawValue) [\(category)] \(item.sourceURL.path) -> \(item.destinationURL.path)\(detail)")
         }
         print(
             "categorize complete: \(result.categorizedCount) categorized, "
-                + "\(result.rootCount) kept at root, \(result.copiedCount) copied, "
+                + "\(result.unclassifiedCount) unclassified, \(result.copiedCount) copied, "
                 + "\(result.dryRunCount) dry-run, \(result.duplicateCount) duplicate, "
                 + "\(result.issueCount) failed"
         )
@@ -736,7 +738,8 @@ enum XDRemuxCommand {
             ("appleStyleDataProducer", cmd.appleStyleDataProducer.rawValue),
             ("tmapFormat", cmd.tmapFormat.rawValue),
             ("outputDir", cmd.outputDirURL.standardizedFileURL.path),
-            ("categorizeOutput", cmd.categorizeOutput ? "true" : "false")
+            ("categorizeOutput", cmd.categorizeOutput ? "true" : "false"),
+            ("categorizationLayout", cmd.categorizeOutput ? PhotoFolderProjection.layoutVersion : "off")
         ]
         let stable = entries.sorted(by: { $0.0 < $1.0 }).map { "\($0.0)=\($0.1)" }.joined(separator: "\n")
         return sha256Hex(Data(stable.utf8))
@@ -793,7 +796,8 @@ enum XDRemuxCommand {
         // skipping them keeps a repeated batch over the same directory
         // idempotent instead of re-converting yesterday's results.
         let categorizedParent = categorized ? (outputPath ?? rootPath) : nil
-        let captureModeFolders = Set(OppoCaptureMode.allCases.map(\.folderName))
+        let categorizedRootFolders = PhotoFolderProjection.rootFolderNames
+            .union(Set(OppoCaptureMode.allCases.map(\.folderName)))
 
         var matched: [URL] = []
         for case let fileURL as URL in enumerator {
@@ -807,7 +811,7 @@ enum XDRemuxCommand {
             }
             if isDirectory, let categorizedParent,
                fileURL.deletingLastPathComponent().standardizedFileURL.path == categorizedParent,
-               captureModeFolders.contains(fileURL.lastPathComponent) {
+               categorizedRootFolders.contains(fileURL.lastPathComponent) {
                 enumerator.skipDescendants()
                 continue
             }

--- a/Sources/XDRemuxCore/Metadata/PhotoAssetCategorizationPlanning.swift
+++ b/Sources/XDRemuxCore/Metadata/PhotoAssetCategorizationPlanning.swift
@@ -1,0 +1,242 @@
+import CryptoKit
+import Foundation
+
+/// Platform-specific code supplies the proof that an image and video form one Apple Live Photo.
+/// XDRemuxCore deliberately does not depend on AVFoundation/Photos just to organize files.
+public typealias LivePhotoPairValidator = (_ imageURL: URL, _ videoURL: URL) -> Bool
+
+public extension PhotoCategorizationEngine {
+    /// Asset-aware standalone categorization.
+    ///
+    /// Images remain the discovery roots. A sibling MOV is claimed only when the supplied validator
+    /// proves that it belongs to the image. Once claimed, all resources in the asset share one
+    /// classification, directory, and collision sequence, so a Live Photo can never be split across
+    /// `name.*` and `name (2).*` merely because one resource collided first.
+    static func makePlan(
+        inputs: [URL],
+        outputDirectory: URL?,
+        livePhotoPairValidator: LivePhotoPairValidator,
+        fileManager: FileManager = .default
+    ) throws -> PhotoCategorizationPlan {
+        let primaryImages = try collectAssetPrimaryImages(
+            inputs: inputs,
+            excluding: outputDirectory,
+            fileManager: fileManager
+        )
+        var reserved: [String: (url: URL, digest: String)] = [:]
+        var items: [PhotoCategorizationItem] = []
+
+        for primaryImage in primaryImages {
+            let asset = resolvedAsset(
+                for: primaryImage,
+                pairValidator: livePhotoPairValidator,
+                fileManager: fileManager
+            )
+            let classification = classify(asset: asset)
+            let destinationRoot = outputDirectory ?? primaryImage.deletingLastPathComponent()
+            let destinationDirectory = PhotoFolderProjection.relativeDirectoryComponents(for: classification)
+                .reduce(destinationRoot) { partial, component in
+                    partial.appendingPathComponent(component, isDirectory: true)
+                }
+            let resourceDigests = try Dictionary(
+                uniqueKeysWithValues: asset.resources.map { resource in
+                    (resource.url.standardizedFileURL.path, try categorizationSHA256(resource.url))
+                }
+            )
+
+            var sequence = 1
+            while true {
+                let candidates = asset.resources.map { resource in
+                    (
+                        resource: resource,
+                        destination: sequencedCategorizationDestination(
+                            directory: destinationDirectory,
+                            sourceName: resource.url.lastPathComponent,
+                            sequence: sequence
+                        )
+                    )
+                }
+
+                var dispositions: [String: PhotoCategorizationDisposition] = [:]
+                var conflict = false
+                for candidate in candidates {
+                    let sourcePath = candidate.resource.url.standardizedFileURL.path
+                    let digest = resourceDigests[sourcePath]!
+                    let destinationKey = candidate.destination.standardizedFileURL.path
+                    if let prior = reserved[destinationKey] {
+                        if prior.digest == digest {
+                            dispositions[sourcePath] = .duplicate
+                        } else {
+                            conflict = true
+                            break
+                        }
+                    } else if fileManager.fileExists(atPath: candidate.destination.path) {
+                        if try categorizationFilesMatch(candidate.resource.url, candidate.destination) {
+                            dispositions[sourcePath] = .duplicate
+                        } else {
+                            conflict = true
+                            break
+                        }
+                    } else {
+                        dispositions[sourcePath] = .copy
+                    }
+                }
+
+                if conflict {
+                    sequence += 1
+                    continue
+                }
+
+                for candidate in candidates {
+                    let sourcePath = candidate.resource.url.standardizedFileURL.path
+                    let digest = resourceDigests[sourcePath]!
+                    let disposition = dispositions[sourcePath] ?? .copy
+                    let destinationKey = candidate.destination.standardizedFileURL.path
+                    if reserved[destinationKey] == nil {
+                        reserved[destinationKey] = (candidate.destination, digest)
+                    }
+                    items.append(
+                        PhotoCategorizationItem(
+                            sourceURL: candidate.resource.url,
+                            destinationURL: candidate.destination,
+                            classification: classification,
+                            disposition: disposition
+                        )
+                    )
+                }
+                break
+            }
+        }
+
+        return PhotoCategorizationPlan(outputDirectory: outputDirectory, items: items)
+    }
+
+    private static func resolvedAsset(
+        for primaryImage: URL,
+        pairValidator: LivePhotoPairValidator,
+        fileManager: FileManager
+    ) -> PhotoAsset {
+        if let videoURL = categorizationCompanionVideo(for: primaryImage, fileManager: fileManager),
+           pairValidator(primaryImage, videoURL) {
+            return .livePhoto(imageURL: primaryImage, videoURL: videoURL)
+        }
+        if inferredAssetType(at: primaryImage) == .livePhoto {
+            return PhotoAsset(
+                id: primaryImage.standardizedFileURL.path,
+                type: .livePhoto,
+                resources: [PhotoResource(url: primaryImage, role: .primaryImage)]
+            )
+        }
+        return .staticPhoto(primaryImage)
+    }
+
+    private static func categorizationCompanionVideo(
+        for imageURL: URL,
+        fileManager: FileManager
+    ) -> URL? {
+        let directory = imageURL.deletingLastPathComponent()
+        let stem = imageURL.deletingPathExtension().lastPathComponent
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else { return nil }
+        return entries
+            .filter {
+                $0.pathExtension.lowercased() == "mov"
+                    && $0.deletingPathExtension().lastPathComponent == stem
+            }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+            .first
+    }
+
+    private static func collectAssetPrimaryImages(
+        inputs: [URL],
+        excluding outputDirectory: URL?,
+        fileManager: FileManager
+    ) throws -> [URL] {
+        let supportedExtensions = Set(["heic", "heif", "jpg", "jpeg"])
+        let inPlaceSkipRoots = PhotoFolderProjection.rootFolderNames
+            .union(Set(OppoCaptureMode.allCases.map(\.folderName)))
+        let excludedPath = outputDirectory?.standardizedFileURL.path
+        var collected: [String: URL] = [:]
+
+        for input in inputs {
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: input.path, isDirectory: &isDirectory) else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            let candidates: [URL]
+            if isDirectory.boolValue {
+                guard let enumerator = fileManager.enumerator(
+                    at: input,
+                    includingPropertiesForKeys: [.isRegularFileKey],
+                    options: [.skipsHiddenFiles]
+                ) else { continue }
+                candidates = enumerator.compactMap { $0 as? URL }
+            } else {
+                candidates = [input]
+            }
+
+            for candidate in candidates {
+                let standardized = candidate.standardizedFileURL
+                let path = standardized.path
+                if let excludedPath,
+                   (path == excludedPath || path.hasPrefix(excludedPath + "/")) {
+                    continue
+                }
+                guard supportedExtensions.contains(candidate.pathExtension.lowercased()) else { continue }
+                let values = try? candidate.resourceValues(forKeys: [.isRegularFileKey])
+                guard values?.isRegularFile != false else { continue }
+
+                if isDirectory.boolValue {
+                    let rootPath = input.standardizedFileURL.path
+                    if path.hasPrefix(rootPath + "/") {
+                        let relative = String(path.dropFirst(rootPath.count + 1))
+                        if let first = relative.split(separator: "/").first,
+                           inPlaceSkipRoots.contains(String(first)) {
+                            continue
+                        }
+                    }
+                }
+                collected[path] = candidate
+            }
+        }
+        return collected.keys.sorted().compactMap { collected[$0] }
+    }
+}
+
+private func sequencedCategorizationDestination(
+    directory: URL,
+    sourceName: String,
+    sequence: Int
+) -> URL {
+    guard sequence > 1 else { return directory.appendingPathComponent(sourceName) }
+    let source = URL(fileURLWithPath: sourceName)
+    let ext = source.pathExtension
+    let stem = source.deletingPathExtension().lastPathComponent
+    let name = ext.isEmpty ? "\(stem) (\(sequence))" : "\(stem) (\(sequence)).\(ext)"
+    return directory.appendingPathComponent(name)
+}
+
+private func categorizationFilesMatch(_ lhs: URL, _ rhs: URL) throws -> Bool {
+    let leftAttributes = try FileManager.default.attributesOfItem(atPath: lhs.path)
+    let rightAttributes = try FileManager.default.attributesOfItem(atPath: rhs.path)
+    if (leftAttributes[.size] as? NSNumber)?.uint64Value
+        != (rightAttributes[.size] as? NSNumber)?.uint64Value {
+        return false
+    }
+    return try categorizationSHA256(lhs) == categorizationSHA256(rhs)
+}
+
+private func categorizationSHA256(_ url: URL) throws -> String {
+    let handle = try FileHandle(forReadingFrom: url)
+    defer { try? handle.close() }
+    var hasher = SHA256()
+    while true {
+        let chunk = try handle.read(upToCount: 1024 * 1024) ?? Data()
+        if chunk.isEmpty { break }
+        hasher.update(data: chunk)
+    }
+    return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+}

--- a/Sources/XDRemuxCore/Metadata/PhotoCategorization.swift
+++ b/Sources/XDRemuxCore/Metadata/PhotoCategorization.swift
@@ -2,6 +2,80 @@ import CryptoKit
 import Foundation
 import ImageIO
 
+public let photoClassificationLayoutVersion = "asset-type-v1"
+public let photoUnclassifiedFolderName = "未分类"
+
+public enum PhotoAssetType: String, CaseIterable, Codable, Sendable, Identifiable, Hashable {
+    case staticPhoto = "static-photo"
+    case livePhoto = "live-photo"
+
+    public var id: String { rawValue }
+
+    public var folderName: String {
+        switch self {
+        case .staticPhoto: return "静态照片"
+        case .livePhoto: return "实况照片"
+        }
+    }
+
+    public var tagID: String { "asset.\(rawValue)" }
+}
+
+public enum PhotoResourceRole: String, Codable, Sendable, Hashable {
+    case primaryImage = "primary-image"
+    case pairedVideo = "paired-video"
+    case sidecar
+}
+
+public struct PhotoResource: Codable, Sendable, Hashable {
+    public let url: URL
+    public let role: PhotoResourceRole
+
+    public init(url: URL, role: PhotoResourceRole) {
+        self.url = url
+        self.role = role
+    }
+}
+
+public struct PhotoAsset: Codable, Sendable, Identifiable, Hashable {
+    public let id: String
+    public let type: PhotoAssetType
+    public let resources: [PhotoResource]
+
+    public init(id: String, type: PhotoAssetType, resources: [PhotoResource]) {
+        self.id = id
+        self.type = type
+        self.resources = resources
+    }
+
+    public static func staticPhoto(_ url: URL) -> PhotoAsset {
+        PhotoAsset(
+            id: url.standardizedFileURL.path,
+            type: .staticPhoto,
+            resources: [PhotoResource(url: url, role: .primaryImage)]
+        )
+    }
+
+    public static func livePhoto(
+        imageURL: URL,
+        videoURL: URL,
+        id: String? = nil
+    ) -> PhotoAsset {
+        PhotoAsset(
+            id: id ?? imageURL.standardizedFileURL.path,
+            type: .livePhoto,
+            resources: [
+                PhotoResource(url: imageURL, role: .primaryImage),
+                PhotoResource(url: videoURL, role: .pairedVideo)
+            ]
+        )
+    }
+
+    public var primaryImageURL: URL? {
+        resources.first(where: { $0.role == .primaryImage })?.url
+    }
+}
+
 public enum OppoCaptureMode: String, CaseIterable, Codable, Sendable, Identifiable, Hashable {
     case normal
     case master
@@ -20,6 +94,7 @@ public enum OppoCaptureMode: String, CaseIterable, Codable, Sendable, Identifiab
     case beauty
 
     public var id: String { rawValue }
+    public var tagID: String { "capture.\(rawValue)" }
 
     public var folderName: String {
         switch self {
@@ -61,7 +136,23 @@ public enum OppoCaptureMode: String, CaseIterable, Codable, Sendable, Identifiab
         }
     }
 
-    fileprivate static let priority = allCases.filter { $0 != .normal }
+    /// Historical ordering is retained only for deterministic folder projection.
+    public static let folderProjectionPriority = allCases.filter { $0 != .normal }
+}
+
+public enum PhotoCapability: String, CaseIterable, Codable, Sendable, Hashable {
+    case proXDR = "proxdr"
+    case gainMap = "gain-map"
+    case hdr
+    case depth
+
+    public var tagID: String { "capability.\(rawValue)" }
+}
+
+public enum CameraVendor: String, Codable, Sendable, Hashable {
+    case oppo
+
+    public var tagID: String { "vendor.\(rawValue)" }
 }
 
 public enum OppoPhotoClassificationStatus: String, Codable, Sendable, Equatable {
@@ -72,25 +163,169 @@ public enum OppoPhotoClassificationStatus: String, Codable, Sendable, Equatable 
     case unreadableImage = "unreadable-image"
 }
 
-public struct OppoPhotoClassification: Sendable, Equatable {
-    public let rawUserComment: String?
-    public let tagFlags: UInt64?
+public enum PhotoMetadataReadStatus: String, Codable, Sendable, Equatable {
+    case ok
+    case missingUserComment = "missing-user-comment"
+    case malformedUserComment = "malformed-user-comment"
+    case unreadableImage = "unreadable-image"
+}
+
+public struct OppoFlagEvidence: Codable, Sendable, Equatable {
+    public let rawFlags: UInt64
+    public let recognizedFlags: UInt64
+    public let knownUnmappedFlags: UInt64
     public let unknownFlags: UInt64
-    public let mode: OppoCaptureMode?
-    public let status: OppoPhotoClassificationStatus
+
+    public init(
+        rawFlags: UInt64,
+        recognizedFlags: UInt64,
+        knownUnmappedFlags: UInt64,
+        unknownFlags: UInt64
+    ) {
+        self.rawFlags = rawFlags
+        self.recognizedFlags = recognizedFlags
+        self.knownUnmappedFlags = knownUnmappedFlags
+        self.unknownFlags = unknownFlags
+    }
+}
+
+public struct OppoPhotoClassification: Codable, Sendable, Equatable {
+    public let rawUserComment: String?
+    public let flagEvidence: OppoFlagEvidence?
+    public let captureModes: Set<OppoCaptureMode>
+    public let metadataStatus: PhotoMetadataReadStatus
 
     public init(
         rawUserComment: String?,
-        tagFlags: UInt64?,
-        unknownFlags: UInt64,
-        mode: OppoCaptureMode?,
-        status: OppoPhotoClassificationStatus
+        flagEvidence: OppoFlagEvidence?,
+        captureModes: Set<OppoCaptureMode>,
+        metadataStatus: PhotoMetadataReadStatus
     ) {
         self.rawUserComment = rawUserComment
-        self.tagFlags = tagFlags
-        self.unknownFlags = unknownFlags
-        self.mode = mode
-        self.status = status
+        self.flagEvidence = flagEvidence
+        self.captureModes = captureModes
+        self.metadataStatus = metadataStatus
+    }
+
+    public var tagFlags: UInt64? { flagEvidence?.rawFlags }
+    public var recognizedFlags: UInt64 { flagEvidence?.recognizedFlags ?? 0 }
+    public var knownUnmappedFlags: UInt64 { flagEvidence?.knownUnmappedFlags ?? 0 }
+    public var unknownFlags: UInt64 { flagEvidence?.unknownFlags ?? 0 }
+
+    public var status: OppoPhotoClassificationStatus {
+        switch metadataStatus {
+        case .missingUserComment: return .missingUserComment
+        case .malformedUserComment: return .malformedUserComment
+        case .unreadableImage: return .unreadableImage
+        case .ok:
+            if !captureModes.isEmpty || unknownFlags == 0 { return .categorized }
+            return .unknownFlags
+        }
+    }
+}
+
+public struct PhotoClassification: Codable, Sendable, Equatable {
+    public let assetType: PhotoAssetType
+    public let captureModes: Set<OppoCaptureMode>
+    public let capabilities: Set<PhotoCapability>
+    public let vendor: CameraVendor?
+    public let evidence: OppoPhotoClassification
+
+    public init(
+        assetType: PhotoAssetType,
+        captureModes: Set<OppoCaptureMode>,
+        capabilities: Set<PhotoCapability>,
+        vendor: CameraVendor?,
+        evidence: OppoPhotoClassification
+    ) {
+        self.assetType = assetType
+        self.captureModes = captureModes
+        self.capabilities = capabilities
+        self.vendor = vendor
+        self.evidence = evidence
+    }
+
+    public var rawUserComment: String? { evidence.rawUserComment }
+    public var tagFlags: UInt64? { evidence.tagFlags }
+    public var recognizedFlags: UInt64 { evidence.recognizedFlags }
+    public var knownUnmappedFlags: UInt64 { evidence.knownUnmappedFlags }
+    public var unknownFlags: UInt64 { evidence.unknownFlags }
+    public var metadataStatus: PhotoMetadataReadStatus { evidence.metadataStatus }
+    public var status: OppoPhotoClassificationStatus { evidence.status }
+
+    /// Compatibility view for old callers. The semantic source of truth is `captureModes`; this is
+    /// only the deterministic physical-folder projection.
+    public var mode: OppoCaptureMode? { PhotoFolderProjection.primaryCaptureMode(for: self) }
+
+    public var tags: [String] {
+        var values = Set<String>()
+        values.insert(assetType.tagID)
+        values.formUnion(captureModes.map(\.tagID))
+        values.formUnion(capabilities.map(\.tagID))
+        if let vendor { values.insert(vendor.tagID) }
+        return values.sorted()
+    }
+}
+
+public enum PhotoFolderProjection {
+    public static let layoutVersion = photoClassificationLayoutVersion
+    public static let rootFolderNames = Set(PhotoAssetType.allCases.map(\.folderName))
+    public static let unclassifiedFolderName = photoUnclassifiedFolderName
+
+    public static func primaryCaptureMode(for classification: PhotoClassification) -> OppoCaptureMode? {
+        for candidate in OppoCaptureMode.folderProjectionPriority
+        where classification.captureModes.contains(candidate) {
+            return candidate
+        }
+        // `normal` is a folder/presentation fallback, not an activated semantic tag. Preserve the
+        // historical normal handling for zero and known-but-unmapped OPPO bits, but do not hide
+        // completely unknown flags under the normal folder.
+        if classification.metadataStatus == .ok,
+           classification.tagFlags != nil,
+           classification.unknownFlags == 0 {
+            return .normal
+        }
+        return nil
+    }
+
+    public static func relativeDirectoryComponents(
+        for classification: PhotoClassification,
+        assetType: PhotoAssetType? = nil
+    ) -> [String] {
+        let resolvedType = assetType ?? classification.assetType
+        let leaf = primaryCaptureMode(for: classification)?.folderName ?? photoUnclassifiedFolderName
+        return [resolvedType.folderName, leaf]
+    }
+
+    public static func relativeDirectory(
+        for classification: PhotoClassification,
+        assetType: PhotoAssetType? = nil
+    ) -> String {
+        relativeDirectoryComponents(for: classification, assetType: assetType).joined(separator: "/")
+    }
+}
+
+public struct PhotoClassificationContract: Codable, Sendable, Equatable {
+    public let assetType: String
+    public let captureModes: [String]
+    public let primaryCaptureMode: String?
+    public let folder: String
+    public let metadataStatus: String
+    public let recognizedFlags: UInt64
+    public let knownUnmappedFlags: UInt64
+    public let unknownFlags: UInt64
+    public let tags: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case assetType = "asset_type"
+        case captureModes = "capture_modes"
+        case primaryCaptureMode = "primary_capture_mode"
+        case folder
+        case metadataStatus = "metadata_status"
+        case recognizedFlags = "recognized_flags"
+        case knownUnmappedFlags = "known_unmapped_flags"
+        case unknownFlags = "unknown_flags"
+        case tags
     }
 }
 
@@ -105,7 +340,7 @@ public enum PhotoCategorizationDisposition: String, Codable, Sendable {
 public struct PhotoCategorizationItem: Sendable, Identifiable {
     public let sourceURL: URL
     public let destinationURL: URL
-    public let classification: OppoPhotoClassification
+    public let classification: PhotoClassification
     public let disposition: PhotoCategorizationDisposition
     public let errorDescription: String?
 
@@ -114,7 +349,7 @@ public struct PhotoCategorizationItem: Sendable, Identifiable {
     public init(
         sourceURL: URL,
         destinationURL: URL,
-        classification: OppoPhotoClassification,
+        classification: PhotoClassification,
         disposition: PhotoCategorizationDisposition,
         errorDescription: String? = nil
     ) {
@@ -144,7 +379,9 @@ public struct PhotoCategorizationResult: Sendable {
     public var duplicateCount: Int { items.count { $0.disposition == .duplicate } }
     public var failedCount: Int { items.count { $0.disposition == .failed } }
     public var categorizedCount: Int { items.count { $0.classification.mode != nil } }
-    public var rootCount: Int { items.count { $0.classification.mode == nil } }
+    public var unclassifiedCount: Int { items.count { $0.classification.mode == nil } }
+    /// Compatibility alias. V1 no longer writes uncategorized photos to the output root.
+    public var rootCount: Int { unclassifiedCount }
     public var issueCount: Int {
         items.count {
             $0.disposition == .failed
@@ -160,7 +397,8 @@ public struct PhotoCategorizationResult: Sendable {
 
 public enum PhotoCategorizationEngine {
     private static let supportedExtensions = Set(["heic", "heif", "jpg", "jpeg"])
-    private static let captureModeFolderNames = Set(OppoCaptureMode.allCases.map(\.folderName))
+    private static let legacyCaptureModeFolderNames = Set(OppoCaptureMode.allCases.map(\.folderName))
+    private static let projectionRootFolderNames = Set(PhotoAssetType.allCases.map(\.folderName))
     private static let knownFlagsMask: UInt64 = [
         0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
         0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000, 0x8000,
@@ -169,58 +407,117 @@ public enum PhotoCategorizationEngine {
         0x800_0000, 0x1000_0000, 0x2000_0000, 0x4000_0000, 0x8000_0000,
         0x1_0000_0000, 0x2_0000_0000, 0x4000_0000_0000_0000
     ].reduce(0, |)
+    private static let mappedFlagsMask: UInt64 = OppoCaptureMode.folderProjectionPriority
+        .map(\.bit)
+        .reduce(0, |)
 
-    public static func classify(userComment: String?) -> OppoPhotoClassification {
+    public static func classify(
+        userComment: String?,
+        assetType: PhotoAssetType = .staticPhoto,
+        capabilities: Set<PhotoCapability> = []
+    ) -> PhotoClassification {
+        let evidence: OppoPhotoClassification
+        let vendor: CameraVendor?
         guard let raw = userComment?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
-            return OppoPhotoClassification(
+            evidence = OppoPhotoClassification(
                 rawUserComment: userComment,
-                tagFlags: nil,
-                unknownFlags: 0,
-                mode: nil,
-                status: .missingUserComment
+                flagEvidence: nil,
+                captureModes: [],
+                metadataStatus: .missingUserComment
+            )
+            return PhotoClassification(
+                assetType: assetType,
+                captureModes: [],
+                capabilities: capabilities,
+                vendor: nil,
+                evidence: evidence
             )
         }
         guard let flags = parseFlags(from: raw) else {
-            return OppoPhotoClassification(
+            evidence = OppoPhotoClassification(
                 rawUserComment: raw,
-                tagFlags: nil,
-                unknownFlags: 0,
-                mode: nil,
-                status: .malformedUserComment
+                flagEvidence: nil,
+                captureModes: [],
+                metadataStatus: .malformedUserComment
+            )
+            return PhotoClassification(
+                assetType: assetType,
+                captureModes: [],
+                capabilities: capabilities,
+                vendor: nil,
+                evidence: evidence
             )
         }
 
+        let recognized = flags & mappedFlagsMask
+        let knownUnmapped = flags & knownFlagsMask & ~mappedFlagsMask
         let unknown = flags & ~knownFlagsMask
-        let mode = OppoCaptureMode.priority.first { flags & $0.bit != 0 }
-        if mode == nil, unknown != 0 {
-            return OppoPhotoClassification(
-                rawUserComment: raw,
-                tagFlags: flags,
-                unknownFlags: unknown,
-                mode: nil,
-                status: .unknownFlags
-            )
-        }
-        return OppoPhotoClassification(
+        let modes = Set(OppoCaptureMode.folderProjectionPriority.filter { flags & $0.bit != 0 })
+        evidence = OppoPhotoClassification(
             rawUserComment: raw,
-            tagFlags: flags,
-            unknownFlags: unknown,
-            mode: mode ?? .normal,
-            status: .categorized
+            flagEvidence: OppoFlagEvidence(
+                rawFlags: flags,
+                recognizedFlags: recognized,
+                knownUnmappedFlags: knownUnmapped,
+                unknownFlags: unknown
+            ),
+            captureModes: modes,
+            metadataStatus: .ok
+        )
+        vendor = .oppo
+        return PhotoClassification(
+            assetType: assetType,
+            captureModes: modes,
+            capabilities: capabilities,
+            vendor: vendor,
+            evidence: evidence
         )
     }
 
-    public static func classify(at url: URL) -> OppoPhotoClassification {
-        guard let data = try? Data(contentsOf: url) else {
-            return OppoPhotoClassification(
+    public static func classify(asset: PhotoAsset) -> PhotoClassification {
+        guard let primaryImageURL = asset.primaryImageURL else {
+            let evidence = OppoPhotoClassification(
                 rawUserComment: nil,
-                tagFlags: nil,
-                unknownFlags: 0,
-                mode: nil,
-                status: .unreadableImage
+                flagEvidence: nil,
+                captureModes: [],
+                metadataStatus: .unreadableImage
+            )
+            return PhotoClassification(
+                assetType: asset.type,
+                captureModes: [],
+                capabilities: [],
+                vendor: nil,
+                evidence: evidence
             )
         }
-        return classify(userComment: extractedUserComment(from: data))
+        return classify(at: primaryImageURL, assetType: asset.type)
+    }
+
+    public static func classify(
+        at url: URL,
+        assetType: PhotoAssetType? = nil
+    ) -> PhotoClassification {
+        let resolvedAssetType = assetType ?? inferredAssetType(at: url)
+        guard let data = try? Data(contentsOf: url) else {
+            let evidence = OppoPhotoClassification(
+                rawUserComment: nil,
+                flagEvidence: nil,
+                captureModes: [],
+                metadataStatus: .unreadableImage
+            )
+            return PhotoClassification(
+                assetType: resolvedAssetType,
+                captureModes: [],
+                capabilities: [],
+                vendor: nil,
+                evidence: evidence
+            )
+        }
+        return classify(
+            userComment: extractedUserComment(from: data),
+            assetType: resolvedAssetType,
+            capabilities: detectedCapabilities(in: data)
+        )
     }
 
     public static func makePlan(
@@ -235,9 +532,10 @@ public enum PhotoCategorizationEngine {
         for source in sources {
             let classification = classify(at: source)
             let destinationRoot = outputDirectory ?? source.deletingLastPathComponent()
-            let destinationDirectory = classification.mode.map {
-                destinationRoot.appendingPathComponent($0.folderName, isDirectory: true)
-            } ?? destinationRoot
+            let destinationDirectory = PhotoFolderProjection.relativeDirectoryComponents(for: classification)
+                .reduce(destinationRoot) { partial, component in
+                    partial.appendingPathComponent(component, isDirectory: true)
+                }
             let sourceDigest = try sha256Hex(source)
             var sequence = 1
             while true {
@@ -340,8 +638,51 @@ public enum PhotoCategorizationEngine {
         return PhotoCategorizationResult(items: ordered)
     }
 
-    public static func categorizedDirectory(for url: URL) -> String? {
-        classify(at: url).mode?.folderName
+    public static func categorizedDirectory(
+        for url: URL,
+        assetType: PhotoAssetType? = nil
+    ) -> String? {
+        PhotoFolderProjection.relativeDirectory(for: classify(at: url, assetType: assetType))
+    }
+
+    public static func classificationContract(
+        for classification: PhotoClassification
+    ) -> PhotoClassificationContract {
+        let mode = classification.mode
+        return PhotoClassificationContract(
+            assetType: classification.assetType.rawValue,
+            captureModes: OppoCaptureMode.folderProjectionPriority
+                .filter { classification.captureModes.contains($0) }
+                .map(\.rawValue),
+            primaryCaptureMode: mode?.rawValue,
+            folder: mode?.folderName ?? photoUnclassifiedFolderName,
+            metadataStatus: classification.metadataStatus.rawValue,
+            recognizedFlags: classification.recognizedFlags,
+            knownUnmappedFlags: classification.knownUnmappedFlags,
+            unknownFlags: classification.unknownFlags,
+            tags: classification.tags
+        )
+    }
+
+    public static func inferredAssetType(at url: URL) -> PhotoAssetType {
+        let ext = url.pathExtension.lowercased()
+        guard ext == "jpg" || ext == "jpeg" || ext == "heic" || ext == "heif" else {
+            return .staticPhoto
+        }
+        return ((try? OppoMotionPhotoParser.parse(url: url)) ?? nil) == nil ? .staticPhoto : .livePhoto
+    }
+
+    private static func detectedCapabilities(in data: Data) -> Set<PhotoCapability> {
+        var capabilities = Set<PhotoCapability>()
+        let privateGainMapNames = ["\"local.uhdr.gainmap.data\"", "\"local.uhdr.gainmap.info\""]
+        if privateGainMapNames.contains(where: { data.range(of: Data($0.utf8)) != nil }) {
+            capabilities.formUnion([.proXDR, .gainMap, .hdr])
+        }
+        if data.range(of: Data("\"rear.depth\"".utf8)) != nil,
+           data.range(of: Data("\"rear.depth.config\"".utf8)) != nil {
+            capabilities.insert(.depth)
+        }
+        return capabilities
     }
 
     private static func parseFlags(from raw: String) -> UInt64? {
@@ -469,6 +810,7 @@ public enum PhotoCategorizationEngine {
     ) throws -> [URL] {
         let excluded = outputDirectory?.standardizedFileURL.path
         var collected: [String: URL] = [:]
+        let inPlaceSkipRoots = projectionRootFolderNames.union(legacyCaptureModeFolderNames)
         for input in inputs {
             var isDirectory: ObjCBool = false
             guard fileManager.fileExists(atPath: input.path, isDirectory: &isDirectory) else {
@@ -485,6 +827,7 @@ public enum PhotoCategorizationEngine {
                 includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey],
                 options: [.skipsHiddenFiles]
             ) else { throw XDRemuxError.unableToRead(input) }
+            let inputRoot = input.standardizedFileURL.path
             for case let url as URL in enumerator {
                 let path = url.standardizedFileURL.path
                 let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
@@ -493,7 +836,8 @@ public enum PhotoCategorizationEngine {
                     continue
                 }
                 if outputDirectory == nil, isDirectory,
-                   captureModeFolderNames.contains(url.lastPathComponent) {
+                   url.deletingLastPathComponent().standardizedFileURL.path == inputRoot,
+                   inPlaceSkipRoots.contains(url.lastPathComponent) {
                     enumerator.skipDescendants()
                     continue
                 }

--- a/Tests/XDRemuxCLITests/MotionPhotoBatchPlannerTests.swift
+++ b/Tests/XDRemuxCLITests/MotionPhotoBatchPlannerTests.swift
@@ -3,78 +3,89 @@ import XCTest
 @testable import XDRemuxCLI
 
 final class MotionPhotoBatchPlannerTests: XCTestCase {
-    func testDuplicateBasenamesRemainDistinctAndStableAcrossSubsetRuns() throws {
+    func testPreferredOutputPreservesUserBasenameForJPEGAndHEIC() {
+        let root = URL(fileURLWithPath: "/tmp/xdremux-input", isDirectory: true)
+        let output = URL(fileURLWithPath: "/tmp/xdremux-output", isDirectory: true)
+
+        for name in ["IMG.jpg", "IMG.heic", "IMG.heif"] {
+            let planned = MotionPhotoBatchPlanner.outputImageURL(
+                for: root.appendingPathComponent(name),
+                inputRootURL: root,
+                outputDirectoryURL: output
+            )
+            XCTAssertEqual(planned.lastPathComponent, "IMG.heic")
+        }
+    }
+
+    func testDuplicateBasenamesReceiveSequenceOnlyAtCollision() {
         let root = URL(fileURLWithPath: "/tmp/xdremux-input", isDirectory: true)
         let output = URL(fileURLWithPath: "/tmp/xdremux-output", isDirectory: true)
         let a = root.appendingPathComponent("A/IMG.jpg")
         let b = root.appendingPathComponent("B/IMG.jpg")
+        var reserved = Set<String>()
 
-        let aOutput = MotionPhotoBatchPlanner.outputImageURL(
+        let aOutput = MotionPhotoBatchPlanner.reserveOutputImageURL(
             for: a,
             inputRootURL: root,
-            outputDirectoryURL: output
+            outputDirectoryURL: output,
+            reservedPaths: &reserved,
+            fileExists: { _ in false }
         )
-        let bOutput = MotionPhotoBatchPlanner.outputImageURL(
+        let bOutput = MotionPhotoBatchPlanner.reserveOutputImageURL(
             for: b,
             inputRootURL: root,
-            outputDirectoryURL: output
-        )
-        let bSubsetOutput = MotionPhotoBatchPlanner.outputImageURL(
-            for: b,
-            inputRootURL: root,
-            outputDirectoryURL: output
+            outputDirectoryURL: output,
+            reservedPaths: &reserved,
+            fileExists: { _ in false }
         )
 
-        XCTAssertNotEqual(aOutput, bOutput)
-        XCTAssertEqual(bOutput, bSubsetOutput)
-        XCTAssertTrue(aOutput.lastPathComponent.hasPrefix("IMG~"))
-        XCTAssertTrue(bOutput.lastPathComponent.hasPrefix("IMG~"))
-        XCTAssertEqual(aOutput.pathExtension, "heic")
+        XCTAssertEqual(aOutput.lastPathComponent, "IMG.heic")
+        XCTAssertEqual(bOutput.lastPathComponent, "IMG (2).heic")
+        XCTAssertTrue(reserved.contains(output.appendingPathComponent("IMG.mov").standardizedFileURL.path))
+        XCTAssertTrue(reserved.contains(output.appendingPathComponent("IMG (2).mov").standardizedFileURL.path))
     }
 
-    func testSameRelativePathInDifferentInputRootsCannotAliasSharedOutputDirectory() {
-        let firstRoot = URL(fileURLWithPath: "/tmp/xdremux-root-one", isDirectory: true)
-        let secondRoot = URL(fileURLWithPath: "/tmp/xdremux-root-two", isDirectory: true)
-        let output = URL(fileURLWithPath: "/tmp/xdremux-shared-output", isDirectory: true)
-        let first = firstRoot.appendingPathComponent("A/IMG.jpg")
-        let second = secondRoot.appendingPathComponent("A/IMG.jpg")
-
-        let firstOutput = MotionPhotoBatchPlanner.outputImageURL(
-            for: first,
-            inputRootURL: firstRoot,
-            outputDirectoryURL: output
-        )
-        let secondOutput = MotionPhotoBatchPlanner.outputImageURL(
-            for: second,
-            inputRootURL: secondRoot,
-            outputDirectoryURL: output
-        )
-
-        XCTAssertNotEqual(firstOutput, secondOutput)
-    }
-
-    func testHEIFMotionPhotoUsesSeparateLiveNamespace() {
+    func testHEICSourceInSameDirectoryUsesSequenceInsteadOfLiveMarker() {
         let root = URL(fileURLWithPath: "/tmp/xdremux-input", isDirectory: true)
-        let output = URL(fileURLWithPath: "/tmp/xdremux-output", isDirectory: true)
         let input = root.appendingPathComponent("IMG.heic")
-        let planned = MotionPhotoBatchPlanner.outputImageURL(
+        var reserved = Set<String>()
+        let planned = MotionPhotoBatchPlanner.reserveOutputImageURL(
             for: input,
             inputRootURL: root,
-            outputDirectoryURL: output
+            outputDirectoryURL: root,
+            reservedPaths: &reserved,
+            fileExists: { _ in false }
         )
-        XCTAssertTrue(planned.lastPathComponent.hasPrefix("IMG.live~"))
-        XCTAssertEqual(planned.pathExtension, "heic")
+        XCTAssertEqual(planned.lastPathComponent, "IMG (2).heic")
     }
 
-    func testPlannerRejectsDuplicateDestinationInsteadOfRenumberingByOrder() {
-        let first = URL(fileURLWithPath: "/tmp/a.jpg")
-        let second = URL(fileURLWithPath: "/tmp/b.jpg")
-        let output = URL(fileURLWithPath: "/tmp/result.heic")
-        XCTAssertThrowsError(
-            try MotionPhotoBatchPlanner.validateUnique([
-                (input: first, output: output),
-                (input: second, output: output),
-            ])
+    func testForeignExistingPairSequencesButProvenanceCanKeepOriginalName() {
+        let root = URL(fileURLWithPath: "/tmp/xdremux-input", isDirectory: true)
+        let output = URL(fileURLWithPath: "/tmp/xdremux-output", isDirectory: true)
+        let input = root.appendingPathComponent("IMG.jpg")
+        let original = output.appendingPathComponent("IMG.heic")
+        var foreignReserved = Set<String>()
+
+        let foreign = MotionPhotoBatchPlanner.reserveOutputImageURL(
+            for: input,
+            inputRootURL: root,
+            outputDirectoryURL: output,
+            reservedPaths: &foreignReserved,
+            fileExists: { $0.lastPathComponent == "IMG.heic" || $0.lastPathComponent == "IMG.mov" }
         )
+        XCTAssertEqual(foreign.lastPathComponent, "IMG (2).heic")
+
+        var ownedReserved = Set<String>()
+        let owned = MotionPhotoBatchPlanner.reserveOutputImageURL(
+            for: input,
+            inputRootURL: root,
+            outputDirectoryURL: output,
+            reservedPaths: &ownedReserved,
+            candidateBelongsToSource: { image, video in
+                image == original && video == output.appendingPathComponent("IMG.mov")
+            },
+            fileExists: { _ in true }
+        )
+        XCTAssertEqual(owned.lastPathComponent, "IMG.heic")
     }
 }

--- a/Tests/XDRemuxCoreTests/CoreContractTests.swift
+++ b/Tests/XDRemuxCoreTests/CoreContractTests.swift
@@ -49,7 +49,13 @@ final class CoreContractTests: XCTestCase {
         XCTAssertEqual(plan.items.count, 3)
         XCTAssertEqual(plan.items[0].destinationURL.deletingLastPathComponent().lastPathComponent, "人像")
         XCTAssertEqual(plan.items[1].destinationURL.lastPathComponent, "plain.jpg")
-        XCTAssertEqual(plan.items[1].destinationURL.deletingLastPathComponent(), output)
+        let unclassifiedDirectory = output
+            .appendingPathComponent("静态照片", isDirectory: true)
+            .appendingPathComponent("未分类", isDirectory: true)
+        XCTAssertEqual(
+            plan.items[1].destinationURL.deletingLastPathComponent().standardizedFileURL.path,
+            unclassifiedDirectory.standardizedFileURL.path
+        )
         XCTAssertEqual(plan.items[2].destinationURL.lastPathComponent, "same (2).heic")
 
         let result = PhotoCategorizationEngine.execute(plan, jobs: 2)
@@ -57,6 +63,56 @@ final class CoreContractTests: XCTestCase {
         let repeated = try PhotoCategorizationEngine.makePlan(inputs: [input], outputDirectory: output)
         XCTAssertEqual(repeated.items.count, 3)
         XCTAssertTrue(repeated.items.allSatisfy { $0.disposition == .duplicate })
+    }
+
+    func testPhotoCategorizationKeepsValidatedLivePhotoResourcesTogether() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-categorize-live-pair-\(UUID().uuidString)", isDirectory: true)
+        let input = root.appendingPathComponent("input", isDirectory: true)
+        let output = root.appendingPathComponent("output", isDirectory: true)
+        try FileManager.default.createDirectory(at: input, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let image = input.appendingPathComponent("pair.heic")
+        let video = input.appendingPathComponent("pair.mov")
+        try Data("oplus_18".utf8).write(to: image)
+        try Data("paired-video".utf8).write(to: video)
+
+        let occupied = output
+            .appendingPathComponent("实况照片", isDirectory: true)
+            .appendingPathComponent("人像", isDirectory: true)
+        try FileManager.default.createDirectory(at: occupied, withIntermediateDirectories: true)
+        try Data("foreign-image".utf8).write(to: occupied.appendingPathComponent("pair.heic"))
+
+        let paired = try PhotoCategorizationEngine.makePlan(
+            inputs: [input],
+            outputDirectory: output,
+            livePhotoPairValidator: { candidateImage, candidateVideo in
+                candidateImage.lastPathComponent == "pair.heic"
+                    && candidateVideo.lastPathComponent == "pair.mov"
+            }
+        )
+        XCTAssertEqual(paired.items.count, 2)
+        XCTAssertTrue(paired.items.allSatisfy { $0.classification.assetType == .livePhoto })
+        XCTAssertEqual(
+            Set(paired.items.map(\.destinationURL.lastPathComponent)),
+            Set(["pair (2).heic", "pair (2).mov"])
+        )
+        XCTAssertTrue(paired.items.allSatisfy {
+            $0.destinationURL.path.contains("实况照片/人像/")
+        })
+
+        let rejected = try PhotoCategorizationEngine.makePlan(
+            inputs: [input],
+            outputDirectory: output,
+            livePhotoPairValidator: { _, _ in false }
+        )
+        XCTAssertEqual(rejected.items.count, 1)
+        XCTAssertEqual(
+            rejected.items[0].sourceURL.resolvingSymlinksInPath().standardizedFileURL.path,
+            image.resolvingSymlinksInPath().standardizedFileURL.path
+        )
+        XCTAssertEqual(rejected.items[0].classification.assetType, .staticPhoto)
     }
 
     func testPhotoCategorizationReadsTIFFUserCommentBytes() throws {

--- a/Tests/XDRemuxCoreTests/PhotoClassificationContractTests.swift
+++ b/Tests/XDRemuxCoreTests/PhotoClassificationContractTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import XCTest
+@testable import XDRemuxCore
+
+final class PhotoClassificationContractTests: XCTestCase {
+    private struct ContractCase: Decodable {
+        let name: String
+        let userComment: String?
+        let assetType: String
+        let captureModes: [String]
+        let primaryCaptureMode: String?
+        let folder: String
+        let metadataStatus: String
+        let recognizedFlags: UInt64
+        let knownUnmappedFlags: UInt64
+        let unknownFlags: UInt64
+        let tags: [String]
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case userComment = "user_comment"
+            case assetType = "asset_type"
+            case captureModes = "capture_modes"
+            case primaryCaptureMode = "primary_capture_mode"
+            case folder
+            case metadataStatus = "metadata_status"
+            case recognizedFlags = "recognized_flags"
+            case knownUnmappedFlags = "known_unmapped_flags"
+            case unknownFlags = "unknown_flags"
+            case tags
+        }
+    }
+
+    func testCanonicalGoldenContract() throws {
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("fixtures/photo_classification_cases.json")
+        let cases = try JSONDecoder().decode([ContractCase].self, from: Data(contentsOf: fixtureURL))
+
+        for item in cases {
+            guard let assetType = PhotoAssetType(rawValue: item.assetType) else {
+                return XCTFail("unknown asset type in fixture: \(item.assetType)")
+            }
+            let classification = PhotoCategorizationEngine.classify(
+                userComment: item.userComment,
+                assetType: assetType
+            )
+            let contract = PhotoCategorizationEngine.classificationContract(for: classification)
+            XCTAssertEqual(contract.assetType, item.assetType, item.name)
+            XCTAssertEqual(contract.captureModes, item.captureModes, item.name)
+            XCTAssertEqual(contract.primaryCaptureMode, item.primaryCaptureMode, item.name)
+            XCTAssertEqual(contract.folder, item.folder, item.name)
+            XCTAssertEqual(contract.metadataStatus, item.metadataStatus, item.name)
+            XCTAssertEqual(contract.recognizedFlags, item.recognizedFlags, item.name)
+            XCTAssertEqual(contract.knownUnmappedFlags, item.knownUnmappedFlags, item.name)
+            XCTAssertEqual(contract.unknownFlags, item.unknownFlags, item.name)
+            XCTAssertEqual(contract.tags, item.tags, item.name)
+        }
+    }
+
+    func testMultiBitFlagsAreLosslessButFolderProjectionIsStable() {
+        let classification = PhotoCategorizationEngine.classify(userComment: "oplus_18")
+        XCTAssertEqual(classification.captureModes, Set([.portrait, .beauty]))
+        XCTAssertEqual(classification.mode, .portrait)
+        XCTAssertFalse(classification.tags.contains("capture.normal"))
+        XCTAssertTrue(classification.tags.contains("capture.portrait"))
+        XCTAssertTrue(classification.tags.contains("capture.beauty"))
+    }
+
+    func testUnknownFlagsAreIndependentFromMetadataReadStatus() {
+        let known = PhotoCategorizationEngine.classify(userComment: "oplus_262144")
+        XCTAssertEqual(known.knownUnmappedFlags, 262144)
+        XCTAssertEqual(known.unknownFlags, 0)
+        XCTAssertEqual(known.metadataStatus, .ok)
+        XCTAssertEqual(known.mode, .normal)
+
+        let unknown = PhotoCategorizationEngine.classify(userComment: "oplus_17179869184")
+        XCTAssertEqual(unknown.knownUnmappedFlags, 0)
+        XCTAssertEqual(unknown.unknownFlags, 17179869184)
+        XCTAssertEqual(unknown.metadataStatus, .ok)
+        XCTAssertNil(unknown.mode)
+        XCTAssertEqual(unknown.status, .unknownFlags)
+    }
+
+    func testFolderProjectionSeparatesAssetTypeFromCaptureTags() {
+        let classification = PhotoCategorizationEngine.classify(userComment: "oplus_18")
+        XCTAssertEqual(
+            PhotoFolderProjection.relativeDirectory(for: classification),
+            "静态照片/人像"
+        )
+        XCTAssertEqual(
+            PhotoFolderProjection.relativeDirectory(for: classification, assetType: .livePhoto),
+            "实况照片/人像"
+        )
+        XCTAssertEqual(PhotoFolderProjection.layoutVersion, "asset-type-v1")
+    }
+
+    func testPhotoAssetKeepsLivePhotoResourcesTogether() {
+        let image = URL(fileURLWithPath: "/tmp/IMG.heic")
+        let video = URL(fileURLWithPath: "/tmp/IMG.mov")
+        let asset = PhotoAsset.livePhoto(imageURL: image, videoURL: video, id: "asset-id")
+        XCTAssertEqual(asset.type, .livePhoto)
+        XCTAssertEqual(asset.primaryImageURL, image)
+        XCTAssertEqual(asset.resources.map(\.role), [.primaryImage, .pairedVideo])
+    }
+
+    func testCapabilitiesRequireCompleteManifestEntryNames() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xdremux-classification-capabilities-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let complete = root.appendingPathComponent("complete.heic")
+        let completePayload = "oplus_18 {\"name\":\"local.uhdr.gainmap.data\"} "
+            + "{\"name\":\"rear.depth\"} {\"name\":\"rear.depth.config\"}"
+        try Data(completePayload.utf8).write(to: complete)
+        let classification = PhotoCategorizationEngine.classify(at: complete, assetType: .staticPhoto)
+        XCTAssertEqual(classification.capabilities, Set([.proXDR, .gainMap, .hdr, .depth]))
+
+        let configOnly = root.appendingPathComponent("config-only.heic")
+        try Data("oplus_18 {\"name\":\"rear.depth.config\"}".utf8).write(to: configOnly)
+        let configClassification = PhotoCategorizationEngine.classify(
+            at: configOnly,
+            assetType: .staticPhoto
+        )
+        XCTAssertFalse(configClassification.capabilities.contains(.depth))
+    }
+}

--- a/Tests/fixtures/photo_classification_cases.json
+++ b/Tests/fixtures/photo_classification_cases.json
@@ -1,0 +1,403 @@
+[
+  {
+    "name": "normal-zero",
+    "user_comment": "oplus_0",
+    "asset_type": "static-photo",
+    "capture_modes": [],
+    "primary_capture_mode": "normal",
+    "folder": "普通拍照",
+    "metadata_status": "ok",
+    "recognized_flags": 0,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "normal-local-hdr",
+    "user_comment": "Oplus_262144",
+    "asset_type": "static-photo",
+    "capture_modes": [],
+    "primary_capture_mode": "normal",
+    "folder": "普通拍照",
+    "metadata_status": "ok",
+    "recognized_flags": 0,
+    "known_unmapped_flags": 262144,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "normal-known-uint64-additional-bit",
+    "user_comment": "oplus_4611686018427387904",
+    "asset_type": "static-photo",
+    "capture_modes": [],
+    "primary_capture_mode": "normal",
+    "folder": "普通拍照",
+    "metadata_status": "ok",
+    "recognized_flags": 0,
+    "known_unmapped_flags": 4611686018427387904,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "master-over-professional",
+    "user_comment": "oplus_4294967552",
+    "asset_type": "static-photo",
+    "capture_modes": [
+      "master",
+      "professional"
+    ],
+    "primary_capture_mode": "master",
+    "folder": "大师模式",
+    "metadata_status": "ok",
+    "recognized_flags": 4294967552,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo",
+      "capture.master",
+      "capture.professional",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "ricoh-gr",
+    "user_comment": "oplus_2147483648",
+    "asset_type": "static-photo",
+    "capture_modes": [
+      "ricoh-gr"
+    ],
+    "primary_capture_mode": "ricoh-gr",
+    "folder": "RICOH GR",
+    "metadata_status": "ok",
+    "recognized_flags": 2147483648,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo",
+      "capture.ricoh-gr",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "professional",
+    "user_comment": "oplus_256",
+    "asset_type": "static-photo",
+    "capture_modes": [
+      "professional"
+    ],
+    "primary_capture_mode": "professional",
+    "folder": "专业模式",
+    "metadata_status": "ok",
+    "recognized_flags": 256,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo",
+      "capture.professional",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "portrait-over-beauty",
+    "user_comment": "oplus_18",
+    "asset_type": "static-photo",
+    "capture_modes": [
+      "portrait",
+      "beauty"
+    ],
+    "primary_capture_mode": "portrait",
+    "folder": "人像",
+    "metadata_status": "ok",
+    "recognized_flags": 18,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo",
+      "capture.beauty",
+      "capture.portrait",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "portrait-beauty-live-photo",
+    "user_comment": "oplus_18",
+    "asset_type": "live-photo",
+    "capture_modes": [
+      "portrait",
+      "beauty"
+    ],
+    "primary_capture_mode": "portrait",
+    "folder": "人像",
+    "metadata_status": "ok",
+    "recognized_flags": 18,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.live-photo",
+      "capture.beauty",
+      "capture.portrait",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "night",
+    "user_comment": "oplus_2048",
+    "asset_type": "static-photo",
+    "capture_modes": [
+      "night"
+    ],
+    "primary_capture_mode": "night",
+    "folder": "夜景",
+    "metadata_status": "ok",
+    "recognized_flags": 2048,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo",
+      "capture.night",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "panorama-oppo-prefix",
+    "user_comment": "Oppo_4",
+    "asset_type": "static-photo",
+    "capture_modes": [
+      "panorama"
+    ],
+    "primary_capture_mode": "panorama",
+    "folder": "全景",
+    "metadata_status": "ok",
+    "recognized_flags": 4,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo",
+      "capture.panorama",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "time-lapse",
+    "user_comment": "oplus_8",
+    "asset_type": "static-photo",
+    "capture_modes": [
+      "time-lapse"
+    ],
+    "primary_capture_mode": "time-lapse",
+    "folder": "延时摄影",
+    "metadata_status": "ok",
+    "recognized_flags": 8,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo",
+      "capture.time-lapse",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "ultra-high-resolution",
+    "user_comment": "oplus_8192",
+    "asset_type": "static-photo",
+    "capture_modes": [
+      "ultra-high-resolution"
+    ],
+    "primary_capture_mode": "ultra-high-resolution",
+    "folder": "超清",
+    "metadata_status": "ok",
+    "recognized_flags": 8192,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo",
+      "capture.ultra-high-resolution",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "id-photo",
+    "user_comment": "oplus_16384",
+    "asset_type": "static-photo",
+    "capture_modes": [
+      "id-photo"
+    ],
+    "primary_capture_mode": "id-photo",
+    "folder": "证件照",
+    "metadata_status": "ok",
+    "recognized_flags": 16384,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo",
+      "capture.id-photo",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "sticker",
+    "user_comment": "oplus_512",
+    "asset_type": "static-photo",
+    "capture_modes": [
+      "sticker"
+    ],
+    "primary_capture_mode": "sticker",
+    "folder": "贴纸",
+    "metadata_status": "ok",
+    "recognized_flags": 512,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo",
+      "capture.sticker",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "enhanced-text-ascii",
+    "user_comment": "ASCIIOplus_4096",
+    "asset_type": "static-photo",
+    "capture_modes": [
+      "enhanced-text"
+    ],
+    "primary_capture_mode": "enhanced-text",
+    "folder": "超级文本",
+    "metadata_status": "ok",
+    "recognized_flags": 4096,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo",
+      "capture.enhanced-text",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "group-photo-json",
+    "user_comment": "{\"oplustag\":4194304}",
+    "asset_type": "static-photo",
+    "capture_modes": [
+      "group-photo"
+    ],
+    "primary_capture_mode": "group-photo",
+    "folder": "合影",
+    "metadata_status": "ok",
+    "recognized_flags": 4194304,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo",
+      "capture.group-photo",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "double-exposure",
+    "user_comment": "oplus_32768",
+    "asset_type": "static-photo",
+    "capture_modes": [
+      "double-exposure"
+    ],
+    "primary_capture_mode": "double-exposure",
+    "folder": "双重曝光",
+    "metadata_status": "ok",
+    "recognized_flags": 32768,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo",
+      "capture.double-exposure",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "beauty",
+    "user_comment": "oplus_2",
+    "asset_type": "static-photo",
+    "capture_modes": [
+      "beauty"
+    ],
+    "primary_capture_mode": "beauty",
+    "folder": "美颜",
+    "metadata_status": "ok",
+    "recognized_flags": 2,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo",
+      "capture.beauty",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "missing",
+    "user_comment": null,
+    "asset_type": "static-photo",
+    "capture_modes": [],
+    "primary_capture_mode": null,
+    "folder": "未分类",
+    "metadata_status": "missing-user-comment",
+    "recognized_flags": 0,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo"
+    ]
+  },
+  {
+    "name": "malformed",
+    "user_comment": "not-an-oppo-comment",
+    "asset_type": "static-photo",
+    "capture_modes": [],
+    "primary_capture_mode": null,
+    "folder": "未分类",
+    "metadata_status": "malformed-user-comment",
+    "recognized_flags": 0,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 0,
+    "tags": [
+      "asset.static-photo"
+    ]
+  },
+  {
+    "name": "unknown",
+    "user_comment": "oplus_17179869184",
+    "asset_type": "static-photo",
+    "capture_modes": [],
+    "primary_capture_mode": null,
+    "folder": "未分类",
+    "metadata_status": "ok",
+    "recognized_flags": 0,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 17179869184,
+    "tags": [
+      "asset.static-photo",
+      "vendor.oppo"
+    ]
+  },
+  {
+    "name": "unknown-above-int64",
+    "user_comment": "oplus_9223372036854775808",
+    "asset_type": "static-photo",
+    "capture_modes": [],
+    "primary_capture_mode": null,
+    "folder": "未分类",
+    "metadata_status": "ok",
+    "recognized_flags": 0,
+    "known_unmapped_flags": 0,
+    "unknown_flags": 9223372036854775808,
+    "tags": [
+      "asset.static-photo",
+      "vendor.oppo"
+    ]
+  }
+]

--- a/Tests/test_photo_categorization.py
+++ b/Tests/test_photo_categorization.py
@@ -37,7 +37,7 @@ class PhotoCategorizationTests(unittest.TestCase):
                 self.assertEqual(result.mode.folder_name if result.mode else None, item["folder"])
                 self.assertEqual(result.status, item["status"])
 
-    def test_plan_copies_to_categories_and_root_without_duplicate_reruns(self) -> None:
+    def test_plan_projects_asset_type_and_mode_without_duplicate_reruns(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             source = root / "source"
@@ -51,13 +51,48 @@ class PhotoCategorizationTests(unittest.TestCase):
             plan = categorize.make_plan([source], output)
             self.assertEqual(len(plan), 3)
             self.assertEqual(plan[0].destination.parent.name, "人像")
-            self.assertEqual(plan[1].destination, output / "plain.jpg")
+            self.assertEqual(plan[1].destination, output / "静态照片" / "未分类" / "plain.jpg")
             self.assertEqual(plan[2].destination.name, "same (2).heic")
 
             results = categorize.execute_plan(plan, jobs=2)
             self.assertTrue(all(item.disposition == "copied" for item in results))
             repeated = categorize.make_plan([source], output)
             self.assertTrue(all(item.disposition == "duplicate" for item in repeated))
+
+    def test_validated_live_photo_pair_moves_as_one_asset(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            output = root / "output"
+            source.mkdir()
+            image = source / "pair.heic"
+            video = source / "pair.mov"
+            image.write_bytes(b"oplus_18")
+            video.write_bytes(b"paired-video")
+            occupied = output / "实况照片" / "人像"
+            occupied.mkdir(parents=True)
+            (occupied / "pair.heic").write_bytes(b"foreign-image")
+
+            paired = categorize.make_plan(
+                [source],
+                output,
+                live_photo_pair_validator=lambda candidate_image, candidate_video: (
+                    candidate_image == image and candidate_video == video
+                ),
+            )
+            self.assertEqual(len(paired), 2)
+            self.assertTrue(all(item.classification.asset_type is categorize.AssetType.LIVE_PHOTO for item in paired))
+            self.assertEqual({item.destination.name for item in paired}, {"pair (2).heic", "pair (2).mov"})
+            self.assertTrue(all("实况照片/人像" in item.destination.as_posix() for item in paired))
+
+            rejected = categorize.make_plan(
+                [source],
+                output,
+                live_photo_pair_validator=lambda _image, _video: False,
+            )
+            self.assertEqual(len(rejected), 1)
+            self.assertEqual(rejected[0].source, image)
+            self.assertIs(rejected[0].classification.asset_type, categorize.AssetType.STATIC_PHOTO)
 
     def test_dry_run_writes_nothing(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -69,7 +104,7 @@ class PhotoCategorizationTests(unittest.TestCase):
             self.assertEqual(results[0].disposition, "dry-run")
             self.assertFalse(output.exists())
 
-    def test_malformed_comment_is_copied_to_root_and_returns_failure(self) -> None:
+    def test_malformed_comment_is_copied_to_unclassified_and_returns_failure(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             source = root / "malformed.jpg"
@@ -85,7 +120,7 @@ class PhotoCategorizationTests(unittest.TestCase):
             ])
 
             self.assertEqual(result, 1)
-            self.assertEqual((output / source.name).read_bytes(), source.read_bytes())
+            self.assertEqual((output / "静态照片" / "未分类" / source.name).read_bytes(), source.read_bytes())
 
     def test_reads_tiff_user_comment_bytes(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/Tests/test_photo_classification_contract.py
+++ b/Tests/test_photo_classification_contract.py
@@ -1,0 +1,98 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from xdremux_py import categorize
+
+
+class PhotoClassificationContractTests(unittest.TestCase):
+    def test_canonical_golden_contract(self) -> None:
+        fixture = Path(__file__).parent / "fixtures" / "photo_classification_cases.json"
+        cases = json.loads(fixture.read_text(encoding="utf-8"))
+        asset_types = {item.key: item for item in categorize.AssetType}
+        for item in cases:
+            with self.subTest(item=item["name"]):
+                classification = categorize.classify_user_comment(item["user_comment"]).with_asset_type(
+                    asset_types[item["asset_type"]]
+                )
+                self.assertEqual(categorize.classification_contract(classification), {
+                    key: value for key, value in item.items() if key not in {"name", "user_comment"}
+                })
+
+    def test_multi_bit_flags_are_lossless_but_projection_is_stable(self) -> None:
+        classification = categorize.classify_user_comment("oplus_18")
+        self.assertEqual(
+            classification.capture_modes,
+            frozenset({categorize.CaptureMode.PORTRAIT, categorize.CaptureMode.BEAUTY}),
+        )
+        self.assertEqual(classification.mode, categorize.CaptureMode.PORTRAIT)
+        self.assertNotIn("capture.normal", classification.tags)
+        self.assertIn("capture.portrait", classification.tags)
+        self.assertIn("capture.beauty", classification.tags)
+
+    def test_known_unmapped_and_unknown_flags_are_distinct(self) -> None:
+        known = categorize.classify_user_comment("oplus_262144")
+        self.assertEqual(known.known_unmapped_flags, 262144)
+        self.assertEqual(known.unknown_flags, 0)
+        self.assertEqual(known.metadata_status, "ok")
+        self.assertEqual(known.mode, categorize.CaptureMode.NORMAL)
+
+        unknown = categorize.classify_user_comment("oplus_17179869184")
+        self.assertEqual(unknown.known_unmapped_flags, 0)
+        self.assertEqual(unknown.unknown_flags, 17179869184)
+        self.assertEqual(unknown.metadata_status, "ok")
+        self.assertIsNone(unknown.mode)
+        self.assertEqual(unknown.status, "unknown-flags")  # legacy compatibility view only
+
+    def test_folder_projection_separates_asset_type_from_capture_tags(self) -> None:
+        portrait = categorize.classify_user_comment("oplus_18")
+        self.assertEqual(
+            categorize.FolderProjection.relative_directory(portrait),
+            Path("静态照片") / "人像",
+        )
+        live = portrait.with_asset_type(categorize.AssetType.LIVE_PHOTO)
+        self.assertEqual(
+            categorize.FolderProjection.relative_directory(live),
+            Path("实况照片") / "人像",
+        )
+        self.assertEqual(categorize.CLASSIFICATION_LAYOUT_VERSION, "asset-type-v1")
+
+    def test_photo_asset_keeps_live_photo_resources_together(self) -> None:
+        asset = categorize.PhotoAsset.live_photo(Path("IMG.heic"), Path("IMG.mov"), "asset-id")
+        self.assertEqual(asset.asset_type, categorize.AssetType.LIVE_PHOTO)
+        self.assertEqual(asset.primary_image, Path("IMG.heic"))
+        self.assertEqual(
+            [resource.role for resource in asset.resources],
+            [categorize.ResourceRole.PRIMARY_IMAGE, categorize.ResourceRole.PAIRED_VIDEO],
+        )
+
+    def test_capabilities_require_complete_manifest_entry_names(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            complete = root / "complete.heic"
+            complete.write_bytes(
+                b'oplus_18 {"name":"local.uhdr.gainmap.data"} '
+                b'{"name":"rear.depth"} {"name":"rear.depth.config"}'
+            )
+            classification = categorize.classify_path(complete, categorize.AssetType.STATIC_PHOTO)
+            self.assertEqual(
+                classification.capabilities,
+                frozenset({
+                    categorize.PhotoCapability.PROXDR,
+                    categorize.PhotoCapability.GAIN_MAP,
+                    categorize.PhotoCapability.HDR,
+                    categorize.PhotoCapability.DEPTH,
+                }),
+            )
+
+            config_only = root / "config-only.heic"
+            config_only.write_bytes(b'oplus_18 {"name":"rear.depth.config"}')
+            config_classification = categorize.classify_path(
+                config_only, categorize.AssetType.STATIC_PHOTO
+            )
+            self.assertNotIn(categorize.PhotoCapability.DEPTH, config_classification.capabilities)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/test_python_live_photo_batch_reliability.py
+++ b/Tests/test_python_live_photo_batch_reliability.py
@@ -12,13 +12,14 @@ from xdremux_py.live_photo_batch import (
     load_state,
     planned_output_image,
     provenance_allows_reuse,
+    reserve_output_image,
     source_signature,
     state_path,
 )
 
 
 class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
-    def test_duplicate_basenames_have_stable_distinct_outputs_across_subset_rerun(self):
+    def test_duplicate_basenames_are_numbered_only_when_they_share_a_destination(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "input"
             output = Path(tmp) / "output"
@@ -28,43 +29,75 @@ class PythonLivePhotoBatchReliabilityTests(unittest.TestCase):
             b.parent.mkdir(parents=True)
             a.write_bytes(b"a")
             b.write_bytes(b"b")
+            reserved: set[str] = set()
 
-            a_output = planned_output_image(a, root, output)
-            b_output = planned_output_image(b, root, output)
-            b_subset_output = planned_output_image(b, root, output)
+            a_output = reserve_output_image(a, root, output, reserved, path_exists=lambda _path: False)
+            b_output = reserve_output_image(b, root, output, reserved, path_exists=lambda _path: False)
 
-            self.assertNotEqual(a_output, b_output)
-            self.assertEqual(b_output, b_subset_output)
-            self.assertTrue(a_output.name.startswith("IMG~"))
-            self.assertTrue(b_output.name.startswith("IMG~"))
+            self.assertEqual(a_output.name, "IMG.heic")
+            self.assertEqual(b_output.name, "IMG (2).heic")
+            self.assertIn(str((output / "IMG.mov").resolve()), reserved)
+            self.assertIn(str((output / "IMG (2).mov").resolve()), reserved)
 
-    def test_same_relative_path_in_different_input_roots_cannot_alias_shared_output(self):
+    def test_preferred_output_preserves_basename_across_input_roots(self):
         with tempfile.TemporaryDirectory() as tmp:
             base = Path(tmp)
-            first_root = base / "root-one"
-            second_root = base / "root-two"
             output = base / "shared-output"
-            first = first_root / "A" / "IMG.jpg"
-            second = second_root / "A" / "IMG.jpg"
+            first = base / "root-one" / "A" / "IMG.jpg"
+            second = base / "root-two" / "A" / "IMG.jpg"
             first.parent.mkdir(parents=True)
             second.parent.mkdir(parents=True)
             first.write_bytes(b"first")
             second.write_bytes(b"second")
 
-            self.assertNotEqual(
-                planned_output_image(first, first_root, output),
-                planned_output_image(second, second_root, output),
-            )
+            self.assertEqual(planned_output_image(first, first.parents[1], output).name, "IMG.heic")
+            self.assertEqual(planned_output_image(second, second.parents[1], output).name, "IMG.heic")
 
-    def test_heif_motion_photo_uses_live_namespace_and_stable_token(self):
+    def test_heif_motion_photo_does_not_add_live_or_hash_markers(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "input"
             root.mkdir()
             source = root / "same.heic"
             source.write_bytes(b"heif")
             output = planned_output_image(source, root, Path(tmp) / "output")
-            self.assertTrue(output.name.startswith("same.live~"))
-            self.assertTrue(output.name.endswith(".heic"))
+            self.assertEqual(output.name, "same.heic")
+
+            reserved: set[str] = set()
+            same_directory = reserve_output_image(
+                source,
+                root,
+                root,
+                reserved,
+                path_exists=lambda _path: False,
+            )
+            self.assertEqual(same_directory.name, "same (2).heic")
+
+    def test_foreign_existing_pair_sequences_but_owned_pair_keeps_original_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "input"
+            output = Path(tmp) / "output"
+            root.mkdir()
+            output.mkdir()
+            source = root / "IMG.jpg"
+            source.write_bytes(b"source")
+            (output / "IMG.heic").write_bytes(b"foreign")
+            (output / "IMG.mov").write_bytes(b"foreign")
+
+            foreign_reserved: set[str] = set()
+            foreign = reserve_output_image(source, root, output, foreign_reserved)
+            self.assertEqual(foreign.name, "IMG (2).heic")
+
+            owned_reserved: set[str] = set()
+            owned = reserve_output_image(
+                source,
+                root,
+                output,
+                owned_reserved,
+                candidate_belongs_to_source=lambda image, video: (
+                    image.name == "IMG.heic" and video.name == "IMG.mov"
+                ),
+            )
+            self.assertEqual(owned.name, "IMG.heic")
 
     def test_content_hash_detects_change_even_when_size_and_mtime_are_preserved(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/Tests/validation/verify_categorization_cross_implementation.py
+++ b/Tests/validation/verify_categorization_cross_implementation.py
@@ -118,7 +118,8 @@ def main() -> int:
             completed = subprocess.run(command, cwd=repo, text=True, capture_output=True)
             if completed.returncode == 0:
                 raise AssertionError(f"{label} accepted a malformed UserComment without reporting failure")
-            if (output / malformed.name).read_bytes() != malformed.read_bytes():
+            unclassified = output / "静态照片" / "未分类" / malformed.name
+            if unclassified.read_bytes() != malformed.read_bytes():
                 raise AssertionError(f"{label} did not preserve the malformed photo in the output root")
 
         swift = run(

--- a/Tests/validation/verify_categorized_batch_outputs.py
+++ b/Tests/validation/verify_categorized_batch_outputs.py
@@ -28,7 +28,7 @@ def main() -> int:
     source = Path(args.input).resolve()
     source_comment = categorize.extract_user_comment(source)
     classification = categorize.classify_path(source)
-    folder = classification.mode.folder_name if classification.mode else ""
+    relative_folder = categorize.FolderProjection.relative_directory(classification)
     swift_executable = str((repo / args.swift_executable).resolve())
     python_cli = str(repo / "xdremux/python/XDRemux.py")
 
@@ -58,7 +58,7 @@ def main() -> int:
                     ],
                     repo,
                 )
-            output = output_dir / folder / source.name if folder else output_dir / source.name
+            output = output_dir / relative_folder / source.name
             if not output.is_file():
                 raise AssertionError(f"{implementation} categorized output missing: {output}")
             if categorize.extract_user_comment(output) != source_comment:
@@ -72,7 +72,7 @@ def main() -> int:
                 raise AssertionError("pillow-heif is required for the functional batch check") from exc
             outputs.append(output)
 
-    print(f"categorized Swift and Python batch outputs passed for {source.name} in {folder or 'root'}")
+    print(f"categorized Swift and Python batch outputs passed for {source.name} in {relative_folder}")
     return 0
 
 

--- a/apps/macos/XDRemuxApp/Sources/PhotoCategorizationView.swift
+++ b/apps/macos/XDRemuxApp/Sources/PhotoCategorizationView.swift
@@ -24,7 +24,7 @@ struct PhotoCategorizationView: View {
                             .truncationMode(.middle)
                     }
                     TableColumn("拍摄模式") { item in
-                        Text(item.classification.mode?.folderName ?? "根目录")
+                        Text(item.classification.mode?.folderName ?? "未分类")
                     }
                     TableColumn("状态") { item in
                         Text(item.classification.mode == nil
@@ -112,10 +112,10 @@ struct PhotoCategorizationView: View {
 
     private var footer: some View {
         HStack(spacing: 18) {
-            Label("\(viewModel.items.isEmpty ? viewModel.inputURLs.count : viewModel.items.count) 张照片", systemImage: "photo.on.rectangle")
+            Label("\(viewModel.items.isEmpty ? viewModel.inputURLs.count : viewModel.items.count) 个文件", systemImage: "photo.on.rectangle")
             Label("\(viewModel.categorizedCount) 已分类", systemImage: "folder.badge.gearshape")
                 .help(viewModel.modeSummary)
-            Label("\(viewModel.rootCount) 根目录", systemImage: "tray")
+            Label("\(viewModel.unclassifiedCount) 未分类", systemImage: "tray")
             Label("\(viewModel.duplicateCount) 重复", systemImage: "equal.circle")
             if viewModel.failedCount > 0 {
                 Label("\(viewModel.failedCount) 失败", systemImage: "exclamationmark.triangle")

--- a/apps/macos/XDRemuxApp/Sources/PhotoCategorizationViewModel.swift
+++ b/apps/macos/XDRemuxApp/Sources/PhotoCategorizationViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Observation
 import XDRemuxCore
+import XDRemuxAppleFeatures
 import AppKit
 
 enum PhotoCategorizationAppState: Equatable {
@@ -43,7 +44,8 @@ final class PhotoCategorizationViewModel {
     var canCopy: Bool { state == .ready && items.contains { $0.disposition == .copy } }
     var isBusy: Bool { state == .scanning || state == .copying }
     var categorizedCount: Int { items.count { $0.classification.mode != nil } }
-    var rootCount: Int { items.count { $0.classification.mode == nil } }
+    var unclassifiedCount: Int { items.count { $0.classification.mode == nil } }
+    var rootCount: Int { unclassifiedCount } // compatibility for older UI/tests
     var duplicateCount: Int { items.count { $0.disposition == .duplicate } }
     var failedCount: Int { items.count { $0.disposition == .failed } }
     var modeSummary: String {
@@ -88,7 +90,10 @@ final class PhotoCategorizationViewModel {
                 let plan = try await Task.detached(priority: .userInitiated) {
                     try PhotoCategorizationEngine.makePlan(
                         inputs: inputs,
-                        outputDirectory: outputDirectory
+                        outputDirectory: outputDirectory,
+                        livePhotoPairValidator: { imageURL, videoURL in
+                            AppleLivePhotoValidator.isValidPair(imageURL: imageURL, videoURL: videoURL)
+                        }
                     )
                 }.value
                 guard !Task.isCancelled else { return }

--- a/apps/macos/XDRemuxApp/Sources/XDRemuxViewModel.swift
+++ b/apps/macos/XDRemuxApp/Sources/XDRemuxViewModel.swift
@@ -97,6 +97,7 @@ struct ConversionQueueItem: Identifiable, Sendable, Equatable {
     var startedAt: Date?
     var finishedAt: Date?
     var captureMode: OppoCaptureMode?
+    var assetType: PhotoAssetType
     var classificationStatus: OppoPhotoClassificationStatus
 
     init(
@@ -109,6 +110,7 @@ struct ConversionQueueItem: Identifiable, Sendable, Equatable {
         startedAt: Date? = nil,
         finishedAt: Date? = nil,
         captureMode: OppoCaptureMode? = nil,
+        assetType: PhotoAssetType = .staticPhoto,
         classificationStatus: OppoPhotoClassificationStatus = .missingUserComment
     ) {
         self.id = id
@@ -120,6 +122,7 @@ struct ConversionQueueItem: Identifiable, Sendable, Equatable {
         self.startedAt = startedAt
         self.finishedAt = finishedAt
         self.captureMode = captureMode
+        self.assetType = assetType
         self.classificationStatus = classificationStatus
     }
 
@@ -258,13 +261,15 @@ final class XDRemuxViewModel {
                 let outputURL = Self.makeOutputURL(
                     for: inputURL,
                     config: config,
-                    captureMode: classification.mode
+                    captureMode: classification.mode,
+                    assetType: classification.assetType
                 )
                 return ConversionQueueItem(
                     inputURL: inputURL,
                     outputURL: outputURL,
                     outputPlanStatus: Self.outputPlanStatus(inputURL: inputURL, outputURL: outputURL, config: config),
                     captureMode: classification.mode,
+                    assetType: classification.assetType,
                     classificationStatus: classification.status
                 )
             }
@@ -330,7 +335,7 @@ final class XDRemuxViewModel {
             queue[index].errorMessage = nil
             queue[index].startedAt = nil
             queue[index].finishedAt = nil
-            queue[index].outputURL = Self.makeOutputURL(for: queue[index].inputURL, config: config, captureMode: queue[index].captureMode)
+            queue[index].outputURL = Self.makeOutputURL(for: queue[index].inputURL, config: config, captureMode: queue[index].captureMode, assetType: queue[index].assetType)
             queue[index].outputPlanStatus = Self.outputPlanStatus(inputURL: queue[index].inputURL, outputURL: queue[index].outputURL, config: config)
         }
         refreshOutputURLsAndPlansForEditableItems()
@@ -398,7 +403,7 @@ final class XDRemuxViewModel {
 
     private func refreshOutputURLsAndPlansForEditableItems() {
         for index in queue.indices where queue[index].status == .pending || queue[index].status == .failed || queue[index].status == .cancelled {
-            queue[index].outputURL = Self.makeOutputURL(for: queue[index].inputURL, config: config, captureMode: queue[index].captureMode)
+            queue[index].outputURL = Self.makeOutputURL(for: queue[index].inputURL, config: config, captureMode: queue[index].captureMode, assetType: queue[index].assetType)
             queue[index].outputPlanStatus = Self.outputPlanStatus(
                 inputURL: queue[index].inputURL,
                 outputURL: queue[index].outputURL,
@@ -561,7 +566,7 @@ final class XDRemuxViewModel {
             queue[index].errorMessage = nil
             queue[index].startedAt = nil
             queue[index].finishedAt = nil
-            queue[index].outputURL = Self.makeOutputURL(for: queue[index].inputURL, config: config, captureMode: queue[index].captureMode)
+            queue[index].outputURL = Self.makeOutputURL(for: queue[index].inputURL, config: config, captureMode: queue[index].captureMode, assetType: queue[index].assetType)
             queue[index].outputPlanStatus = Self.outputPlanStatus(inputURL: queue[index].inputURL, outputURL: queue[index].outputURL, config: config)
         }
         refreshOutputURLsAndPlansForEditableItems()
@@ -648,21 +653,27 @@ final class XDRemuxViewModel {
     nonisolated private static func makeOutputURL(
         for inputURL: URL,
         config: ConversionConfig,
-        captureMode: OppoCaptureMode?
+        captureMode: OppoCaptureMode?,
+        assetType: PhotoAssetType
     ) -> URL {
-        let category = config.categorizeOutputByCaptureMode ? captureMode?.folderName : nil
+        let categoryComponents = config.categorizeOutputByCaptureMode
+            ? [assetType.folderName, captureMode?.folderName ?? PhotoFolderProjection.unclassifiedFolderName]
+            : []
+
+        func projectedDirectory(from root: URL) -> URL {
+            categoryComponents.reduce(root) { directory, component in
+                directory.appendingPathComponent(component, isDirectory: true)
+            }
+        }
+
         if let outputDirectory = config.outputDirectory {
-            let directory = category.map {
-                outputDirectory.appendingPathComponent($0, isDirectory: true)
-            } ?? outputDirectory
-            return directory.appendingPathComponent(inputURL.lastPathComponent)
+            return projectedDirectory(from: outputDirectory)
+                .appendingPathComponent(inputURL.lastPathComponent)
         }
 
         let suffix = config.fileNameSuffix.isEmpty ? "_iso" : config.fileNameSuffix
         let stem = inputURL.deletingPathExtension().lastPathComponent
-        let parent = category.map {
-            inputURL.deletingLastPathComponent().appendingPathComponent($0, isDirectory: true)
-        } ?? inputURL.deletingLastPathComponent()
+        let parent = projectedDirectory(from: inputURL.deletingLastPathComponent())
         return parent.appendingPathComponent("\(stem)\(suffix).heic")
     }
 

--- a/apps/macos/XDRemuxApp/Tests/XDRemuxAppModelTests.swift
+++ b/apps/macos/XDRemuxApp/Tests/XDRemuxAppModelTests.swift
@@ -37,7 +37,7 @@ struct XDRemuxAppModelTests {
     @MainActor
     static func main() async throws {
         try await testImportDiscoversHEICFilesAndDeduplicates()
-        try await testConversionCategorizationMapsModeAndRootDirectories()
+        try await testConversionCategorizationUsesAssetTypeAndModeDirectories()
         try await testCategorizationPreviewCopyAndDuplicateRerun()
         try await testCategorizationDefaultsToEachSourceDirectory()
         try await testCategorizationCancellationKeepsCancelledState()
@@ -71,7 +71,7 @@ struct XDRemuxAppModelTests {
     }
 
     @MainActor
-    private static func testConversionCategorizationMapsModeAndRootDirectories() async throws {
+    private static func testConversionCategorizationUsesAssetTypeAndModeDirectories() async throws {
         let root = try makeTempDirectory("conversion-categorize")
         defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
         let output = root.appendingPathComponent("output", isDirectory: true)
@@ -87,9 +87,9 @@ struct XDRemuxAppModelTests {
 
         let byName = Dictionary(uniqueKeysWithValues: viewModel.queue.map { ($0.inputURL.lastPathComponent, $0) })
         try expect(byName["portrait.heic"]?.captureMode == .portrait, "conversion queue should expose the parsed capture mode")
-        try expect(byName["portrait.heic"]?.outputURL == output.appendingPathComponent("人像/portrait.heic"), "categorized conversion should use the mode directory")
+        try expect(byName["portrait.heic"]?.outputURL == output.appendingPathComponent("静态照片/人像/portrait.heic"), "categorized conversion should use the mode directory")
         try expect(byName["unknown.heic"]?.classificationStatus == .unknownFlags, "unknown flags should remain visible in the queue")
-        try expect(byName["unknown.heic"]?.outputURL == output.appendingPathComponent("unknown.heic"), "unclassified conversion should stay at the output root")
+        try expect(byName["unknown.heic"]?.outputURL == output.appendingPathComponent("静态照片/未分类/unknown.heic"), "unclassified conversion should use the static-photo / unclassified projection")
     }
 
     @MainActor
@@ -110,16 +110,16 @@ struct XDRemuxAppModelTests {
 
         try expect(viewModel.state == .ready, "scan should produce a ready preview")
         try expect(viewModel.items.count == 2, "preview should include both supported files")
-        try expect(viewModel.categorizedCount == 1 && viewModel.rootCount == 1, "preview counts should separate categorized and root items")
+        try expect(viewModel.categorizedCount == 1 && viewModel.rootCount == 1, "preview counts should separate categorized and unclassified items")
         try expect(viewModel.modeSummary.contains("人像 1"), "preview should summarize counts by capture mode")
-        try expect(viewModel.items.contains { $0.destinationURL == output.appendingPathComponent("人像/portrait.heic") }, "preview should show the mode destination")
-        try expect(viewModel.items.contains { $0.destinationURL == output.appendingPathComponent("plain.jpg") }, "preview should show the root destination")
+        try expect(viewModel.items.contains { $0.destinationURL == output.appendingPathComponent("静态照片/人像/portrait.heic") }, "preview should show the mode destination")
+        try expect(viewModel.items.contains { $0.destinationURL == output.appendingPathComponent("静态照片/未分类/plain.jpg") }, "preview should show the unclassified destination")
 
         viewModel.copyPlannedFiles()
         try await waitForCategorization(viewModel)
         try expect(viewModel.state == .completed, "copy should complete")
-        try expect(FileManager.default.fileExists(atPath: output.appendingPathComponent("人像/portrait.heic").path), "copy should create the categorized file")
-        try expect(FileManager.default.fileExists(atPath: output.appendingPathComponent("plain.jpg").path), "copy should create the root file")
+        try expect(FileManager.default.fileExists(atPath: output.appendingPathComponent("静态照片/人像/portrait.heic").path), "copy should create the categorized file")
+        try expect(FileManager.default.fileExists(atPath: output.appendingPathComponent("静态照片/未分类/plain.jpg").path), "copy should create the unclassified file")
 
         viewModel.scan()
         try await waitForCategorization(viewModel)
@@ -161,8 +161,8 @@ struct XDRemuxAppModelTests {
         try await waitForCategorization(viewModel)
 
         let destinations = Set(viewModel.items.map(\.destinationURL))
-        try expect(destinations.contains(firstDirectory.appendingPathComponent("人像/a.heic")), "first input should use its own parent as the classification root")
-        try expect(destinations.contains(secondDirectory.appendingPathComponent("专业模式/b.heic")), "second input should use its own parent as the classification root")
+        try expect(destinations.contains(firstDirectory.appendingPathComponent("静态照片/人像/a.heic")), "first input should use its own parent as the classification root")
+        try expect(destinations.contains(secondDirectory.appendingPathComponent("静态照片/专业模式/b.heic")), "second input should use its own parent as the classification root")
     }
 
     @MainActor

--- a/docs/cli.en.md
+++ b/docs/cli.en.md
@@ -38,7 +38,7 @@ xdremux categorize --input ~/Pictures/ProXDR --output-dir ~/Pictures/Sorted
 
 - `convert` **overwrites the input file** when `--output` is omitted.
 - `batch` writes back into the input directory when `--output-dir` is omitted.
-- `batch --categorize` files results under Chinese shooting-mode folders (`人像`, `夜景`, `大师模式`, …). Photos whose mode cannot be read stay in the output root.
+- `batch --categorize` first files results by asset type (`静态照片` / `实况照片`), then by the primary shooting mode (`人像`, `夜景`, `大师模式`, …). Photos whose mode cannot be read go to `未分类`.
 - `categorize` only copies HEIC/HEIF/JPEG files into those folders. It never modifies or converts anything.
 
 ## Options
@@ -63,7 +63,7 @@ xdremux categorize --input ~/Pictures/ProXDR --output-dir ~/Pictures/Sorted
 | `--output-dir <dir>` | the input directory | Output directory |
 | `--glob <pattern>` | `*.heic` | Which files to pick up |
 | `--jobs <n>` | `min(cpu, 4)` | How many files to convert at once |
-| `--categorize` | off | File results under shooting-mode folders |
+| `--categorize` | off | File results by asset type + primary shooting mode |
 | `--resume` / `--no-resume` | `--resume` | Continue from the previous run's progress |
 | `--skip-existing` / `--no-skip-existing` | `--skip-existing` | Skip a file whose output already matches the current settings |
 | `--checkpoint <file>` | a hidden JSONL file under the output directory | Where progress is recorded |
@@ -130,7 +130,7 @@ The CLI prints human-readable text: progress on stdout, errors on stderr. There 
 
 1. Skips outputs that already match the current settings (`--skip-existing`, on by default).
 2. Retries the files that failed (`--resume`, on by default).
-3. Does not re-scan the shooting-mode folders `--categorize` wrote, so repeated runs are idempotent.
+3. Does not re-scan the asset-type folders written by `--categorize` (or legacy shooting-mode folders), so repeated runs are idempotent.
 
 ## Common errors
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,7 +38,7 @@ xdremux categorize --input ~/Pictures/ProXDR --output-dir ~/Pictures/分类
 
 - `convert` 省略 `--output` 时**原地覆盖输入文件**。
 - `batch` 省略 `--output-dir` 时写回输入目录。
-- `batch --categorize` 把结果放进中文拍摄模式子目录（`人像`、`夜景`、`大师模式` 等）。读不出模式的照片留在输出根目录。
+- `batch --categorize` 先按资产类型写进 `静态照片` / `实况照片`，再按主拍摄模式写进 `人像`、`夜景`、`大师模式` 等子目录；读不出模式的照片进入 `未分类`。
 - `categorize` 只复制 HEIC/HEIF/JPEG 文件到这些目录，不修改也不转换任何东西。
 
 ## 参数
@@ -63,7 +63,7 @@ xdremux categorize --input ~/Pictures/ProXDR --output-dir ~/Pictures/分类
 | `--output-dir <目录>` | 输入目录 | 输出目录 |
 | `--glob <模式>` | `*.heic` | 挑选哪些文件 |
 | `--jobs <数量>` | `min(cpu, 4)` | 同时转换几个文件 |
-| `--categorize` | 关闭 | 按拍摄模式分目录写出 |
+| `--categorize` | 关闭 | 按资产类型 + 主拍摄模式分目录写出 |
 | `--resume` / `--no-resume` | `--resume` | 是否续跑上次的进度 |
 | `--skip-existing` / `--no-skip-existing` | `--skip-existing` | 输出已经符合当前设置时是否跳过 |
 | `--checkpoint <文件>` | 输出目录下的隐藏 JSONL | 进度记录位置 |
@@ -130,7 +130,7 @@ CLI 输出人类可读的文本：进度写 stdout，错误写 stderr。目前�
 
 1. 已经符合当前设置的输出直接跳过（`--skip-existing`，默认开启）。
 2. 之前失败的文件重新尝试（`--resume`，默认开启）。
-3. `--categorize` 写出的拍摄模式目录不会被当成新输入重新扫描，所以重复运行是幂等的。
+3. `--categorize` 写出的资产类型目录（以及旧版拍摄模式目录）不会被当成新输入重新扫描，所以重复运行是幂等的。
 
 ## 常见错误
 

--- a/xdremux_py/categorize.py
+++ b/xdremux_py/categorize.py
@@ -1,4 +1,4 @@
-"""OPPO UserComment shooting-mode categorization shared by the Python CLI."""
+"""Photo asset classification and folder projection shared by the Python CLI."""
 
 from __future__ import annotations
 
@@ -13,7 +13,73 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, replace
 from enum import Enum
 from pathlib import Path
-from typing import Iterable
+from typing import Callable, Iterable
+
+
+CLASSIFICATION_LAYOUT_VERSION = "asset-type-v1"
+UNCLASSIFIED_FOLDER_NAME = "未分类"
+
+
+class AssetType(Enum):
+    STATIC_PHOTO = ("static-photo", "静态照片")
+    LIVE_PHOTO = ("live-photo", "实况照片")
+
+    def __init__(self, key: str, folder_name: str) -> None:
+        self.key = key
+        self.folder_name = folder_name
+
+    @property
+    def tag_id(self) -> str:
+        return f"asset.{self.key}"
+
+
+class ResourceRole(Enum):
+    PRIMARY_IMAGE = "primary-image"
+    PAIRED_VIDEO = "paired-video"
+    SIDECAR = "sidecar"
+
+
+@dataclass(frozen=True)
+class PhotoResource:
+    path: Path
+    role: ResourceRole
+
+
+@dataclass(frozen=True)
+class PhotoAsset:
+    asset_id: str
+    asset_type: AssetType
+    resources: tuple[PhotoResource, ...]
+
+    @property
+    def primary_image(self) -> Path:
+        for resource in self.resources:
+            if resource.role is ResourceRole.PRIMARY_IMAGE:
+                return resource.path
+        raise ValueError("photo asset has no primary image")
+
+    @classmethod
+    def static_photo(cls, path: Path) -> "PhotoAsset":
+        resolved = Path(path).resolve(strict=False)
+        return cls(
+            asset_id=str(resolved),
+            asset_type=AssetType.STATIC_PHOTO,
+            resources=(PhotoResource(Path(path), ResourceRole.PRIMARY_IMAGE),),
+        )
+
+    @classmethod
+    def live_photo(cls, image: Path, video: Path, asset_id: str | None = None) -> "PhotoAsset":
+        image = Path(image)
+        video = Path(video)
+        resolved_id = asset_id or str(image.resolve(strict=False))
+        return cls(
+            asset_id=resolved_id,
+            asset_type=AssetType.LIVE_PHOTO,
+            resources=(
+                PhotoResource(image, ResourceRole.PRIMARY_IMAGE),
+                PhotoResource(video, ResourceRole.PAIRED_VIDEO),
+            ),
+        )
 
 
 class CaptureMode(Enum):
@@ -31,6 +97,7 @@ class CaptureMode(Enum):
     GROUP_PHOTO = ("group-photo", "合影", 0x400000)
     DOUBLE_EXPOSURE = ("double-exposure", "双重曝光", 0x8000)
     BEAUTY = ("beauty", "美颜", 0x2)
+    # NORMAL is a folder projection fallback, not a semantic tag/activated bit.
     NORMAL = ("normal", "普通拍照", 0)
 
     def __init__(self, key: str, folder_name: str, bit: int) -> None:
@@ -38,8 +105,16 @@ class CaptureMode(Enum):
         self.folder_name = folder_name
         self.bit = bit
 
+    @property
+    def tag_id(self) -> str:
+        return f"capture.{self.key}"
+
 
 MODE_PRIORITY = tuple(mode for mode in CaptureMode if mode is not CaptureMode.NORMAL)
+MAPPED_FLAGS_MASK = 0
+for _mode in MODE_PRIORITY:
+    MAPPED_FLAGS_MASK |= _mode.bit
+
 KNOWN_FLAGS_MASK = 0
 for _bit in (
     0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
@@ -51,18 +126,113 @@ for _bit in (
 ):
     KNOWN_FLAGS_MASK |= _bit
 
-SUPPORTED_EXTENSIONS = {".heic", ".heif", ".jpg", ".jpeg"}
-COMMENT_PATTERN = re.compile(rb"(?:Oplus|Oppo)_[0-9]+", re.IGNORECASE)
-JSON_TAG_PATTERN = re.compile(rb'"oplustag"\s*:\s*"?([0-9]+)"?', re.IGNORECASE)
+
+class PhotoCapability(Enum):
+    PROXDR = "proxdr"
+    GAIN_MAP = "gain-map"
+    HDR = "hdr"
+    DEPTH = "depth"
+
+    @property
+    def tag_id(self) -> str:
+        return f"capability.{self.value}"
+
+
+class CameraVendor(Enum):
+    OPPO = "oppo"
+
+    @property
+    def tag_id(self) -> str:
+        return f"vendor.{self.value}"
+
+
+@dataclass(frozen=True)
+class OppoFlagEvidence:
+    raw_flags: int
+    recognized_flags: int
+    known_unmapped_flags: int
+    unknown_flags: int
 
 
 @dataclass(frozen=True)
 class Classification:
     raw_user_comment: str | None
     tag_flags: int | None
+    recognized_flags: int
+    known_unmapped_flags: int
     unknown_flags: int
-    mode: CaptureMode | None
-    status: str
+    capture_modes: frozenset[CaptureMode]
+    metadata_status: str
+    asset_type: AssetType = AssetType.STATIC_PHOTO
+    capabilities: frozenset[PhotoCapability] = frozenset()
+    vendor: CameraVendor | None = None
+
+    @property
+    def evidence(self) -> OppoFlagEvidence | None:
+        if self.tag_flags is None:
+            return None
+        return OppoFlagEvidence(
+            raw_flags=self.tag_flags,
+            recognized_flags=self.recognized_flags,
+            known_unmapped_flags=self.known_unmapped_flags,
+            unknown_flags=self.unknown_flags,
+        )
+
+    @property
+    def status(self) -> str:
+        """Legacy compatibility view; new code should use metadata_status + unknown_flags."""
+        if self.metadata_status != "ok":
+            return self.metadata_status
+        if self.capture_modes or self.unknown_flags == 0:
+            return "categorized"
+        return "unknown-flags"
+
+    @property
+    def mode(self) -> CaptureMode | None:
+        """Compatibility view: the single folder projection mode, never the semantic source of truth."""
+        return FolderProjection.primary_capture_mode(self)
+
+    @property
+    def tags(self) -> tuple[str, ...]:
+        values = {self.asset_type.tag_id}
+        values.update(mode.tag_id for mode in self.capture_modes)
+        values.update(capability.tag_id for capability in self.capabilities)
+        if self.vendor is not None:
+            values.add(self.vendor.tag_id)
+        return tuple(sorted(values))
+
+    def with_asset_type(self, asset_type: AssetType) -> "Classification":
+        return replace(self, asset_type=asset_type)
+
+
+class FolderProjection:
+    """Deterministic many-tag -> one physical directory projection."""
+
+    layout_version = CLASSIFICATION_LAYOUT_VERSION
+    root_folder_names = frozenset(asset.folder_name for asset in AssetType)
+
+    @staticmethod
+    def primary_capture_mode(classification: Classification) -> CaptureMode | None:
+        for candidate in MODE_PRIORITY:
+            if candidate in classification.capture_modes:
+                return candidate
+        # "Normal" is a presentation fallback only when OPPO metadata parsed cleanly and there are
+        # no completely unknown bits. Known-but-unmapped flags retain the historical normal folder.
+        if classification.metadata_status == "ok" and classification.tag_flags is not None and classification.unknown_flags == 0:
+            return CaptureMode.NORMAL
+        return None
+
+    @staticmethod
+    def relative_directory(classification: Classification, asset_type: AssetType | None = None) -> Path:
+        resolved_asset_type = asset_type or classification.asset_type
+        mode = FolderProjection.primary_capture_mode(classification)
+        leaf = mode.folder_name if mode is not None else UNCLASSIFIED_FOLDER_NAME
+        return Path(resolved_asset_type.folder_name) / leaf
+
+
+SUPPORTED_EXTENSIONS = {".heic", ".heif", ".jpg", ".jpeg"}
+COMMENT_PATTERN = re.compile(rb"(?:Oplus|Oppo)_[0-9]+", re.IGNORECASE)
+JSON_TAG_PATTERN = re.compile(rb'"oplustag"\s*:\s*"?([0-9]+)"?', re.IGNORECASE)
 
 
 @dataclass(frozen=True)
@@ -74,26 +244,80 @@ class CategorizationItem:
     error: str | None = None
 
 
+
 def classify_user_comment(raw: str | None) -> Classification:
     if raw is None or not raw.strip():
-        return Classification(raw, None, 0, None, "missing-user-comment")
+        return Classification(raw, None, 0, 0, 0, frozenset(), "missing-user-comment")
     normalized = raw.strip()
     flags = _parse_flags(normalized)
     if flags is None:
-        return Classification(normalized, None, 0, None, "malformed-user-comment")
+        return Classification(normalized, None, 0, 0, 0, frozenset(), "malformed-user-comment")
+
+    recognized = flags & MAPPED_FLAGS_MASK
+    known_unmapped = flags & KNOWN_FLAGS_MASK & ~MAPPED_FLAGS_MASK
     unknown = flags & ~KNOWN_FLAGS_MASK
-    mode = next((candidate for candidate in MODE_PRIORITY if flags & candidate.bit), None)
-    if mode is None and unknown:
-        return Classification(normalized, flags, unknown, None, "unknown-flags")
-    return Classification(normalized, flags, unknown, mode or CaptureMode.NORMAL, "categorized")
+    modes = frozenset(mode for mode in MODE_PRIORITY if flags & mode.bit)
+    return Classification(
+        normalized,
+        flags,
+        recognized,
+        known_unmapped,
+        unknown,
+        modes,
+        "ok",
+        vendor=CameraVendor.OPPO,
+    )
 
 
-def classify_path(path: Path) -> Classification:
+
+def classify_asset(asset: PhotoAsset) -> Classification:
+    """Classify the primary image while preserving the asset-level resource identity."""
+    return classify_path(asset.primary_image, asset.asset_type)
+
+
+def classify_path(path: Path, asset_type: AssetType | None = None) -> Classification:
+    resolved_asset_type = asset_type or infer_asset_type(path)
     try:
         raw = extract_user_comment(path)
+        data = path.read_bytes()
     except OSError:
-        return Classification(None, None, 0, None, "unreadable-image")
-    return classify_user_comment(raw)
+        return Classification(None, None, 0, 0, 0, frozenset(), "unreadable-image", asset_type=resolved_asset_type)
+    base = classify_user_comment(raw)
+    return replace(
+        base,
+        asset_type=resolved_asset_type,
+        capabilities=frozenset(_detect_capabilities(data)),
+    )
+
+
+
+
+def infer_asset_type(path: Path) -> AssetType:
+    suffix = Path(path).suffix.lower()
+    if suffix not in {".jpg", ".jpeg", ".heic", ".heif"}:
+        return AssetType.STATIC_PHOTO
+    try:
+        from .motion_photo import MotionPhotoError, parse_motion_photo
+    except (ImportError, ValueError):
+        return AssetType.STATIC_PHOTO
+    try:
+        return AssetType.LIVE_PHOTO if parse_motion_photo(Path(path)) is not None else AssetType.STATIC_PHOTO
+    except (OSError, MotionPhotoError):
+        return AssetType.STATIC_PHOTO
+
+def _detect_capabilities(data: bytes) -> set[PhotoCapability]:
+    """Emit only capabilities backed by container evidence understood by both implementations."""
+    capabilities: set[PhotoCapability] = set()
+    has_private_gain_map = (
+        b'"local.uhdr.gainmap.data"' in data
+        or b'"local.uhdr.gainmap.info"' in data
+    )
+    if has_private_gain_map:
+        capabilities.update({PhotoCapability.PROXDR, PhotoCapability.GAIN_MAP, PhotoCapability.HDR})
+    if b'\"rear.depth\"' in data and b'\"rear.depth.config\"' in data:
+        capabilities.add(PhotoCapability.DEPTH)
+    return capabilities
+
 
 
 def extract_user_comment(path: Path) -> str | None:
@@ -139,10 +363,16 @@ def extract_user_comment(path: Path) -> str | None:
     return None
 
 
+
 def collect_inputs(inputs: Iterable[Path], output_dir: Path) -> list[Path]:
+    input_paths = [Path(item) for item in inputs]
     excluded = output_dir.resolve(strict=False)
     collected: dict[str, Path] = {}
-    for source in inputs:
+    in_place_skip_roots = (
+        {asset.folder_name for asset in AssetType}
+        | {mode.folder_name for mode in CaptureMode}
+    )
+    for source in input_paths:
         if not source.exists():
             raise FileNotFoundError(f"input not found: {source}")
         candidates = [source] if source.is_file() else source.rglob("*")
@@ -150,39 +380,127 @@ def collect_inputs(inputs: Iterable[Path], output_dir: Path) -> list[Path]:
             resolved = candidate.resolve(strict=False)
             if resolved == excluded or excluded in resolved.parents:
                 continue
-            if candidate.is_file() and candidate.suffix.lower() in SUPPORTED_EXTENSIONS:
+            if not candidate.is_file() or candidate.suffix.lower() not in SUPPORTED_EXTENSIONS:
+                continue
+            skip = False
+            for input_root in input_paths:
+                if not input_root.is_dir():
+                    continue
+                try:
+                    relative = candidate.relative_to(input_root)
+                except ValueError:
+                    continue
+                if len(relative.parts) > 1 and relative.parts[0] in in_place_skip_roots:
+                    skip = True
+                    break
+            if not skip:
                 collected[str(resolved)] = candidate
     return [collected[key] for key in sorted(collected)]
 
 
-def make_plan(inputs: Iterable[Path], output_dir: Path) -> list[CategorizationItem]:
+LivePhotoPairValidator = Callable[[Path, Path], bool]
+
+
+def _companion_video(path: Path) -> Path | None:
+    stem = path.stem
+    try:
+        candidates = sorted(
+            (
+                candidate
+                for candidate in path.parent.iterdir()
+                if candidate.is_file()
+                and candidate.suffix.lower() == ".mov"
+                and candidate.stem == stem
+            ),
+            key=lambda candidate: candidate.name,
+        )
+    except OSError:
+        return None
+    return candidates[0] if candidates else None
+
+
+def _portable_live_photo_pair_validator(image: Path, video: Path) -> bool:
+    try:
+        from . import live_photo
+        return live_photo.existing_pair_is_valid(image, video)
+    except Exception:
+        return False
+
+
+def _resolved_asset(source: Path, pair_validator: LivePhotoPairValidator) -> PhotoAsset:
+    companion = _companion_video(source)
+    if companion is not None and pair_validator(source, companion):
+        return PhotoAsset.live_photo(source, companion)
+    if infer_asset_type(source) is AssetType.LIVE_PHOTO:
+        return PhotoAsset(
+            asset_id=str(source.resolve(strict=False)),
+            asset_type=AssetType.LIVE_PHOTO,
+            resources=(PhotoResource(source, ResourceRole.PRIMARY_IMAGE),),
+        )
+    return PhotoAsset.static_photo(source)
+
+
+def make_plan(
+    inputs: Iterable[Path],
+    output_dir: Path,
+    live_photo_pair_validator: LivePhotoPairValidator | None = None,
+) -> list[CategorizationItem]:
+    """Plan by user-visible photo asset while publishing one item per physical resource.
+
+    A same-basename MOV is never claimed on filename alone. The portable Live Photo validator must
+    confirm the HEIC/JPEG and MOV content identifiers before both resources enter one PhotoAsset.
+    """
+    pair_validator = live_photo_pair_validator or _portable_live_photo_pair_validator
     reserved: dict[Path, tuple[Path, str]] = {}
     items: list[CategorizationItem] = []
     for source in collect_inputs(inputs, output_dir):
-        classification = classify_path(source)
-        directory = output_dir / classification.mode.folder_name if classification.mode else output_dir
-        source_digest = _sha256(source)
+        asset = _resolved_asset(source, pair_validator)
+        classification = classify_asset(asset)
+        directory = output_dir / FolderProjection.relative_directory(classification)
+        digests = {resource.path: _sha256(resource.path) for resource in asset.resources}
         sequence = 1
         while True:
-            destination = _sequenced_destination(directory, source.name, sequence)
-            prior = reserved.get(destination)
-            if prior:
-                if prior[1] == source_digest:
-                    items.append(CategorizationItem(source, prior[0], classification, "duplicate"))
-                    break
+            candidates = [
+                (resource, _sequenced_destination(directory, resource.path.name, sequence))
+                for resource in asset.resources
+            ]
+            dispositions: dict[Path, str] = {}
+            conflict = False
+            for resource, destination in candidates:
+                digest = digests[resource.path]
+                prior = reserved.get(destination)
+                if prior is not None:
+                    if prior[1] == digest:
+                        dispositions[resource.path] = "duplicate"
+                    else:
+                        conflict = True
+                        break
+                elif destination.exists():
+                    if _files_match(resource.path, destination):
+                        dispositions[resource.path] = "duplicate"
+                    else:
+                        conflict = True
+                        break
+                else:
+                    dispositions[resource.path] = "copy"
+            if conflict:
                 sequence += 1
                 continue
-            if destination.exists():
-                if _files_match(source, destination):
-                    reserved[destination] = (destination, source_digest)
-                    items.append(CategorizationItem(source, destination, classification, "duplicate"))
-                    break
-                sequence += 1
-                continue
-            reserved[destination] = (destination, source_digest)
-            items.append(CategorizationItem(source, destination, classification, "copy"))
+
+            for resource, destination in candidates:
+                digest = digests[resource.path]
+                reserved.setdefault(destination, (destination, digest))
+                items.append(
+                    CategorizationItem(
+                        resource.path,
+                        destination,
+                        classification,
+                        dispositions.get(resource.path, "copy"),
+                    )
+                )
             break
     return items
+
 
 
 def execute_plan(items: list[CategorizationItem], jobs: int = 4, dry_run: bool = False) -> list[CategorizationItem]:
@@ -201,12 +519,17 @@ def execute_plan(items: list[CategorizationItem], jobs: int = 4, dry_run: bool =
         return list(pool.map(execute, items))
 
 
-def batch_destinations(files: list[Path], output_dir: Path) -> dict[Path, Path]:
+
+def batch_destinations(
+    files: list[Path],
+    output_dir: Path,
+    asset_type: AssetType | None = None,
+) -> dict[Path, Path]:
     reserved: set[Path] = set()
     result: dict[Path, Path] = {}
     for source in sorted(files, key=lambda item: str(item.resolve(strict=False))):
-        classification = classify_path(source)
-        directory = output_dir / classification.mode.folder_name if classification.mode else output_dir
+        classification = classify_path(source, asset_type)
+        directory = output_dir / FolderProjection.relative_directory(classification, asset_type)
         sequence = 1
         while True:
             destination = _sequenced_destination(directory, source.with_suffix(".heic").name, sequence)
@@ -216,6 +539,24 @@ def batch_destinations(files: list[Path], output_dir: Path) -> dict[Path, Path]:
                 break
             sequence += 1
     return result
+
+
+
+def classification_contract(classification: Classification) -> dict[str, object]:
+    """Canonical cross-runtime representation used by golden tests and future JSON surfaces."""
+    mode = classification.mode
+    return {
+        "asset_type": classification.asset_type.key,
+        "capture_modes": [candidate.key for candidate in MODE_PRIORITY if candidate in classification.capture_modes],
+        "primary_capture_mode": mode.key if mode is not None else None,
+        "folder": mode.folder_name if mode is not None else UNCLASSIFIED_FOLDER_NAME,
+        "metadata_status": classification.metadata_status,
+        "recognized_flags": classification.recognized_flags,
+        "known_unmapped_flags": classification.known_unmapped_flags,
+        "unknown_flags": classification.unknown_flags,
+        "tags": list(classification.tags),
+    }
+
 
 
 def _parse_flags(raw: str) -> int | None:
@@ -234,6 +575,7 @@ def _parse_flags(raw: str) -> int | None:
     return int(match.group(1)) if match else None
 
 
+
 def _decode_user_comment_value(value: object) -> str | None:
     if isinstance(value, str):
         return value.strip("\x00")
@@ -241,6 +583,7 @@ def _decode_user_comment_value(value: object) -> str | None:
         payload = value[8:] if len(value) >= 8 else value
         return payload.decode("utf-8", errors="replace").strip("\x00")
     return None
+
 
 
 def _extract_tiff_user_comment(exif_bytes: bytes) -> str | None:
@@ -281,11 +624,13 @@ def _extract_tiff_user_comment(exif_bytes: bytes) -> str | None:
     return None
 
 
+
 def _sequenced_destination(directory: Path, name: str, sequence: int) -> Path:
     if sequence == 1:
         return directory / name
     source = Path(name)
     return directory / f"{source.stem} ({sequence}){source.suffix}"
+
 
 
 def _sha256(path: Path) -> str:
@@ -296,8 +641,10 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+
 def _files_match(left: Path, right: Path) -> bool:
     return left.stat().st_size == right.stat().st_size and _sha256(left) == _sha256(right)
+
 
 
 def _copy_atomically(source: Path, destination: Path) -> None:

--- a/xdremux_py/cli.py
+++ b/xdremux_py/cli.py
@@ -27,9 +27,9 @@ from .live_photo_batch import (
     load_state,
     planned_output_image,
     provenance_allows_reuse,
+    reserve_output_image,
     source_signature,
     state_path,
-    validate_unique_plan,
 )
 from .motion_photo import MotionPhotoError, parse_motion_photo
 from .pipeline import ConversionAnalysis, ConversionConfiguration, ConversionError, MissingImagingDependencies
@@ -141,19 +141,27 @@ def _motion_output_directory(source: Path, command: BatchCommand) -> Path:
     return parent
 
 
-def _plan_motion_outputs(motion_inputs: list[Path], command: BatchCommand) -> list[tuple[Path, Path]]:
-    plan = [
-        (
+def _plan_motion_outputs(
+    motion_inputs: list[Path],
+    command: BatchCommand,
+    *,
+    reserved_paths: set[str],
+    state: dict,
+) -> list[tuple[Path, Path]]:
+    reserved = set(reserved_paths)
+    plan: list[tuple[Path, Path]] = []
+    for source in sorted(motion_inputs, key=lambda value: str(value.resolve())):
+        prior = state.get(str(source.resolve()))
+        output = reserve_output_image(
             source,
-            planned_output_image(
-                source,
-                command.input_dir,
-                _motion_output_directory(source, command),
+            command.input_dir,
+            _motion_output_directory(source, command),
+            reserved,
+            candidate_belongs_to_source=(
+                (lambda image, video, prior=prior: prior is not None and prior.matches_outputs(image, video))
             ),
         )
-        for source in sorted(motion_inputs, key=lambda value: str(value.resolve()))
-    ]
-    validate_unique_plan(plan)
+        plan.append((source, output))
     return plan
 
 
@@ -219,20 +227,20 @@ def cmd_batch(command: BatchCommand) -> int:
         (input_path, normal_destinations.get(input_path, command.output_dir / input_path.name))
         for input_path in normal_inputs
     ]
+    checkpoint = state_path(command.output_dir, command.checkpoint_path) if motion_inputs else None
+    state = load_state(checkpoint) if checkpoint is not None else {}
+    normal_output_paths = {str(output.resolve()) for _, output in normal_plan}
     try:
         _validate_unique_normal_plan(normal_plan)
-        motion_plan = _plan_motion_outputs(motion_inputs, command)
+        motion_plan = _plan_motion_outputs(
+            motion_inputs,
+            command,
+            reserved_paths=normal_output_paths,
+            state=state,
+        )
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
-
-    normal_output_paths = {str(output.resolve()) for _, output in normal_plan}
-    for source, output in motion_plan:
-        image_key = str(output.resolve())
-        video_key = str(live_photo.companion_video_path(output).resolve())
-        if image_key in normal_output_paths or video_key in normal_output_paths:
-            print(f"error: planned output collision for {source}: {output}", file=sys.stderr)
-            return 1
 
     converted = 0
     for input_path, output_path in normal_plan:
@@ -248,8 +256,7 @@ def cmd_batch(command: BatchCommand) -> int:
         )
         failed += len(motion_inputs)
     elif motion_plan:
-        checkpoint = state_path(command.output_dir, command.checkpoint_path)
-        state = load_state(checkpoint)
+        assert checkpoint is not None
         with StateWriter(checkpoint) as writer:
             for input_path, output_image in motion_plan:
                 output_video = live_photo.companion_video_path(output_image)
@@ -352,9 +359,9 @@ def cmd_categorize(command: CategorizeCommand) -> int:
         return 1
     results = categorize.execute_plan(plan, jobs=command.jobs, dry_run=command.dry_run)
     for item in results:
-        mode = item.classification.mode.folder_name if item.classification.mode else f"根目录 ({item.classification.status})"
+        category = categorize.FolderProjection.relative_directory(item.classification)
         detail = f" error={item.error}" if item.error else ""
-        print(f"{item.disposition} [{mode}] {item.source} -> {item.destination}{detail}")
+        print(f"{item.disposition} [{category}] {item.source} -> {item.destination}{detail}")
     copied = sum(item.disposition == "copied" for item in results)
     dry_run = sum(item.disposition == "dry-run" for item in results)
     duplicate = sum(item.disposition == "duplicate" for item in results)
@@ -365,7 +372,7 @@ def cmd_categorize(command: CategorizeCommand) -> int:
         for item in results
     )
     print(
-        f"categorize complete: {categorized} categorized, {root} kept at root, "
+        f"categorize complete: {categorized} categorized, {root} unclassified, "
         f"{copied} copied, {dry_run} dry-run, {duplicate} duplicate, {failed} failed"
     )
     return 0 if failed == 0 else 1
@@ -408,13 +415,13 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     b.add_argument("--categorize", action="store_true", dest="categorize_output",
-                   help="Write outputs under Chinese shooting-mode directories")
+                   help="Write outputs under asset-type / primary shooting-mode directories")
     b.add_argument("--skip-existing", action="store_true",
                    help="Reuse an existing Live Photo pair only when saved source provenance matches")
     b.add_argument("--resume", action="store_true",
                    help="Resume using the durable Motion Photo checkpoint/provenance state")
     b.add_argument("--checkpoint", help="Path for durable Motion Photo batch checkpoint/provenance state")
-    category = sub.add_parser("categorize", help="Copy photos into shooting-mode directories")
+    category = sub.add_parser("categorize", help="Copy photo assets into asset-type / shooting-mode directories")
     category.add_argument("--input", action="append", required=True,
                           help="Input photo or directory; may be repeated")
     category.add_argument("--output-dir", required=True)

--- a/xdremux_py/live_photo.py
+++ b/xdremux_py/live_photo.py
@@ -51,9 +51,12 @@ def is_motion_photo(path: Path) -> bool:
 
 
 def default_output_image(input_path: Path) -> Path:
-    if input_path.suffix.lower() in {".heic", ".heif"}:
-        return input_path.with_name(input_path.stem + ".live.heic")
-    return input_path.with_suffix(".heic")
+    """Preserve the user's basename; only avoid overwriting a same-path HEIC source."""
+    input_path = Path(input_path)
+    output = input_path.with_suffix(".heic")
+    if output.resolve() == input_path.resolve():
+        return output.with_name(f"{output.stem} (2){output.suffix}")
+    return output
 
 
 def companion_video_path(image_path: Path) -> Path:

--- a/xdremux_py/live_photo_batch.py
+++ b/xdremux_py/live_photo_batch.py
@@ -130,22 +130,50 @@ def relative_source_path(source: Path, input_root: Path) -> str:
     return unicodedata.normalize("NFC", relative)
 
 
-def stable_source_token(source: Path, input_root: Path, length: int = 32) -> str:
-    """Return a 128-bit token namespaced by canonical root plus normalized relative path."""
-    root = Path(input_root).resolve()
-    root_identity = unicodedata.normalize("NFC", root.as_posix())
-    relative = relative_source_path(source, root)
-    identity = root_identity + "\0" + relative
-    return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:length]
-
-
 def planned_output_image(source: Path, input_root: Path, output_directory: Path) -> Path:
-    """Return a stable Motion Photo output independent of the current batch membership/order."""
+    """Return the preferred user-facing output before collision resolution."""
     source = Path(source)
-    output_directory = Path(output_directory)
-    token = stable_source_token(source, input_root)
-    stem = source.stem + (".live" if source.suffix.lower() in {".heic", ".heif"} else "")
-    return output_directory / f"{stem}~{token}.heic"
+    _ = input_root  # Kept in the shared planner signature for Swift/Python parity.
+    return Path(output_directory) / f"{source.stem}.heic"
+
+
+def numbered_output_image(base: Path, sequence: int) -> Path:
+    base = Path(base)
+    if sequence <= 1:
+        return base
+    return base.with_name(f"{base.stem} ({sequence}){base.suffix}")
+
+
+def reserve_output_image(
+    source: Path,
+    input_root: Path,
+    output_directory: Path,
+    reserved_paths: set[str],
+    *,
+    candidate_belongs_to_source: Callable[[Path, Path], bool] | None = None,
+    path_exists: Callable[[Path], bool] | None = None,
+) -> Path:
+    """Reserve one HEIC+MOV basename, numbering only genuine destination collisions."""
+    source = Path(source)
+    base = planned_output_image(source, input_root, output_directory)
+    belongs = candidate_belongs_to_source or (lambda _image, _video: False)
+    exists = path_exists or (lambda path: path.exists())
+    source_key = str(source.resolve())
+    sequence = 1
+
+    while True:
+        image = numbered_output_image(base, sequence)
+        video = image.with_suffix(".mov")
+        image_key = str(image.resolve())
+        video_key = str(video.resolve())
+        planned_conflict = image_key in reserved_paths or video_key in reserved_paths
+        source_conflict = image_key == source_key or video_key == source_key
+        filesystem_conflict = not belongs(image, video) and (exists(image) or exists(video))
+        if not planned_conflict and not source_conflict and not filesystem_conflict:
+            reserved_paths.add(image_key)
+            reserved_paths.add(video_key)
+            return image
+        sequence += 1
 
 
 def validate_unique_plan(outputs: list[tuple[Path, Path]]) -> None:


### PR DESCRIPTION
## Summary

Refactors photo categorization from a lossy single-mode classifier into an asset-aware, multi-facet classification model while keeping a deterministic filesystem projection.

### Classification model
- Preserve every recognized OPPO capture-mode bit instead of selecting only the first matching mode.
- Keep `normal` as a folder fallback, not a semantic tag.
- Separate raw flag evidence into recognized, known-unmapped, and unknown flags.
- Separate metadata read status from unknown-bit diagnostics.
- Expose stable computed tag IDs such as `asset.live-photo`, `capture.portrait`, `capability.proxdr`, and `vendor.oppo`.
- Add typed asset, capability, vendor, resource-role, and evidence models.

### Asset-aware folder projection
- Project to `{asset type}/{primary capture mode}` instead of making classification itself choose one mode.
- Static photos: `静态照片/<mode>/...`
- Live Photos / Motion Photo conversions: `实况照片/<mode>/image.heic + video.mov`
- Unclassifiable capture modes: `<asset type>/未分类/...`
- Keep ProXDR/HDR/gain-map/depth/vendor as tags rather than additional physical folder levels.
- Preserve the historical mode priority only inside `PhotoFolderProjection` so each asset still has one deterministic physical location.

### Preserve user filenames
- Motion Photo conversion now preserves the source basename by default instead of appending `.live` or a source-identity hash.
- `IMG_1234.jpg`, `IMG_1234.heic`, and `IMG_1234.heif` prefer the Live Photo pair `IMG_1234.heic` + `IMG_1234.mov` when the destination namespace permits it.
- Only a real destination collision adds a sequence suffix: `IMG_1234 (2).heic` + `IMG_1234 (2).mov`, then `(3)`, and so on.
- HEIC and MOV are reserved atomically so both resources always receive the same sequence.
- Durable source identity remains internal in checkpoint/provenance and is never exposed in the filename.
- On rerun, checkpoint provenance can retain an existing original basename when that pair belongs to the same source; unrelated existing files are treated as collisions rather than silently reused.
- For an in-place single-file HEIC Motion Photo conversion, `(2)` is used only because the unchanged basename would overwrite the source itself.

### Live Photo resource identity
- Reuse the existing Apple Live Photo validator rather than recognizing pairs by filename.
- Standalone Swift CLI and macOS App claim a sibling MOV only when HEIC/JPEG + MOV pass pair validation.
- Python standalone categorization uses the existing portable Live Photo validator for the same rule.
- An unrelated same-basename MOV is never copied as part of the photo asset.
- The image and paired video share one collision sequence: if either resource conflicts, both move together to `name (2).*` rather than splitting the pair.
- Embedded Android Motion Photo sources remain single-resource `live-photo` assets until conversion produces the Apple pair.

### Batch / migration behavior
- Add the categorization layout version to the Swift batch checkpoint configuration identity.
- Skip the new asset-type output roots during in-place categorized batch scans while retaining compatibility with legacy capture-mode roots.
- Reuse the existing Motion Photo pair lifecycle; classification now supplies the asset-aware destination instead of introducing a second HEIC/MOV publication system.

### Cross-runtime contract
- Mirror the model and folder projection in Swift and Python.
- Add a shared canonical `photo_classification_cases.json` golden fixture covering multi-bit flags, known-unmapped bits, unknown bits, normal fallback, Live Photo projection, and malformed/missing metadata.
- Add Swift and Python contract tests plus update existing categorization parity/batch validation tests.
- Add explicit tests that a validated HEIC+MOV pair stays together and that a rejected same-name MOV remains untouched.
- Add filename-planner tests covering basename preservation, same-name collision sequencing, source-path collision avoidance, and provenance-owned reruns.

### Documentation
- Update Chinese/English README and CLI docs for the new `静态照片` / `实况照片` hierarchy and tag-vs-folder semantics.

The design follows the same separation used by mature photo managers: a user-visible photo/asset may own multiple physical resources, labels/keywords can be multi-valued, and physical folders are a separate storage projection.