### PR TITLE
Universal style v3: optional RAW-linear and gain-map inputs

### DIFF
--- a/.github/workflows/universal-style-training.yml
+++ b/.github/workflows/universal-style-training.yml
@@ -65,7 +65,7 @@ jobs:
             --output "$RUNNER_TEMP/public-style-pretraining" \
             --epochs 1 \
             --batch-size 2 \
-            --transforms-per-image 2 \
+            --transforms-per-image 8 \
             --device cpu
 
       - name: Upload public corpus audit and synthetic checkpoint

--- a/.github/workflows/universal-style-training.yml
+++ b/.github/workflows/universal-style-training.yml
@@ -9,6 +9,9 @@ on:
       - "scripts/predict_universal_photographic_style.py"
       - "scripts/train_universal_photographic_style.py"
       - "Tests/test_universal_photographic_style_training.py"
+      - "Tests/test_public_style_pretraining.py"
+      - "xdremux_py/public_style_pretraining.py"
+      - "scripts/train_public_synthetic_style.py"
       - ".github/workflows/universal-style-training.yml"
   workflow_dispatch:
     inputs:
@@ -45,7 +48,36 @@ jobs:
         run: >-
           python -m unittest
           Tests.test_apple_reverse_key1_training
+          Tests.test_public_style_pretraining
           Tests.test_universal_photographic_style_training
+
+      - name: Collect licensed public camera samples
+        run: |
+          python scripts/train_public_synthetic_style.py collect \
+            --output "$RUNNER_TEMP/public-style-corpus.json" \
+            --image-directory "$RUNNER_TEMP/public-style-images" \
+            --per-category 2
+
+      - name: Run one public synthetic pretraining epoch
+        run: |
+          python scripts/train_public_synthetic_style.py train \
+            --manifest "$RUNNER_TEMP/public-style-corpus.json" \
+            --output "$RUNNER_TEMP/public-style-pretraining" \
+            --epochs 1 \
+            --batch-size 2 \
+            --transforms-per-image 2 \
+            --device cpu
+
+      - name: Upload public corpus audit and synthetic checkpoint
+        uses: actions/upload-artifact@v7
+        with:
+          name: public-synthetic-style-${{ github.sha }}
+          path: |
+            ${{ runner.temp }}/public-style-corpus.json
+            ${{ runner.temp }}/public-style-pretraining/report.json
+            ${{ runner.temp }}/public-style-pretraining/synthetic-pretrained.pt
+          if-no-files-found: error
+          retention-days: 14
 
   private-training:
     if: github.event_name == 'workflow_dispatch' && inputs.run_private_training

--- a/.github/workflows/universal-style-training.yml
+++ b/.github/workflows/universal-style-training.yml
@@ -58,12 +58,12 @@ jobs:
             --image-directory "$RUNNER_TEMP/public-style-images" \
             --per-category 2
 
-      - name: Run one public synthetic pretraining epoch
+      - name: Run public synthetic pretraining
         run: |
           python scripts/train_public_synthetic_style.py train \
             --manifest "$RUNNER_TEMP/public-style-corpus.json" \
             --output "$RUNNER_TEMP/public-style-pretraining" \
-            --epochs 1 \
+            --epochs 3 \
             --batch-size 2 \
             --transforms-per-image 8 \
             --device cpu

--- a/.github/workflows/universal-style-training.yml
+++ b/.github/workflows/universal-style-training.yml
@@ -1,0 +1,106 @@
+name: Universal Style Training
+
+on:
+  pull_request:
+    paths:
+      - "xdremux_py/universal_photographic_style.py"
+      - "xdremux_py/universal_photographic_style_training.py"
+      - "scripts/export_universal_photographic_style_coreml.py"
+      - "scripts/predict_universal_photographic_style.py"
+      - "scripts/train_universal_photographic_style.py"
+      - "Tests/test_universal_photographic_style_training.py"
+      - ".github/workflows/universal-style-training.yml"
+  workflow_dispatch:
+    inputs:
+      run_private_training:
+        description: Run training on the labelled-data self-hosted Mac
+        required: true
+        default: false
+        type: boolean
+      epochs:
+        description: Training epochs
+        required: true
+        default: "40"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  multimodal-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install training dependencies
+        run: python -m pip install -e ".[training]"
+
+      - name: Run universal model regressions with PyTorch
+        run: >-
+          python -m unittest
+          Tests.test_apple_reverse_key1_training
+          Tests.test_universal_photographic_style_training
+
+  private-training:
+    if: github.event_name == 'workflow_dispatch' && inputs.run_private_training
+    runs-on: [self-hosted, macOS, ARM64, xdremux-style-training]
+    timeout-minutes: 720
+    env:
+      UNIVERSAL_MANIFEST: ${{ vars.XDREMUX_UNIVERSAL_MANIFEST }}
+      RESUME_CHECKPOINT: ${{ vars.XDREMUX_UNIVERSAL_CHECKPOINT }}
+      TRAINING_EPOCHS: ${{ inputs.epochs }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Require private labelled inputs
+        shell: bash
+        run: |
+          test -n "$UNIVERSAL_MANIFEST"
+          test -f "$UNIVERSAL_MANIFEST"
+          if [[ -n "$RESUME_CHECKPOINT" ]]; then
+            test -f "$RESUME_CHECKPOINT"
+          fi
+
+      - name: Install training dependencies
+        run: python -m pip install -e ".[training]"
+
+      - name: Train required-image plus optional-modality model
+        shell: bash
+        run: |
+          args=(
+            python scripts/train_universal_photographic_style.py train
+            --manifest "$UNIVERSAL_MANIFEST"
+            --output "$RUNNER_TEMP/universal-style-v3"
+            --epochs "$TRAINING_EPOCHS"
+            --architecture multimodal_large
+            --metadata-dropout 0.25
+            --optional-modality-dropout 0.35
+            --device mps
+          )
+          if [[ -n "$RESUME_CHECKPOINT" ]]; then
+            args+=(--warm-start "$RESUME_CHECKPOINT")
+          fi
+          "${args[@]}"
+
+      - name: Upload checkpoint and reports
+        uses: actions/upload-artifact@v7
+        with:
+          name: universal-style-v3-${{ github.sha }}
+          path: |
+            ${{ runner.temp }}/universal-style-v3/best.pt
+            ${{ runner.temp }}/universal-style-v3/last.pt
+            ${{ runner.temp }}/universal-style-v3/history.json
+            ${{ runner.temp }}/universal-style-v3/report.json
+          if-no-files-found: error
+          retention-days: 14

--- a/Tests/test_public_style_pretraining.py
+++ b/Tests/test_public_style_pretraining.py
@@ -3,12 +3,25 @@ import unittest
 import numpy as np
 
 from xdremux_py.public_style_pretraining import (
+    COMMONS_USER_AGENT,
+    CURATED_GITHUB_SAMPLES,
     commons_candidates,
     synthetic_affine_pair,
 )
 
 
 class PublicStylePretrainingTests(unittest.TestCase):
+    def test_commons_user_agent_identifies_bot_and_contact(self) -> None:
+        self.assertIn("Bot/", COMMONS_USER_AGENT)
+        self.assertIn("https://github.com/21Z121Z1/XDRemux", COMMONS_USER_AGENT)
+
+    def test_curated_github_samples_are_reusable_and_revision_pinned(self) -> None:
+        self.assertGreaterEqual(len(CURATED_GITHUB_SAMPLES), 7)
+        for sample in CURATED_GITHUB_SAMPLES:
+            self.assertIn(sample["license"], {"CC0", "Public domain"})
+            self.assertIn("/v0.24.0/", sample["downloadURL"])
+            self.assertEqual(len(sample["sourceGitBlobSHA1"]), 40)
+
     def test_commons_candidates_enforce_license_and_raster_contract(self) -> None:
         def page(title: str, license_name: str, mime: str = "image/jpeg") -> dict:
             return {

--- a/Tests/test_public_style_pretraining.py
+++ b/Tests/test_public_style_pretraining.py
@@ -1,0 +1,60 @@
+import unittest
+
+import numpy as np
+
+from xdremux_py.public_style_pretraining import (
+    commons_candidates,
+    synthetic_affine_pair,
+)
+
+
+class PublicStylePretrainingTests(unittest.TestCase):
+    def test_commons_candidates_enforce_license_and_raster_contract(self) -> None:
+        def page(title: str, license_name: str, mime: str = "image/jpeg") -> dict:
+            return {
+                "title": title,
+                "imageinfo": [
+                    {
+                        "mime": mime,
+                        "thumburl": f"https://example.test/{title}",
+                        "descriptionurl": f"https://example.test/wiki/{title}",
+                        "sha1": "a" * 40,
+                        "extmetadata": {
+                            "LicenseShortName": {"value": license_name},
+                            "LicenseUrl": {"value": "https://license.test"},
+                            "Artist": {"value": "Photographer"},
+                        },
+                    }
+                ],
+            }
+
+        payload = {
+            "query": {
+                "pages": [
+                    page("allowed.jpg", "CC BY 4.0"),
+                    page("legacy.jpg", "CC BY-SA 3.0"),
+                    page("video.webm", "CC0", "video/webm"),
+                ]
+            }
+        }
+        actual = commons_candidates(payload, "test camera", 5)
+        self.assertEqual([item["title"] for item in actual], ["allowed.jpg"])
+        self.assertEqual(actual[0]["license"], "CC BY 4.0")
+
+    def test_synthetic_affine_key_exactly_recovers_clean_target(self) -> None:
+        source = np.random.default_rng(7).random((3, 256, 256), dtype=np.float32)
+        styled, clean, key1 = synthetic_affine_pair(source, np.random.default_rng(8))
+        coefficients = key1.mean(axis=(0, 1, 2))
+        red, green, blue = styled
+        terms = np.stack(
+            (
+                np.ones_like(red), red, green, blue, red * red, red * green,
+                red * blue, green * green, green * blue, blue * blue,
+            )
+        )
+        recovered = np.einsum("thw,tc->chw", terms, coefficients)
+        self.assertLess(float(np.max(np.abs(recovered - clean))), 2e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/test_public_style_pretraining.py
+++ b/Tests/test_public_style_pretraining.py
@@ -32,7 +32,7 @@ class PublicStylePretrainingTests(unittest.TestCase):
             "query": {
                 "pages": [
                     page("allowed.jpg", "CC BY 4.0"),
-                    page("legacy.jpg", "CC BY-SA 3.0"),
+                    page("legacy.jpg", "CC BY-NC 4.0"),
                     page("video.webm", "CC0", "video/webm"),
                 ]
             }

--- a/Tests/test_universal_photographic_style_training.py
+++ b/Tests/test_universal_photographic_style_training.py
@@ -1,5 +1,7 @@
 import base64
 import hashlib
+import json
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -7,13 +9,20 @@ import numpy as np
 
 from xdremux_py.apple_reverse_key1_training import ReverseKey1Error
 from xdremux_py.universal_photographic_style_training import (
+    GAIN_MAP_CHANNELS,
+    INPUT_SIZE,
+    LINEAR_CHANNELS,
     METADATA_FIELDS,
+    MODALITY_FIELDS,
+    OPTIONAL_MODALITIES_SCHEMA,
     PRIMARY_CHANNELS,
     STYLE_SCALAR_FIELDS,
     build_universal_model,
     decode_style_binary,
+    gain_map_features,
     metadata_vector,
     primary_image_features,
+    _load_optional_modalities_manifest,
     _consumer_quadratic_proxy,
 )
 from xdremux_py.universal_photographic_style import (
@@ -23,6 +32,23 @@ from xdremux_py.universal_photographic_style import (
 
 
 class UniversalPhotographicStyleTrainingTests(unittest.TestCase):
+    @staticmethod
+    def _statistics() -> dict[str, np.ndarray]:
+        return {
+            "metadataCenter": np.zeros(len(METADATA_FIELDS), dtype=np.float32),
+            "metadataScale": np.ones(len(METADATA_FIELDS), dtype=np.float32),
+            "metadataActive": np.ones(len(METADATA_FIELDS), dtype=np.float32),
+            "key1Scale": np.ones((8, 10, 3), dtype=np.float32),
+            "gtcCenter": np.zeros(516, dtype=np.float32),
+            "gtcScale": np.ones(516, dtype=np.float32),
+            "lightCenter": np.zeros((2, 32, 32), dtype=np.float32),
+            "lightScale": np.ones(2, dtype=np.float32),
+            "scalarCenter": np.zeros(len(STYLE_SCALAR_FIELDS), dtype=np.float32),
+            "scalarScale": np.ones(len(STYLE_SCALAR_FIELDS), dtype=np.float32),
+            "scalarLow": np.full(len(STYLE_SCALAR_FIELDS), -10.0, dtype=np.float32),
+            "scalarHigh": np.full(len(STYLE_SCALAR_FIELDS), 10.0, dtype=np.float32),
+        }
+
     def test_published_coreml_package_has_recorded_file_identities(self) -> None:
         root = (
             Path(__file__).resolve().parents[1]
@@ -58,6 +84,45 @@ class UniversalPhotographicStyleTrainingTests(unittest.TestCase):
         self.assertEqual(mask[METADATA_FIELDS.index("has_gain_map")], 1)
         self.assertEqual(values[METADATA_FIELDS.index("has_gain_map")], 0)
 
+    def test_gain_map_features_use_linear_gain_ratio_contract(self) -> None:
+        neutral = gain_map_features(np.ones((INPUT_SIZE, INPUT_SIZE), dtype=np.float32))
+        self.assertEqual(neutral.shape, (GAIN_MAP_CHANNELS, INPUT_SIZE, INPUT_SIZE))
+        self.assertTrue(np.array_equal(neutral, np.zeros_like(neutral)))
+        with self.assertRaises(ReverseKey1Error):
+            gain_map_features(np.zeros((INPUT_SIZE, INPUT_SIZE), dtype=np.float32))
+
+    def test_optional_modality_manifest_is_content_addressed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            np.save(
+                root / "linear.npy",
+                np.full((3, INPUT_SIZE, INPUT_SIZE), 0.5, dtype=np.float32),
+            )
+            np.save(
+                root / "gain.npy",
+                np.ones((INPUT_SIZE, INPUT_SIZE), dtype=np.float32),
+            )
+            manifest = root / "modalities.json"
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "schema": OPTIONAL_MODALITIES_SCHEMA,
+                        "samples": [
+                            {
+                                "sourceSHA256": "a" * 64,
+                                "linearRGBPath": "linear.npy",
+                                "gainMapPath": "gain.npy",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            loaded = _load_optional_modalities_manifest(manifest)["a" * 64]
+            self.assertEqual(len(loaded["linearRGBSHA256"]), 64)
+            self.assertEqual(len(loaded["gainMapSHA256"]), 64)
+            self.assertEqual(Path(loaded["linearRGBPath"]), (root / "linear.npy").resolve())
+
     def test_binary_labels_are_length_checked(self) -> None:
         encoded = "base64:" + base64.b64encode(b"abcd").decode("ascii")
         self.assertEqual(decode_style_binary(encoded, 4, "test"), b"abcd")
@@ -69,20 +134,7 @@ class UniversalPhotographicStyleTrainingTests(unittest.TestCase):
             import torch
         except ImportError:
             self.skipTest("PyTorch is unavailable")
-        statistics = {
-            "metadataCenter": np.zeros(len(METADATA_FIELDS), dtype=np.float32),
-            "metadataScale": np.ones(len(METADATA_FIELDS), dtype=np.float32),
-            "metadataActive": np.ones(len(METADATA_FIELDS), dtype=np.float32),
-            "key1Scale": np.ones((8, 10, 3), dtype=np.float32),
-            "gtcCenter": np.zeros(516, dtype=np.float32),
-            "gtcScale": np.ones(516, dtype=np.float32),
-            "lightCenter": np.zeros((2, 32, 32), dtype=np.float32),
-            "lightScale": np.ones(2, dtype=np.float32),
-            "scalarCenter": np.zeros(len(STYLE_SCALAR_FIELDS), dtype=np.float32),
-            "scalarScale": np.ones(len(STYLE_SCALAR_FIELDS), dtype=np.float32),
-            "scalarLow": np.full(len(STYLE_SCALAR_FIELDS), -10.0, dtype=np.float32),
-            "scalarHigh": np.full(len(STYLE_SCALAR_FIELDS), 10.0, dtype=np.float32),
-        }
+        statistics = self._statistics()
         expected = {
             "key1": (1, 12, 12, 8, 10, 3),
             "key1LogVariance": (1, 8, 10, 3),
@@ -91,7 +143,7 @@ class UniversalPhotographicStyleTrainingTests(unittest.TestCase):
             "scalars": (1, len(STYLE_SCALAR_FIELDS)),
             "unstyled": (1, 3, 64, 64),
         }
-        for architecture in ("base", "multiscale_large"):
+        for architecture in ("base", "multiscale_large", "multimodal_large"):
             with self.subTest(architecture=architecture):
                 model = build_universal_model(
                     statistics, architecture=architecture
@@ -109,6 +161,30 @@ class UniversalPhotographicStyleTrainingTests(unittest.TestCase):
                 self.assertTrue(
                     all(bool(torch.isfinite(value).all()) for value in output.values())
                 )
+
+    def test_multimodal_zero_mask_is_identical_to_missing_sidecars(self) -> None:
+        try:
+            import torch
+        except ImportError:
+            self.skipTest("PyTorch is unavailable")
+        model = build_universal_model(
+            self._statistics(), architecture="multimodal_large"
+        ).eval()
+        primary = torch.rand((1, PRIMARY_CHANNELS, INPUT_SIZE, INPUT_SIZE))
+        metadata = torch.zeros((1, len(METADATA_FIELDS)))
+        metadata_mask = torch.zeros_like(metadata)
+        with torch.no_grad():
+            missing = model(primary, metadata, metadata_mask)
+            masked = model(
+                primary,
+                metadata,
+                metadata_mask,
+                torch.rand((1, LINEAR_CHANNELS, INPUT_SIZE, INPUT_SIZE)),
+                torch.rand((1, GAIN_MAP_CHANNELS, INPUT_SIZE, INPUT_SIZE)),
+                torch.zeros((1, len(MODALITY_FIELDS))),
+            )
+        for name in missing:
+            self.assertTrue(torch.equal(missing[name], masked[name]), name)
 
     def test_native_state_resources_have_native_byte_lengths(self) -> None:
         image = UniversalImageInput(

--- a/Tests/test_universal_photographic_style_training.py
+++ b/Tests/test_universal_photographic_style_training.py
@@ -23,6 +23,7 @@ from xdremux_py.universal_photographic_style_training import (
     metadata_vector,
     primary_image_features,
     _load_optional_modalities_manifest,
+    _warm_start_model_state,
     _consumer_quadratic_proxy,
 )
 from xdremux_py.universal_photographic_style import (
@@ -185,6 +186,36 @@ class UniversalPhotographicStyleTrainingTests(unittest.TestCase):
             )
         for name in missing:
             self.assertTrue(torch.equal(missing[name], masked[name]), name)
+
+    def test_warm_start_migrates_stem_but_keeps_target_statistics(self) -> None:
+        try:
+            import torch
+        except ImportError:
+            self.skipTest("PyTorch is unavailable")
+        source_statistics = self._statistics()
+        source_statistics["key1Scale"] = np.full((8, 10, 3), 7.0, dtype=np.float32)
+        source = build_universal_model(
+            source_statistics, architecture="multiscale_large"
+        )
+        target = build_universal_model(
+            self._statistics(), architecture="multimodal_large"
+        )
+        _warm_start_model_state(
+            target,
+            source.state_dict(),
+            source_architecture="multiscale_large",
+            target_architecture="multimodal_large",
+        )
+        self.assertTrue(torch.equal(target.key1_scale, torch.ones_like(target.key1_scale)))
+        source_stem = source.encoder_stages[0][0].weight
+        target_stem = target.encoder_stages[0][0].weight
+        self.assertTrue(torch.equal(target_stem[:, :PRIMARY_CHANNELS], source_stem))
+        self.assertTrue(
+            torch.equal(
+                target_stem[:, PRIMARY_CHANNELS:],
+                torch.zeros_like(target_stem[:, PRIMARY_CHANNELS:]),
+            )
+        )
 
     def test_native_state_resources_have_native_byte_lengths(self) -> None:
         image = UniversalImageInput(

--- a/docs/development.md
+++ b/docs/development.md
@@ -205,8 +205,10 @@ self-hosted Apple Silicon runner，并从 repository variables 读取私有 mani
 路径。训练产物只上传为短期 Actions artifact，不提交样片或 checkpoint。
 
 公开内容域的第一阶段预训练由 `scripts/train_public_synthetic_style.py` 完成。collector
-通过 Wikimedia Commons API 从 iPhone 16/16 Pro/17 Pro 与 OPPO A3x/F29 实拍分类抽样，
-只接受 `CC0`、Public Domain，以及 1.0–4.0 的 `CC BY` / `CC BY-SA`（排除 NC/ND），
+先从固定到 `scikit-image` v0.24.0 revision 的 GitHub 数据中下载逐张确认过的 CC0/
+Public Domain 人像、动物、静物、纹理、暗场和航天照片，再通过 Wikimedia Commons API
+从 iPhone 16/16 Pro/17 Pro 与 OPPO A3x/F29 实拍分类抽样。它只接受 `CC0`、
+Public Domain，以及 1.0–4.0 的 `CC BY` / `CC BY-SA`（排除 NC/ND），
 保存源页面、作者、许可 URL、源 SHA-1、
 下载 SHA-256 与归一化 tensor SHA-256。原图和 tensor 只存在于 Actions 临时目录。
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -206,7 +206,8 @@ self-hosted Apple Silicon runner，并从 repository variables 读取私有 mani
 
 公开内容域的第一阶段预训练由 `scripts/train_public_synthetic_style.py` 完成。collector
 通过 Wikimedia Commons API 从 iPhone 16/16 Pro/17 Pro 与 OPPO A3x/F29 实拍分类抽样，
-只接受 `CC0`、`CC BY 4.0`、`CC BY-SA 4.0`，保存源页面、作者、许可 URL、源 SHA-1、
+只接受 `CC0`、Public Domain，以及 1.0–4.0 的 `CC BY` / `CC BY-SA`（排除 NC/ND），
+保存源页面、作者、许可 URL、源 SHA-1、
 下载 SHA-256 与归一化 tensor SHA-256。原图和 tensor 只存在于 Actions 临时目录。
 
 由于这些公开图没有 Apple key1 真值，训练脚本对每张图生成有精确解析逆解的受约束

--- a/docs/development.md
+++ b/docs/development.md
@@ -153,6 +153,57 @@ Universal 训练支持 `--resume`（要求 checkpoint 与 manifest hash 一致�
 consumer proxy 训练正则；它不是 Apple renderer。短程 v3 resume ablation 的 held-out
 key1 MAE 有改善，但 proxy 像素 RMSE 仍高于 identity，未导出或替换发布模型。
 
+### Universal optional-modality v3 研究接口
+
+新的 `multimodal_large` 训练架构仍把一张普通主图设为唯一必需输入。RAW 解码得到的
+归一化 scene-linear RGB 与 HDR gain map 是两个可选张量，并另带 `modality_mask`；因此“没有该模态”
+不会和全零线性图或 neutral gain map 混淆。训练默认独立随机丢弃 35% 的可选模态，
+用于约束 primary-only 路径，而不是让网络依赖某一手机的容器结构。
+
+训练 sidecar 必须预先解码、方向归一并缩放到 `256 × 256`。线性 RGB 数值范围为
+`[0, 1]`，其中 `1.0` 是归一化线性白点；数据形状为
+`3 × 256 × 256` 浮点 `.npy`，或带 `linear_rgb` key 的 `.npz`；gain map 为线性曝光
+倍率（`1.0` 表示 neutral）的 `256 × 256` 浮点 `.npy`，或带 `gain_map` key 的
+`.npz`。清单示例：
+
+```json
+{
+  "schema": "xdremux-universal-optional-modalities-v1",
+  "samples": [
+    {
+      "sourceSHA256": "<对应 native 样本的 SHA-256>",
+      "linearRGBPath": "sidecars/example-linear.npy",
+      "gainMapPath": "sidecars/example-gain.npy"
+    }
+  ]
+}
+```
+
+先把 sidecar 与 native 标签清单合并，再训练：
+
+```bash
+python3 scripts/train_universal_photographic_style.py prepare \
+  --native-manifest /private/native/manifest.json \
+  --optional-modalities-manifest /private/modalities.json \
+  --output /private/universal-v3
+
+python3 scripts/train_universal_photographic_style.py train \
+  --manifest /private/universal-v3/manifest.json \
+  --output /private/universal-v3-run \
+  --architecture multimodal_large \
+  --warm-start /private/checkpoints/multiscale-large.pt
+```
+
+`--resume` 只允许完全相同的 prepared manifest；增加样本或 sidecar 后必须使用
+`--warm-start`。从 `multiscale_large` checkpoint warm-start 时，主图通道权重原样迁移，新模态通道以
+零初始化，所以所有可选模态缺失时的初始函数保持一致。在线普通图片没有 key1/GTC/
+light-map 真值，只能扩充内容域或做自监督；要提升 solver 一致性，仍必须在具备完整
+Neutrino 的受控 Mac 上为它们生成教师标签。GitHub 托管 macOS runner 的 identity
+fallback 不能作为教师。`Universal Style Training` workflow 因此只在 Ubuntu 执行公开
+PyTorch 契约测试；真实训练是显式触发、带 `xdremux-style-training` 标签的私有
+self-hosted Apple Silicon runner，并从 repository variables 读取私有 manifest/checkpoint
+路径。训练产物只上传为短期 Actions artifact，不提交样片或 checkpoint。
+
 Privileged-teacher cascade 评测入口为
 `scripts/evaluate_universal_paired_cascade.py`。它固定 calibration-derived 的
 paired ensemble alpha `0.625`，分别报告 Universal direct、真实 disabled unstyled 的

--- a/docs/development.md
+++ b/docs/development.md
@@ -204,6 +204,18 @@ PyTorch 契约测试；真实训练是显式触发、带 `xdremux-style-training
 self-hosted Apple Silicon runner，并从 repository variables 读取私有 manifest/checkpoint
 路径。训练产物只上传为短期 Actions artifact，不提交样片或 checkpoint。
 
+公开内容域的第一阶段预训练由 `scripts/train_public_synthetic_style.py` 完成。collector
+通过 Wikimedia Commons API 从 iPhone 16/16 Pro/17 Pro 与 OPPO A3x/F29 实拍分类抽样，
+只接受 `CC0`、`CC BY 4.0`、`CC BY-SA 4.0`，保存源页面、作者、许可 URL、源 SHA-1、
+下载 SHA-256 与归一化 tensor SHA-256。原图和 tensor 只存在于 Actions 临时目录。
+
+由于这些公开图没有 Apple key1 真值，训练脚本对每张图生成有精确解析逆解的受约束
+RGB affine style，并把对应的 10 项 polynomial key1 作为合成教师；训练目标只用于主图
+encoder/key1/unstyled 的内容域预训练。报告明确标为 `syntheticPretrainingOnly`，不能把
+合成 heldout 的改善解释为 native Apple 或 constrained solver 精度。下一阶段必须用
+原生样本或完整 Neutrino solver 标注 warm-start 该 checkpoint，并以原有 session-heldout
+与真实 consumer A/B 决定是否接受。
+
 Privileged-teacher cascade 评测入口为
 `scripts/evaluate_universal_paired_cascade.py`。它固定 calibration-derived 的
 paired ensemble alpha `0.625`，分别报告 Universal direct、真实 disabled unstyled 的

--- a/scripts/export_universal_photographic_style_coreml.py
+++ b/scripts/export_universal_photographic_style_coreml.py
@@ -18,6 +18,12 @@ if __package__ in (None, ""):
 from xdremux_py.apple_reverse_key1_training import _atomic_json, _require_torch, sha256_file
 from xdremux_py.universal_photographic_style import load_universal_image, load_universal_model
 from xdremux_py.universal_photographic_style_training import METADATA_FIELDS, PRIMARY_CHANNELS
+from xdremux_py.universal_photographic_style_training import (
+    GAIN_MAP_CHANNELS,
+    INPUT_SIZE,
+    LINEAR_CHANNELS,
+    MODALITY_FIELDS,
+)
 
 
 def main() -> None:
@@ -26,6 +32,8 @@ def main() -> None:
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument("--report", required=True, type=Path)
     parser.add_argument("--fixture", type=Path)
+    parser.add_argument("--linear-rgb-sidecar", type=Path)
+    parser.add_argument("--gain-map-sidecar", type=Path)
     args = parser.parse_args()
     output = args.output.resolve()
     if output.exists():
@@ -80,8 +88,31 @@ def main() -> None:
                 source.key1_scale.detach().reshape(1, 1, 1, 8, 30),
             )
 
-        def forward(self, features: Any, metadata: Any, metadata_mask: Any) -> tuple[Any, ...]:
+        def forward(
+            self,
+            features: Any,
+            metadata: Any,
+            metadata_mask: Any,
+            linear_features: Any | None = None,
+            gain_map_features: Any | None = None,
+            modality_mask: Any | None = None,
+        ) -> tuple[Any, ...]:
             value = features
+            if self.source.supports_optional_modalities:
+                linear_mask = modality_mask[:, 0, None, None, None]
+                gain_mask = modality_mask[:, 1, None, None, None]
+                mask_planes = modality_mask[:, :, None, None].expand(
+                    -1, -1, INPUT_SIZE, INPUT_SIZE
+                )
+                value = torch.cat(
+                    (
+                        features,
+                        linear_features * linear_mask,
+                        gain_map_features * gain_mask,
+                        mask_planes,
+                    ),
+                    dim=1,
+                )
             pyramid = []
             for stage, projection in zip(
                 self.source.encoder_stages, self.source.scale_projections
@@ -149,7 +180,11 @@ def main() -> None:
     if hasattr(torch.backends, "mha"):
         torch.backends.mha.set_fastpath_enabled(False)
     if args.fixture is not None:
-        fixture = load_universal_image(args.fixture)
+        fixture = load_universal_image(
+            args.fixture,
+            linear_rgb_sidecar=args.linear_rgb_sidecar,
+            gain_map_sidecar=args.gain_map_sidecar,
+        )
         examples = (
             torch.from_numpy(fixture.primary).unsqueeze(0),
             torch.from_numpy(fixture.metadata).unsqueeze(0),
@@ -161,6 +196,29 @@ def main() -> None:
             torch.zeros((1, PRIMARY_CHANNELS, 256, 256), dtype=torch.float32),
             torch.zeros((1, len(METADATA_FIELDS)), dtype=torch.float32),
             torch.zeros((1, len(METADATA_FIELDS)), dtype=torch.float32),
+        )
+    if model.supports_optional_modalities:
+        linear = (
+            fixture.linear_rgb_features
+            if fixture is not None and fixture.linear_rgb_features is not None
+            else np.zeros((LINEAR_CHANNELS, INPUT_SIZE, INPUT_SIZE), dtype=np.float32)
+        )
+        gain = (
+            fixture.gain_map_features
+            if fixture is not None and fixture.gain_map_features is not None
+            else np.zeros((GAIN_MAP_CHANNELS, INPUT_SIZE, INPUT_SIZE), dtype=np.float32)
+        )
+        modality_mask = np.asarray(
+            [
+                fixture is not None and fixture.linear_rgb_features is not None,
+                fixture is not None and fixture.gain_map_features is not None,
+            ],
+            dtype=np.float32,
+        )
+        examples = examples + (
+            torch.from_numpy(linear).unsqueeze(0),
+            torch.from_numpy(gain).unsqueeze(0),
+            torch.from_numpy(modality_mask).unsqueeze(0),
         )
     with torch.no_grad():
         expected = [value.numpy() for value in wrapper(*examples)]
@@ -174,7 +232,22 @@ def main() -> None:
             ct.TensorType(
                 name="metadata_mask", shape=examples[2].shape, dtype=np.float32
             ),
-        ],
+        ]
+        + (
+            [
+                ct.TensorType(
+                    name="linear_features", shape=examples[3].shape, dtype=np.float32
+                ),
+                ct.TensorType(
+                    name="gain_map_features", shape=examples[4].shape, dtype=np.float32
+                ),
+                ct.TensorType(
+                    name="modality_mask", shape=examples[5].shape, dtype=np.float32
+                ),
+            ]
+            if model.supports_optional_modalities
+            else []
+        ),
         outputs=[
             ct.TensorType(name="key1"),
             ct.TensorType(name="key1_log_variance"),
@@ -192,7 +265,9 @@ def main() -> None:
     )
     converted.user_defined_metadata["architecture"] = str(checkpoint["architecture"])
     converted.user_defined_metadata["inputContract"] = (
-        "primary image features plus masked metadata"
+        "required primary features plus masked metadata and optional linear/gain tensors"
+        if model.supports_optional_modalities
+        else "primary image features plus masked metadata"
     )
     output.parent.mkdir(parents=True, exist_ok=True)
     converted.save(output)
@@ -203,6 +278,14 @@ def main() -> None:
         "metadata": examples[1].numpy(),
         "metadata_mask": examples[2].numpy(),
     }
+    if model.supports_optional_modalities:
+        feed.update(
+            {
+                "linear_features": examples[3].numpy(),
+                "gain_map_features": examples[4].numpy(),
+                "modality_mask": examples[5].numpy(),
+            }
+        )
     names = (
         "key1",
         "key1_log_variance",

--- a/scripts/predict_universal_photographic_style.py
+++ b/scripts/predict_universal_photographic_style.py
@@ -27,9 +27,24 @@ def main() -> None:
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument("--device", choices=("auto", "mps", "cpu"), default="auto")
     parser.add_argument("--exiftool", default="exiftool")
+    parser.add_argument(
+        "--linear-rgb-sidecar",
+        type=Path,
+        help="decoded oriented 3x256x256 linear RGB .npy/.npz sidecar",
+    )
+    parser.add_argument(
+        "--gain-map-sidecar",
+        type=Path,
+        help="decoded oriented 256x256 exposure-gain-ratio .npy/.npz sidecar",
+    )
     args = parser.parse_args()
 
-    image = load_universal_image(args.input, exiftool=args.exiftool)
+    image = load_universal_image(
+        args.input,
+        exiftool=args.exiftool,
+        linear_rgb_sidecar=args.linear_rgb_sidecar,
+        gain_map_sidecar=args.gain_map_sidecar,
+    )
     model, checkpoint, device = load_universal_model(args.checkpoint, args.device)
     prediction, elapsed = predict_universal_state(image, model, device=device)
     resources = native_state_resources(image, prediction)
@@ -52,6 +67,8 @@ def main() -> None:
             "displayHeight": image.display_height,
             "hasRAW": image.has_raw,
             "hasGainMap": image.has_gain_map,
+            "usedLinearRGB": image.linear_rgb_features is not None,
+            "usedGainMap": image.gain_map_features is not None,
             "make": image.source_make,
             "model": image.source_model,
         },

--- a/scripts/train_public_synthetic_style.py
+++ b/scripts/train_public_synthetic_style.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Collect licensed public photos and run synthetic key1 pretraining."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from xdremux_py.public_style_pretraining import (
+    DEFAULT_CATEGORIES,
+    PublicPretrainingConfig,
+    collect_public_corpus,
+    pretrain_public_synthetic_style,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    collect = commands.add_parser("collect")
+    collect.add_argument("--output", required=True, type=Path)
+    collect.add_argument("--image-directory", required=True, type=Path)
+    collect.add_argument("--category", action="append", dest="categories")
+    collect.add_argument("--per-category", type=int, default=3)
+    collect.add_argument("--seed", type=int, default=260829)
+    train = commands.add_parser("train")
+    train.add_argument("--manifest", required=True, type=Path)
+    train.add_argument("--output", required=True, type=Path)
+    train.add_argument("--epochs", type=int, default=1)
+    train.add_argument("--batch-size", type=int, default=2)
+    train.add_argument("--learning-rate", type=float, default=2e-4)
+    train.add_argument("--transforms-per-image", type=int, default=2)
+    train.add_argument("--device", choices=("cpu", "mps"), default="cpu")
+    train.add_argument("--seed", type=int, default=260829)
+    args = parser.parse_args()
+    if args.command == "collect":
+        result = collect_public_corpus(
+            args.output,
+            args.image_directory,
+            categories=args.categories or DEFAULT_CATEGORIES,
+            per_category=args.per_category,
+            seed=args.seed,
+        )
+    else:
+        result = pretrain_public_synthetic_style(
+            PublicPretrainingConfig(
+                manifest=args.manifest,
+                output=args.output,
+                epochs=args.epochs,
+                batch_size=args.batch_size,
+                learning_rate=args.learning_rate,
+                transforms_per_image=args.transforms_per_image,
+                device=args.device,
+                seed=args.seed,
+            )
+        )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_public_synthetic_style.py
+++ b/scripts/train_public_synthetic_style.py
@@ -35,6 +35,8 @@ def main() -> None:
     train.add_argument("--batch-size", type=int, default=2)
     train.add_argument("--learning-rate", type=float, default=2e-4)
     train.add_argument("--transforms-per-image", type=int, default=2)
+    train.add_argument("--key-loss-weight", type=float, default=8.0)
+    train.add_argument("--unstyled-loss-weight", type=float, default=0.1)
     train.add_argument("--device", choices=("cpu", "mps"), default="cpu")
     train.add_argument("--seed", type=int, default=260829)
     args = parser.parse_args()
@@ -55,6 +57,8 @@ def main() -> None:
                 batch_size=args.batch_size,
                 learning_rate=args.learning_rate,
                 transforms_per_image=args.transforms_per_image,
+                key_loss_weight=args.key_loss_weight,
+                unstyled_loss_weight=args.unstyled_loss_weight,
                 device=args.device,
                 seed=args.seed,
             )

--- a/scripts/train_universal_photographic_style.py
+++ b/scripts/train_universal_photographic_style.py
@@ -26,6 +26,11 @@ def main() -> None:
     prepare.add_argument("--native-manifest", required=True, type=Path)
     prepare.add_argument("--output", required=True, type=Path)
     prepare.add_argument("--exiftool", default="exiftool")
+    prepare.add_argument(
+        "--optional-modalities-manifest",
+        type=Path,
+        help="optional decoded RAW-linear/gain-map sidecar manifest",
+    )
     train = commands.add_parser("train")
     train.add_argument("--manifest", required=True, type=Path)
     train.add_argument("--output", required=True, type=Path)
@@ -35,13 +40,24 @@ def main() -> None:
     train.add_argument("--device", choices=("auto", "mps", "cpu"), default="auto")
     train.add_argument("--seed", type=int, default=260820)
     train.add_argument("--metadata-dropout", type=float, default=0.25)
+    train.add_argument("--optional-modality-dropout", type=float, default=0.35)
     train.add_argument(
         "--architecture",
-        choices=("base", "multiscale_large"),
+        choices=("base", "multiscale_large", "multimodal_large"),
         default="base",
     )
     train.add_argument("--consumer-weight", type=float, default=0.0)
-    train.add_argument("--resume", type=Path)
+    checkpoint = train.add_mutually_exclusive_group()
+    checkpoint.add_argument(
+        "--resume",
+        type=Path,
+        help="continue from the exact same prepared manifest",
+    )
+    checkpoint.add_argument(
+        "--warm-start",
+        type=Path,
+        help="initialize from a checkpoint while allowing a new manifest",
+    )
     args = parser.parse_args()
     if args.command == "prepare":
         result = prepare_universal_dataset(
@@ -49,6 +65,7 @@ def main() -> None:
                 native_manifest=args.native_manifest,
                 output=args.output,
                 exiftool=args.exiftool,
+                optional_modalities_manifest=args.optional_modalities_manifest,
             )
         )
     else:
@@ -62,9 +79,11 @@ def main() -> None:
                 device=args.device,
                 seed=args.seed,
                 metadata_dropout=args.metadata_dropout,
+                optional_modality_dropout=args.optional_modality_dropout,
                 architecture=args.architecture,
                 consumer_weight=args.consumer_weight,
                 resume=args.resume,
+                warm_start=args.warm_start,
             )
         )
     print(json.dumps(result, indent=2, sort_keys=True))

--- a/xdremux_py/public_style_pretraining.py
+++ b/xdremux_py/public_style_pretraining.py
@@ -7,6 +7,7 @@ import hashlib
 import html
 import json
 import random
+import re
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -40,7 +41,16 @@ DEFAULT_CATEGORIES = (
     "Taken with Oppo A3x 4G",
     "Taken with Oppo F29 5G",
 )
-ALLOWED_LICENSES = frozenset(("CC0", "CC BY 4.0", "CC BY-SA 4.0"))
+ALLOWED_LICENSE_POLICY = (
+    "CC0 or Public Domain, or CC BY / CC BY-SA versions 1.0 through 4.0; "
+    "NC and ND variants are rejected"
+)
+
+
+def license_is_allowed(value: str) -> bool:
+    if value.casefold() in {"cc0", "public domain", "public-domain"}:
+        return True
+    return bool(re.fullmatch(r"CC BY(?:-SA)? (?:1\.0|2\.0|2\.5|3\.0|4\.0)", value))
 
 
 def _metadata_value(metadata: Mapping[str, Any], name: str) -> str:
@@ -67,7 +77,7 @@ def commons_candidates(
         mime = str(info.get("mime") or "")
         download_url = info.get("thumburl") or info.get("url")
         if (
-            license_name not in ALLOWED_LICENSES
+            not license_is_allowed(license_name)
             or mime not in {"image/jpeg", "image/png", "image/webp"}
             or not isinstance(download_url, str)
         ):
@@ -180,7 +190,7 @@ def collect_public_corpus(
     result = {
         "schema": PUBLIC_CORPUS_SCHEMA,
         "seed": seed,
-        "allowedLicenses": sorted(ALLOWED_LICENSES),
+        "allowedLicensePolicy": ALLOWED_LICENSE_POLICY,
         "categories": list(categories),
         "samples": records,
         "failures": failures,

--- a/xdremux_py/public_style_pretraining.py
+++ b/xdremux_py/public_style_pretraining.py
@@ -8,6 +8,8 @@ import html
 import json
 import random
 import re
+import time
+import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -128,8 +130,18 @@ def _download_sample(record: Mapping[str, Any], path: Path) -> dict[str, Any]:
         str(record["downloadURL"]),
         headers={"User-Agent": "XDRemux-public-style-research/1.0"},
     )
-    with urllib.request.urlopen(request, timeout=90) as response:
-        payload = response.read(24 * 1024 * 1024 + 1)
+    payload: bytes | None = None
+    for attempt in range(4):
+        try:
+            with urllib.request.urlopen(request, timeout=90) as response:
+                payload = response.read(24 * 1024 * 1024 + 1)
+            break
+        except urllib.error.HTTPError as error:
+            if error.code not in {429, 500, 502, 503, 504} or attempt == 3:
+                raise
+            time.sleep(2**attempt)
+    if payload is None:
+        raise ReverseKey1Error(f"public sample download returned no data: {record['title']}")
     if len(payload) > 24 * 1024 * 1024:
         raise ReverseKey1Error(f"public sample exceeds 24 MiB: {record['title']}")
     try:
@@ -171,6 +183,12 @@ def collect_public_corpus(
     failures: list[dict[str, str]] = []
     for category in categories:
         candidates = _commons_category(category)
+        print(
+            json.dumps(
+                {"category": category, "licenseCompatibleCandidates": len(candidates)}
+            ),
+            flush=True,
+        )
         rng.shuffle(candidates)
         accepted = 0
         for candidate in candidates:
@@ -181,8 +199,15 @@ def collect_public_corpus(
                 records.append(_download_sample(candidate, path))
             except (OSError, ReverseKey1Error) as error:
                 failures.append({"title": candidate["title"], "error": str(error)})
+                print(
+                    json.dumps(
+                        {"category": category, "title": candidate["title"], "error": str(error)}
+                    ),
+                    flush=True,
+                )
                 continue
             accepted += 1
+            time.sleep(0.5)
     if len(records) < max(4, len(categories)):
         raise ReverseKey1Error(
             f"only {len(records)} public samples passed license/decode checks"

--- a/xdremux_py/public_style_pretraining.py
+++ b/xdremux_py/public_style_pretraining.py
@@ -8,8 +8,6 @@ import html
 import json
 import random
 import re
-import time
-import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -130,18 +128,8 @@ def _download_sample(record: Mapping[str, Any], path: Path) -> dict[str, Any]:
         str(record["downloadURL"]),
         headers={"User-Agent": "XDRemux-public-style-research/1.0"},
     )
-    payload: bytes | None = None
-    for attempt in range(4):
-        try:
-            with urllib.request.urlopen(request, timeout=90) as response:
-                payload = response.read(24 * 1024 * 1024 + 1)
-            break
-        except urllib.error.HTTPError as error:
-            if error.code not in {429, 500, 502, 503, 504} or attempt == 3:
-                raise
-            time.sleep(2**attempt)
-    if payload is None:
-        raise ReverseKey1Error(f"public sample download returned no data: {record['title']}")
+    with urllib.request.urlopen(request, timeout=20) as response:
+        payload = response.read(24 * 1024 * 1024 + 1)
     if len(payload) > 24 * 1024 * 1024:
         raise ReverseKey1Error(f"public sample exceeds 24 MiB: {record['title']}")
     try:
@@ -207,8 +195,7 @@ def collect_public_corpus(
                 )
                 continue
             accepted += 1
-            time.sleep(0.5)
-    if len(records) < max(4, len(categories)):
+    if len(records) < 2:
         raise ReverseKey1Error(
             f"only {len(records)} public samples passed license/decode checks"
         )
@@ -217,6 +204,8 @@ def collect_public_corpus(
         "seed": seed,
         "allowedLicensePolicy": ALLOWED_LICENSE_POLICY,
         "categories": list(categories),
+        "requestedSamples": len(categories) * per_category,
+        "complete": len(records) == len(categories) * per_category,
         "samples": records,
         "failures": failures,
     }
@@ -293,7 +282,7 @@ def pretrain_public_synthetic_style(config: PublicPretrainingConfig) -> dict[str
     if value.get("schema") != PUBLIC_CORPUS_SCHEMA:
         raise ReverseKey1Error("invalid public style corpus manifest")
     records = value.get("samples")
-    if not isinstance(records, list) or len(records) < 4:
+    if not isinstance(records, list) or len(records) < 2:
         raise ReverseKey1Error("public style corpus is too small")
     torch.manual_seed(config.seed)
     np.random.seed(config.seed)

--- a/xdremux_py/public_style_pretraining.py
+++ b/xdremux_py/public_style_pretraining.py
@@ -1,0 +1,442 @@
+"""License-audited public-image collection and synthetic style pretraining."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import html
+import json
+import random
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+from PIL import Image, ImageOps
+
+from xdremux_py.apple_reverse_key1_training import (
+    ReverseKey1Error,
+    _atomic_json,
+    _require_torch,
+    sha256_file,
+)
+from xdremux_py.universal_photographic_style_training import (
+    INPUT_SIZE,
+    METADATA_FIELDS,
+    STYLE_SCALAR_FIELDS,
+    build_universal_model,
+    primary_image_features,
+)
+
+
+PUBLIC_CORPUS_SCHEMA = "xdremux-public-style-content-corpus-v1"
+SYNTHETIC_REPORT_SCHEMA = "xdremux-public-synthetic-style-pretraining-v1"
+COMMONS_API = "https://commons.wikimedia.org/w/api.php"
+DEFAULT_CATEGORIES = (
+    "Taken with iPhone 16",
+    "Taken with iPhone 16 Pro",
+    "Taken with iPhone 17 Pro",
+    "Taken with Oppo A3x 4G",
+    "Taken with Oppo F29 5G",
+)
+ALLOWED_LICENSES = frozenset(("CC0", "CC BY 4.0", "CC BY-SA 4.0"))
+
+
+def _metadata_value(metadata: Mapping[str, Any], name: str) -> str:
+    value = metadata.get(name)
+    if not isinstance(value, Mapping):
+        return ""
+    return html.unescape(str(value.get("value") or "")).strip()
+
+
+def commons_candidates(
+    payload: Mapping[str, Any], category: str, limit: int
+) -> list[dict[str, Any]]:
+    pages = payload.get("query", {}).get("pages", [])
+    if not isinstance(pages, list):
+        raise ReverseKey1Error("Wikimedia Commons response has no page array")
+    selected: list[dict[str, Any]] = []
+    for page in sorted(pages, key=lambda item: str(item.get("title") or "")):
+        imageinfo = page.get("imageinfo")
+        if not isinstance(imageinfo, list) or len(imageinfo) != 1:
+            continue
+        info = imageinfo[0]
+        metadata = info.get("extmetadata") or {}
+        license_name = _metadata_value(metadata, "LicenseShortName")
+        mime = str(info.get("mime") or "")
+        download_url = info.get("thumburl") or info.get("url")
+        if (
+            license_name not in ALLOWED_LICENSES
+            or mime not in {"image/jpeg", "image/png", "image/webp"}
+            or not isinstance(download_url, str)
+        ):
+            continue
+        selected.append(
+            {
+                "category": category,
+                "title": str(page.get("title") or ""),
+                "sourceURL": str(info.get("descriptionurl") or ""),
+                "downloadURL": download_url,
+                "sourceSHA1": str(info.get("sha1") or ""),
+                "license": license_name,
+                "licenseURL": _metadata_value(metadata, "LicenseUrl"),
+                "artist": _metadata_value(metadata, "Artist"),
+                "credit": _metadata_value(metadata, "Credit"),
+            }
+        )
+        if len(selected) >= limit:
+            break
+    return selected
+
+
+def _commons_category(category: str, request_limit: int = 80) -> list[dict[str, Any]]:
+    query = urllib.parse.urlencode(
+        {
+            "action": "query",
+            "generator": "categorymembers",
+            "gcmtitle": f"Category:{category}",
+            "gcmtype": "file",
+            "gcmlimit": str(request_limit),
+            "prop": "imageinfo",
+            "iiprop": "url|sha1|mime|extmetadata",
+            "iiurlwidth": "768",
+            "format": "json",
+            "formatversion": "2",
+        }
+    )
+    request = urllib.request.Request(
+        f"{COMMONS_API}?{query}",
+        headers={"User-Agent": "XDRemux-public-style-research/1.0"},
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return commons_candidates(json.load(response), category, request_limit)
+
+
+def _download_sample(record: Mapping[str, Any], path: Path) -> dict[str, Any]:
+    request = urllib.request.Request(
+        str(record["downloadURL"]),
+        headers={"User-Agent": "XDRemux-public-style-research/1.0"},
+    )
+    with urllib.request.urlopen(request, timeout=90) as response:
+        payload = response.read(24 * 1024 * 1024 + 1)
+    if len(payload) > 24 * 1024 * 1024:
+        raise ReverseKey1Error(f"public sample exceeds 24 MiB: {record['title']}")
+    try:
+        from io import BytesIO
+
+        with Image.open(BytesIO(payload)) as source:
+            image = ImageOps.fit(
+                ImageOps.exif_transpose(source).convert("RGB"),
+                (INPUT_SIZE, INPUT_SIZE),
+                method=Image.Resampling.LANCZOS,
+            )
+            value = np.asarray(image, dtype=np.uint8).transpose(2, 0, 1)
+    except Exception as error:
+        raise ReverseKey1Error(
+            f"public sample decode failed for {record['title']}: {error}"
+        ) from error
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.save(path, value, allow_pickle=False)
+    result = dict(record)
+    result.pop("downloadURL", None)
+    result["imagePath"] = str(path.resolve())
+    result["downloadSHA256"] = hashlib.sha256(payload).hexdigest()
+    result["tensorSHA256"] = sha256_file(path)
+    return result
+
+
+def collect_public_corpus(
+    output: Path,
+    image_directory: Path,
+    *,
+    categories: Sequence[str] = DEFAULT_CATEGORIES,
+    per_category: int = 3,
+    seed: int = 260829,
+) -> dict[str, Any]:
+    if per_category <= 0:
+        raise ReverseKey1Error("per-category sample count must be positive")
+    rng = random.Random(seed)
+    records: list[dict[str, Any]] = []
+    failures: list[dict[str, str]] = []
+    for category in categories:
+        candidates = _commons_category(category)
+        rng.shuffle(candidates)
+        accepted = 0
+        for candidate in candidates:
+            if accepted >= per_category:
+                break
+            path = image_directory.resolve() / f"{len(records):04d}.npy"
+            try:
+                records.append(_download_sample(candidate, path))
+            except (OSError, ReverseKey1Error) as error:
+                failures.append({"title": candidate["title"], "error": str(error)})
+                continue
+            accepted += 1
+    if len(records) < max(4, len(categories)):
+        raise ReverseKey1Error(
+            f"only {len(records)} public samples passed license/decode checks"
+        )
+    result = {
+        "schema": PUBLIC_CORPUS_SCHEMA,
+        "seed": seed,
+        "allowedLicenses": sorted(ALLOWED_LICENSES),
+        "categories": list(categories),
+        "samples": records,
+        "failures": failures,
+    }
+    _atomic_json(output.resolve(), result)
+    return result
+
+
+def synthetic_affine_pair(
+    image: np.ndarray, rng: np.random.Generator
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    clean = np.asarray(image, dtype=np.float32)
+    if clean.shape != (3, INPUT_SIZE, INPUT_SIZE):
+        raise ReverseKey1Error("synthetic source image must be 3x256x256")
+    if clean.max(initial=0) > 1:
+        clean = clean / 255.0
+    clean = np.clip(clean, 0.08, 0.92)
+    delta = rng.normal(0.0, 0.055, size=(3, 3)).astype(np.float32)
+    delta *= np.asarray(
+        [[1.0, 0.35, 0.35], [0.35, 1.0, 0.35], [0.35, 0.35, 1.0]],
+        dtype=np.float32,
+    )
+    bias = rng.normal(0.0, 0.025, size=3).astype(np.float32)
+    for strength in (1.0, 0.5, 0.25, 0.125):
+        matrix = np.eye(3, dtype=np.float32) + delta * strength
+        offset = bias * strength
+        styled = np.einsum("ci,ihw->chw", matrix, clean) + offset[:, None, None]
+        if float(styled.min()) >= 0 and float(styled.max()) <= 1:
+            break
+    inverse = np.linalg.inv(matrix).astype(np.float32)
+    coefficients = np.zeros((10, 3), dtype=np.float32)
+    coefficients[0] = -inverse @ offset
+    coefficients[1:4] = inverse.T
+    key1 = np.broadcast_to(
+        coefficients, (12, 12, 8, 10, 3)
+    ).copy()
+    return styled.astype(np.float32), clean, key1
+
+
+def _synthetic_statistics() -> dict[str, np.ndarray]:
+    return {
+        "metadataCenter": np.zeros(len(METADATA_FIELDS), dtype=np.float32),
+        "metadataScale": np.ones(len(METADATA_FIELDS), dtype=np.float32),
+        "metadataActive": np.zeros(len(METADATA_FIELDS), dtype=np.float32),
+        "key1Scale": np.ones((8, 10, 3), dtype=np.float32),
+        "gtcCenter": np.zeros(516, dtype=np.float32),
+        "gtcScale": np.ones(516, dtype=np.float32),
+        "lightCenter": np.zeros((2, 32, 32), dtype=np.float32),
+        "lightScale": np.ones(2, dtype=np.float32),
+        "scalarCenter": np.zeros(len(STYLE_SCALAR_FIELDS), dtype=np.float32),
+        "scalarScale": np.ones(len(STYLE_SCALAR_FIELDS), dtype=np.float32),
+        "scalarLow": np.full(len(STYLE_SCALAR_FIELDS), -10.0, dtype=np.float32),
+        "scalarHigh": np.full(len(STYLE_SCALAR_FIELDS), 10.0, dtype=np.float32),
+    }
+
+
+@dataclasses.dataclass(frozen=True)
+class PublicPretrainingConfig:
+    manifest: Path
+    output: Path
+    epochs: int = 1
+    batch_size: int = 2
+    learning_rate: float = 2e-4
+    transforms_per_image: int = 2
+    device: str = "cpu"
+    seed: int = 260829
+
+
+def pretrain_public_synthetic_style(config: PublicPretrainingConfig) -> dict[str, Any]:
+    torch, _ = _require_torch()
+    if config.device == "mps" and not torch.backends.mps.is_available():
+        raise ReverseKey1Error("MPS was requested but is unavailable")
+    manifest = config.manifest.resolve()
+    value = json.loads(manifest.read_text(encoding="utf-8"))
+    if value.get("schema") != PUBLIC_CORPUS_SCHEMA:
+        raise ReverseKey1Error("invalid public style corpus manifest")
+    records = value.get("samples")
+    if not isinstance(records, list) or len(records) < 4:
+        raise ReverseKey1Error("public style corpus is too small")
+    torch.manual_seed(config.seed)
+    np.random.seed(config.seed)
+    examples: list[tuple[np.ndarray, np.ndarray, np.ndarray, str]] = []
+    for record_index, record in enumerate(records):
+        path = Path(str(record["imagePath"]))
+        if record.get("tensorSHA256") != sha256_file(path):
+            raise ReverseKey1Error(f"public tensor identity mismatch: {path}")
+        image = np.load(path, allow_pickle=False)
+        for transform_index in range(config.transforms_per_image):
+            rng = np.random.default_rng(
+                config.seed + record_index * 1009 + transform_index
+            )
+            styled, clean, key1 = synthetic_affine_pair(image, rng)
+            examples.append(
+                (
+                    primary_image_features(styled),
+                    clean[:, ::4, ::4].astype(np.float32),
+                    key1,
+                    str(record["title"]),
+                )
+            )
+    split = max(1, int(len(records) * 0.8)) * config.transforms_per_image
+    train_examples = examples[:split]
+    heldout_examples = examples[split:]
+    if not heldout_examples:
+        raise ReverseKey1Error("public synthetic heldout split is empty")
+
+    class Dataset:
+        def __init__(self, rows: Sequence[tuple[np.ndarray, ...]]) -> None:
+            self.rows = rows
+
+        def __len__(self) -> int:
+            return len(self.rows)
+
+        def __getitem__(self, index: int) -> tuple[Any, ...]:
+            primary, clean, key1, title = self.rows[index]
+            return (
+                torch.from_numpy(primary),
+                torch.from_numpy(clean),
+                torch.from_numpy(key1),
+                title,
+            )
+
+    loaders = {
+        "train": torch.utils.data.DataLoader(
+            Dataset(train_examples), batch_size=config.batch_size, shuffle=True
+        ),
+        "heldout": torch.utils.data.DataLoader(
+            Dataset(heldout_examples), batch_size=config.batch_size, shuffle=False
+        ),
+    }
+    statistics = _synthetic_statistics()
+    model = build_universal_model(
+        statistics, architecture="multimodal_large"
+    ).to(config.device)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=config.learning_rate)
+
+    def evaluate() -> dict[str, float]:
+        model.eval()
+        key_errors: list[float] = []
+        unstyled_errors: list[float] = []
+        response_errors: list[float] = []
+        with torch.no_grad():
+            for primary, clean, key1, _titles in loaders["heldout"]:
+                primary = primary.to(config.device)
+                clean = clean.to(config.device)
+                key1 = key1.to(config.device)
+                output = model(
+                    primary,
+                    torch.zeros((len(primary), len(METADATA_FIELDS)), device=config.device),
+                    torch.zeros((len(primary), len(METADATA_FIELDS)), device=config.device),
+                )
+                key_errors.extend(
+                    (output["key1"] - key1)
+                    .abs()
+                    .mean(dim=(1, 2, 3, 4, 5))
+                    .cpu()
+                    .tolist()
+                )
+                unstyled_errors.extend(
+                    (output["unstyled"] - clean)
+                    .abs()
+                    .mean(dim=(1, 2, 3))
+                    .cpu()
+                    .tolist()
+                )
+                predicted_coefficients = output["key1"].mean(dim=(1, 2, 3))
+                rgb = primary[:, :3, ::4, ::4]
+                red, green, blue = rgb[:, 0], rgb[:, 1], rgb[:, 2]
+                terms = torch.stack(
+                    (
+                        torch.ones_like(red), red, green, blue, red.square(),
+                        red * green, red * blue, green.square(), green * blue,
+                        blue.square(),
+                    ),
+                    dim=1,
+                )
+                rendered = torch.einsum(
+                    "bthw,btc->bchw", terms, predicted_coefficients
+                ).clamp(0, 1)
+                response_errors.extend(
+                    (rendered - clean)
+                    .square()
+                    .mean(dim=(1, 2, 3))
+                    .sqrt()
+                    .mul(255)
+                    .cpu()
+                    .tolist()
+                )
+        return {
+            "key1MAE": float(np.mean(key_errors)),
+            "unstyledMAE": float(np.mean(unstyled_errors)),
+            "syntheticResponseRMSE8": float(np.mean(response_errors)),
+        }
+
+    baseline = evaluate()
+    history: list[dict[str, Any]] = []
+    for epoch in range(1, config.epochs + 1):
+        model.train()
+        losses: list[float] = []
+        for primary, clean, key1, _titles in loaders["train"]:
+            primary = primary.to(config.device)
+            clean = clean.to(config.device)
+            key1 = key1.to(config.device)
+            optimizer.zero_grad(set_to_none=True)
+            output = model(
+                primary,
+                torch.zeros((len(primary), len(METADATA_FIELDS)), device=config.device),
+                torch.zeros((len(primary), len(METADATA_FIELDS)), device=config.device),
+            )
+            key_loss = torch.nn.functional.smooth_l1_loss(output["key1"], key1)
+            unstyled_loss = torch.nn.functional.l1_loss(output["unstyled"], clean)
+            loss = key_loss + 0.25 * unstyled_loss
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 2.0)
+            optimizer.step()
+            losses.append(float(loss.detach().cpu()))
+        metrics = evaluate()
+        history.append(
+            {"epoch": epoch, "trainingLoss": float(np.mean(losses)), "heldout": metrics}
+        )
+        print(json.dumps(history[-1], sort_keys=True), flush=True)
+    output = config.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    checkpoint = {
+        "schema": SYNTHETIC_REPORT_SCHEMA,
+        "architecture": "UniversalPhotographicStyleStateNet-v3-optional-modalities",
+        "architectureConfig": "multimodal_large",
+        "epoch": config.epochs,
+        "manifestSHA256": sha256_file(manifest),
+        "model": model.state_dict(),
+        "statistics": {name: array.tolist() for name, array in statistics.items()},
+        "metadataFields": list(METADATA_FIELDS),
+        "styleScalarFields": list(STYLE_SCALAR_FIELDS),
+        "syntheticPretrainingOnly": True,
+    }
+    torch.save(checkpoint, output / "synthetic-pretrained.pt")
+    report = {
+        "schema": SYNTHETIC_REPORT_SCHEMA,
+        "manifestSHA256": sha256_file(manifest),
+        "sourceSamples": len(records),
+        "syntheticExamples": len(examples),
+        "splitExamples": {
+            "train": len(train_examples),
+            "heldout": len(heldout_examples),
+        },
+        "architecture": checkpoint["architecture"],
+        "device": config.device,
+        "baseline": baseline,
+        "final": history[-1]["heldout"],
+        "history": history,
+        "licenses": sorted({str(record["license"]) for record in records}),
+        "categories": sorted({str(record["category"]) for record in records}),
+        "claimBoundary": (
+            "Synthetic affine key1 pretraining only. This is not native Apple or "
+            "Neutrino solver supervision and cannot establish production accuracy."
+        ),
+    }
+    _atomic_json(output / "report.json", report)
+    return report

--- a/xdremux_py/public_style_pretraining.py
+++ b/xdremux_py/public_style_pretraining.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import copy
 import dataclasses
 import hashlib
 import html
 import json
 import random
 import re
+import time
+import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -34,12 +37,95 @@ from xdremux_py.universal_photographic_style_training import (
 PUBLIC_CORPUS_SCHEMA = "xdremux-public-style-content-corpus-v1"
 SYNTHETIC_REPORT_SCHEMA = "xdremux-public-synthetic-style-pretraining-v1"
 COMMONS_API = "https://commons.wikimedia.org/w/api.php"
+COMMONS_USER_AGENT = (
+    "XDRemuxStyleResearchBot/1.1 "
+    "(https://github.com/21Z121Z1/XDRemux; contact via GitHub Issues)"
+)
 DEFAULT_CATEGORIES = (
     "Taken with iPhone 16",
     "Taken with iPhone 16 Pro",
     "Taken with iPhone 17 Pro",
     "Taken with Oppo A3x 4G",
     "Taken with Oppo F29 5G",
+)
+CURATED_GITHUB_SAMPLES: tuple[dict[str, str], ...] = (
+    {
+        "category": "scikit-image public-domain photos",
+        "title": "astronaut.png",
+        "downloadURL": "https://raw.githubusercontent.com/scikit-image/scikit-image/v0.24.0/skimage/data/astronaut.png",
+        "sourceURL": "https://github.com/scikit-image/scikit-image/blob/v0.24.0/skimage/data/astronaut.png",
+        "sourceGitBlobSHA1": "834cda0012478c5edc8d43bade96d315dedeaab4",
+        "license": "Public domain",
+        "licenseURL": "https://scikit-image.org/docs/stable/api/skimage.data#skimage.data.astronaut",
+        "artist": "NASA",
+        "credit": "NASA Great Images",
+    },
+    {
+        "category": "scikit-image CC0 photos",
+        "title": "brick.png",
+        "downloadURL": "https://raw.githubusercontent.com/scikit-image/scikit-image/v0.24.0/skimage/data/brick.png",
+        "sourceURL": "https://github.com/scikit-image/scikit-image/blob/v0.24.0/skimage/data/brick.png",
+        "sourceGitBlobSHA1": "79941ecd6605663c653e03c85b4ca7e59b3c4412",
+        "license": "CC0",
+        "licenseURL": "https://scikit-image.org/docs/stable/api/skimage.data#skimage.data.brick",
+        "artist": "CC0Textures",
+        "credit": "scikit-image data",
+    },
+    {
+        "category": "scikit-image CC0 photos",
+        "title": "camera.png",
+        "downloadURL": "https://raw.githubusercontent.com/scikit-image/scikit-image/v0.24.0/skimage/data/camera.png",
+        "sourceURL": "https://github.com/scikit-image/scikit-image/blob/v0.24.0/skimage/data/camera.png",
+        "sourceGitBlobSHA1": "cdb3405d0086639638a13a2c72bfb646060180e2",
+        "license": "CC0",
+        "licenseURL": "https://scikit-image.org/docs/stable/api/skimage.data#skimage.data.camera",
+        "artist": "Lav Varshney",
+        "credit": "scikit-image data",
+    },
+    {
+        "category": "scikit-image CC0 photos",
+        "title": "chelsea.png",
+        "downloadURL": "https://raw.githubusercontent.com/scikit-image/scikit-image/v0.24.0/skimage/data/chelsea.png",
+        "sourceURL": "https://github.com/scikit-image/scikit-image/blob/v0.24.0/skimage/data/chelsea.png",
+        "sourceGitBlobSHA1": "fae212d2befa8926f05d7cf06c799f06b81545ab",
+        "license": "CC0",
+        "licenseURL": "https://scikit-image.org/docs/stable/api/skimage.data#skimage.data.chelsea",
+        "artist": "Stefan van der Walt",
+        "credit": "scikit-image data",
+    },
+    {
+        "category": "scikit-image CC0 photos",
+        "title": "coffee.png",
+        "downloadURL": "https://raw.githubusercontent.com/scikit-image/scikit-image/v0.24.0/skimage/data/coffee.png",
+        "sourceURL": "https://github.com/scikit-image/scikit-image/blob/v0.24.0/skimage/data/coffee.png",
+        "sourceGitBlobSHA1": "f8350bf7e6e22734667f8c86fd230a741370fbcb",
+        "license": "CC0",
+        "licenseURL": "https://scikit-image.org/docs/stable/api/skimage.data#skimage.data.coffee",
+        "artist": "Rachel Michetti",
+        "credit": "Pikolo Espresso Bar / scikit-image data",
+    },
+    {
+        "category": "scikit-image public-domain photos",
+        "title": "hubble_deep_field.jpg",
+        "downloadURL": "https://raw.githubusercontent.com/scikit-image/scikit-image/v0.24.0/skimage/data/hubble_deep_field.jpg",
+        "sourceURL": "https://github.com/scikit-image/scikit-image/blob/v0.24.0/skimage/data/hubble_deep_field.jpg",
+        "sourceGitBlobSHA1": "50c1b81aea1d565d78741387b5279bbed0ba4ce8",
+        "license": "Public domain",
+        "licenseURL": "https://scikit-image.org/docs/stable/api/skimage.data#skimage.data.hubble_deep_field",
+        "artist": "NASA",
+        "credit": "HubbleSite / scikit-image data",
+    },
+    {
+        "category": "scikit-image public-domain photos",
+        "title": "rocket.jpg",
+        "downloadURL": "https://raw.githubusercontent.com/scikit-image/scikit-image/v0.24.0/skimage/data/rocket.jpg",
+        "sourceURL": "https://github.com/scikit-image/scikit-image/blob/v0.24.0/skimage/data/rocket.jpg",
+        "sourceGitBlobSHA1": "32bdd33960c60d012fc71b5fd80a7ccc24d3b906",
+        "license": "Public domain",
+        "licenseURL": "https://scikit-image.org/docs/stable/api/skimage.data#skimage.data.rocket",
+        "artist": "SpaceX",
+        "credit": "SpaceX Photos / scikit-image data",
+    },
 )
 ALLOWED_LICENSE_POLICY = (
     "CC0 or Public Domain, or CC BY / CC BY-SA versions 1.0 through 4.0; "
@@ -117,7 +203,10 @@ def _commons_category(category: str, request_limit: int = 80) -> list[dict[str, 
     )
     request = urllib.request.Request(
         f"{COMMONS_API}?{query}",
-        headers={"User-Agent": "XDRemux-public-style-research/1.0"},
+        headers={
+            "User-Agent": COMMONS_USER_AGENT,
+            "Api-User-Agent": COMMONS_USER_AGENT,
+        },
     )
     with urllib.request.urlopen(request, timeout=60) as response:
         return commons_candidates(json.load(response), category, request_limit)
@@ -126,10 +215,28 @@ def _commons_category(category: str, request_limit: int = 80) -> list[dict[str, 
 def _download_sample(record: Mapping[str, Any], path: Path) -> dict[str, Any]:
     request = urllib.request.Request(
         str(record["downloadURL"]),
-        headers={"User-Agent": "XDRemux-public-style-research/1.0"},
+        headers={"User-Agent": COMMONS_USER_AGENT},
     )
-    with urllib.request.urlopen(request, timeout=20) as response:
-        payload = response.read(24 * 1024 * 1024 + 1)
+    payload: bytes | None = None
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                payload = response.read(24 * 1024 * 1024 + 1)
+            break
+        except urllib.error.HTTPError as error:
+            if error.code != 429 or attempt == 2:
+                raise
+            retry_after = error.headers.get("Retry-After")
+            delay = (
+                float(retry_after)
+                if retry_after and retry_after.isdigit()
+                else 2 ** (attempt + 1)
+            )
+            time.sleep(min(delay, 30.0))
+    if payload is None:
+        raise ReverseKey1Error(
+            f"public sample download returned no data: {record['title']}"
+        )
     if len(payload) > 24 * 1024 * 1024:
         raise ReverseKey1Error(f"public sample exceeds 24 MiB: {record['title']}")
     try:
@@ -169,6 +276,22 @@ def collect_public_corpus(
     rng = random.Random(seed)
     records: list[dict[str, Any]] = []
     failures: list[dict[str, str]] = []
+    for candidate in CURATED_GITHUB_SAMPLES:
+        path = image_directory.resolve() / f"{len(records):04d}.npy"
+        try:
+            records.append(_download_sample(candidate, path))
+        except (OSError, ReverseKey1Error) as error:
+            failures.append({"title": candidate["title"], "error": str(error)})
+            print(
+                json.dumps(
+                    {
+                        "category": candidate["category"],
+                        "title": candidate["title"],
+                        "error": str(error),
+                    }
+                ),
+                flush=True,
+            )
     for category in categories:
         candidates = _commons_category(category)
         print(
@@ -179,13 +302,17 @@ def collect_public_corpus(
         )
         rng.shuffle(candidates)
         accepted = 0
+        consecutive_failures = 0
         for candidate in candidates:
             if accepted >= per_category:
                 break
+            if accepted or consecutive_failures:
+                time.sleep(1.0)
             path = image_directory.resolve() / f"{len(records):04d}.npy"
             try:
                 records.append(_download_sample(candidate, path))
             except (OSError, ReverseKey1Error) as error:
+                consecutive_failures += 1
                 failures.append({"title": candidate["title"], "error": str(error)})
                 print(
                     json.dumps(
@@ -193,8 +320,11 @@ def collect_public_corpus(
                     ),
                     flush=True,
                 )
+                if consecutive_failures >= 3:
+                    break
                 continue
             accepted += 1
+            consecutive_failures = 0
     if len(records) < 2:
         raise ReverseKey1Error(
             f"only {len(records)} public samples passed license/decode checks"
@@ -204,8 +334,10 @@ def collect_public_corpus(
         "seed": seed,
         "allowedLicensePolicy": ALLOWED_LICENSE_POLICY,
         "categories": list(categories),
-        "requestedSamples": len(categories) * per_category,
-        "complete": len(records) == len(categories) * per_category,
+        "requestedSamples": len(CURATED_GITHUB_SAMPLES)
+        + len(categories) * per_category,
+        "complete": len(records)
+        == len(CURATED_GITHUB_SAMPLES) + len(categories) * per_category,
         "samples": records,
         "failures": failures,
     }
@@ -269,12 +401,18 @@ class PublicPretrainingConfig:
     batch_size: int = 2
     learning_rate: float = 2e-4
     transforms_per_image: int = 2
+    key_loss_weight: float = 8.0
+    unstyled_loss_weight: float = 0.1
     device: str = "cpu"
     seed: int = 260829
 
 
 def pretrain_public_synthetic_style(config: PublicPretrainingConfig) -> dict[str, Any]:
     torch, _ = _require_torch()
+    if config.epochs <= 0 or config.transforms_per_image <= 0:
+        raise ReverseKey1Error("epochs and transforms-per-image must be positive")
+    if config.key_loss_weight <= 0 or config.unstyled_loss_weight < 0:
+        raise ReverseKey1Error("key loss weight must be positive and unstyled weight nonnegative")
     if config.device == "mps" and not torch.backends.mps.is_available():
         raise ReverseKey1Error("MPS was requested but is unavailable")
     manifest = config.manifest.resolve()
@@ -286,8 +424,10 @@ def pretrain_public_synthetic_style(config: PublicPretrainingConfig) -> dict[str
         raise ReverseKey1Error("public style corpus is too small")
     torch.manual_seed(config.seed)
     np.random.seed(config.seed)
+    shuffled_records = list(records)
+    random.Random(config.seed).shuffle(shuffled_records)
     examples: list[tuple[np.ndarray, np.ndarray, np.ndarray, str]] = []
-    for record_index, record in enumerate(records):
+    for record_index, record in enumerate(shuffled_records):
         path = Path(str(record["imagePath"]))
         if record.get("tensorSHA256") != sha256_file(path):
             raise ReverseKey1Error(f"public tensor identity mismatch: {path}")
@@ -400,6 +540,9 @@ def pretrain_public_synthetic_style(config: PublicPretrainingConfig) -> dict[str
         }
 
     baseline = evaluate()
+    best_epoch = 0
+    best_metrics = dict(baseline)
+    best_state = copy.deepcopy(model.state_dict())
     history: list[dict[str, Any]] = []
     for epoch in range(1, config.epochs + 1):
         model.train()
@@ -414,9 +557,12 @@ def pretrain_public_synthetic_style(config: PublicPretrainingConfig) -> dict[str
                 torch.zeros((len(primary), len(METADATA_FIELDS)), device=config.device),
                 torch.zeros((len(primary), len(METADATA_FIELDS)), device=config.device),
             )
-            key_loss = torch.nn.functional.smooth_l1_loss(output["key1"], key1)
+            key_loss = torch.nn.functional.l1_loss(output["key1"], key1)
             unstyled_loss = torch.nn.functional.l1_loss(output["unstyled"], clean)
-            loss = key_loss + 0.25 * unstyled_loss
+            loss = (
+                config.key_loss_weight * key_loss
+                + config.unstyled_loss_weight * unstyled_loss
+            )
             loss.backward()
             torch.nn.utils.clip_grad_norm_(model.parameters(), 2.0)
             optimizer.step()
@@ -425,14 +571,23 @@ def pretrain_public_synthetic_style(config: PublicPretrainingConfig) -> dict[str
         history.append(
             {"epoch": epoch, "trainingLoss": float(np.mean(losses)), "heldout": metrics}
         )
+        selection = (metrics["key1MAE"], metrics["syntheticResponseRMSE8"])
+        best_selection = (
+            best_metrics["key1MAE"], best_metrics["syntheticResponseRMSE8"]
+        )
+        if selection < best_selection:
+            best_epoch = epoch
+            best_metrics = dict(metrics)
+            best_state = copy.deepcopy(model.state_dict())
         print(json.dumps(history[-1], sort_keys=True), flush=True)
+    model.load_state_dict(best_state)
     output = config.output.resolve()
     output.mkdir(parents=True, exist_ok=True)
     checkpoint = {
         "schema": SYNTHETIC_REPORT_SCHEMA,
         "architecture": "UniversalPhotographicStyleStateNet-v3-optional-modalities",
         "architectureConfig": "multimodal_large",
-        "epoch": config.epochs,
+        "epoch": best_epoch,
         "manifestSHA256": sha256_file(manifest),
         "model": model.state_dict(),
         "statistics": {name: array.tolist() for name, array in statistics.items()},
@@ -452,8 +607,14 @@ def pretrain_public_synthetic_style(config: PublicPretrainingConfig) -> dict[str
         },
         "architecture": checkpoint["architecture"],
         "device": config.device,
+        "lossWeights": {
+            "key1L1": config.key_loss_weight,
+            "unstyledL1": config.unstyled_loss_weight,
+        },
         "baseline": baseline,
-        "final": history[-1]["heldout"],
+        "bestEpoch": best_epoch,
+        "final": best_metrics,
+        "lastEpoch": history[-1]["heldout"],
         "history": history,
         "licenses": sorted({str(record["license"]) for record in records}),
         "categories": sorted({str(record["category"]) for record in records}),

--- a/xdremux_py/universal_photographic_style.py
+++ b/xdremux_py/universal_photographic_style.py
@@ -25,9 +25,15 @@ from xdremux_py.apple_reverse_key1_training import (
     sha256_file,
 )
 from xdremux_py.universal_photographic_style_training import (
+    GAIN_MAP_CHANNELS,
+    INPUT_SIZE,
+    LINEAR_CHANNELS,
     METADATA_FIELDS,
+    MODALITY_FIELDS,
     STYLE_SCALAR_FIELDS,
     build_universal_model,
+    gain_map_sidecar_features,
+    linear_sidecar_features,
     metadata_vector,
     primary_image_features,
 )
@@ -68,6 +74,8 @@ class UniversalImageInput:
     source_sha256: str
     source_make: str | None = None
     source_model: str | None = None
+    linear_rgb_features: np.ndarray | None = None
+    gain_map_features: np.ndarray | None = None
 
 
 def _register_heif() -> None:
@@ -144,7 +152,13 @@ def _metadata_tags(path: Path, exiftool: str) -> dict[str, Any]:
     return values[0]
 
 
-def load_universal_image(path: Path, *, exiftool: str = "exiftool") -> UniversalImageInput:
+def load_universal_image(
+    path: Path,
+    *,
+    exiftool: str = "exiftool",
+    linear_rgb_sidecar: Path | None = None,
+    gain_map_sidecar: Path | None = None,
+) -> UniversalImageInput:
     resolved = path.resolve()
     if resolved.suffix.lower() not in SUPPORTED_IMAGE_SUFFIXES:
         raise ReverseKey1Error(f"unsupported image suffix: {resolved.suffix}")
@@ -155,8 +169,18 @@ def load_universal_image(path: Path, *, exiftool: str = "exiftool") -> Universal
         bit_depth = max((float(value) for value in bit_depth), default=None)
     elif not isinstance(bit_depth, (int, float)):
         bit_depth = None
-    has_raw = resolved.suffix.lower() == ".dng"
-    has_gain_map = _contains_gain_map(resolved)
+    linear_features = (
+        linear_sidecar_features(linear_rgb_sidecar.resolve())
+        if linear_rgb_sidecar is not None
+        else None
+    )
+    gain_features = (
+        gain_map_sidecar_features(gain_map_sidecar.resolve())
+        if gain_map_sidecar is not None
+        else None
+    )
+    has_raw = resolved.suffix.lower() == ".dng" or linear_features is not None
+    has_gain_map = _contains_gain_map(resolved) or gain_features is not None
     metadata, metadata_mask = metadata_vector(
         {
             "displayWidth": width,
@@ -183,6 +207,8 @@ def load_universal_image(path: Path, *, exiftool: str = "exiftool") -> Universal
         source_sha256=sha256_file(resolved),
         source_make=str(tags.get("Make")) if tags.get("Make") is not None else None,
         source_model=str(tags.get("Model")) if tags.get("Model") is not None else None,
+        linear_rgb_features=linear_features,
+        gain_map_features=gain_features,
     )
 
 
@@ -215,11 +241,34 @@ def predict_universal_state(
     primary = torch.from_numpy(image.primary).unsqueeze(0).to(device)
     metadata = torch.from_numpy(image.metadata).unsqueeze(0).to(device)
     metadata_mask = torch.from_numpy(image.metadata_mask).unsqueeze(0).to(device)
+    linear_rgb = np.zeros(
+        (LINEAR_CHANNELS, INPUT_SIZE, INPUT_SIZE), dtype=np.float32
+    )
+    gain_map = np.zeros(
+        (GAIN_MAP_CHANNELS, INPUT_SIZE, INPUT_SIZE), dtype=np.float32
+    )
+    modality_mask = np.zeros(len(MODALITY_FIELDS), dtype=np.float32)
+    if image.linear_rgb_features is not None:
+        linear_rgb = image.linear_rgb_features
+        modality_mask[0] = 1.0
+    if image.gain_map_features is not None:
+        gain_map = image.gain_map_features
+        modality_mask[1] = 1.0
+    linear_tensor = torch.from_numpy(linear_rgb).unsqueeze(0).to(device)
+    gain_tensor = torch.from_numpy(gain_map).unsqueeze(0).to(device)
+    modality_tensor = torch.from_numpy(modality_mask).unsqueeze(0).to(device)
     if device == "mps":
         torch.mps.synchronize()
     started = time.perf_counter()
     with torch.no_grad():
-        predicted = model(primary, metadata, metadata_mask)
+        predicted = model(
+            primary,
+            metadata,
+            metadata_mask,
+            linear_tensor,
+            gain_tensor,
+            modality_tensor,
+        )
     if device == "mps":
         torch.mps.synchronize()
     elapsed = time.perf_counter() - started

--- a/xdremux_py/universal_photographic_style_training.py
+++ b/xdremux_py/universal_photographic_style_training.py
@@ -831,6 +831,57 @@ def build_universal_model(
     return UniversalPhotographicStyleStateNet()
 
 
+_STATISTIC_STATE_KEYS = frozenset(
+    (
+        "identity",
+        "key1_scale",
+        "metadata_center",
+        "metadata_scale",
+        "gtc_center",
+        "gtc_scale",
+        "light_center",
+        "light_scale",
+        "scalar_center",
+        "scalar_scale",
+    )
+)
+
+
+def _warm_start_model_state(
+    model: Any,
+    checkpoint_state: Mapping[str, Any],
+    *,
+    source_architecture: str,
+    target_architecture: str,
+) -> None:
+    compatible = source_architecture == target_architecture or (
+        source_architecture == "multiscale_large"
+        and target_architecture == "multimodal_large"
+    )
+    if not compatible:
+        raise ReverseKey1Error(
+            f"cannot warm-start {target_architecture} from {source_architecture}"
+        )
+    migrated = model.state_dict()
+    for name, value in checkpoint_state.items():
+        if name in _STATISTIC_STATE_KEYS:
+            # Target-corpus statistics define output normalization and must not
+            # leak from synthetic or earlier-data checkpoints.
+            continue
+        if (
+            name == "encoder_stages.0.0.weight"
+            and source_architecture == "multiscale_large"
+            and target_architecture == "multimodal_large"
+        ):
+            migrated[name].zero_()
+            migrated[name][:, :PRIMARY_CHANNELS].copy_(value)
+        elif name in migrated and migrated[name].shape == value.shape:
+            migrated[name].copy_(value)
+        else:
+            raise ReverseKey1Error(f"cannot migrate checkpoint parameter: {name}")
+    model.load_state_dict(migrated)
+
+
 class _UniversalDataset:
     def __init__(
         self,
@@ -1165,27 +1216,17 @@ def train_universal_model(config: UniversalTrainingConfig) -> dict[str, Any]:
         ):
             raise ReverseKey1Error("resume checkpoint manifest hash does not match dataset")
         checkpoint_architecture = checkpoint.get("architectureConfig", "base")
-        if checkpoint_architecture == config.architecture:
+        if config.resume is not None and checkpoint_architecture == config.architecture:
             model.load_state_dict(checkpoint["model"])
-        elif (
-            config.architecture == "multimodal_large"
-            and checkpoint_architecture == "multiscale_large"
-        ):
-            # Warm-start the required-image path exactly. Optional channels are
-            # initialized to zero so an all-missing v3 model starts from the
-            # same function as the v2 checkpoint.
-            migrated = model.state_dict()
-            for name, value in checkpoint["model"].items():
-                if name == "encoder_stages.0.0.weight":
-                    migrated[name].zero_()
-                    migrated[name][:, :PRIMARY_CHANNELS].copy_(value)
-                elif name in migrated and migrated[name].shape == value.shape:
-                    migrated[name].copy_(value)
-                else:
-                    raise ReverseKey1Error(
-                        f"cannot migrate multiscale checkpoint parameter: {name}"
-                    )
-            model.load_state_dict(migrated)
+        elif config.warm_start is not None:
+            # Warm-start learned parameters while keeping normalization buffers
+            # computed from the new target corpus.
+            _warm_start_model_state(
+                model,
+                checkpoint["model"],
+                source_architecture=str(checkpoint_architecture),
+                target_architecture=config.architecture,
+            )
         else:
             raise ReverseKey1Error(
                 f"cannot resume {config.architecture} from {checkpoint_architecture}"

--- a/xdremux_py/universal_photographic_style_training.py
+++ b/xdremux_py/universal_photographic_style_training.py
@@ -39,8 +39,12 @@ from xdremux_py.apple_reverse_key1_training import (
 
 DATASET_SCHEMA = "xdremux-universal-photographic-style-dataset-v1"
 REPORT_SCHEMA = "xdremux-universal-photographic-style-training-v1"
+OPTIONAL_MODALITIES_SCHEMA = "xdremux-universal-optional-modalities-v1"
 INPUT_SIZE = 256
 PRIMARY_CHANNELS = 9
+LINEAR_CHANNELS = PRIMARY_CHANNELS
+GAIN_MAP_CHANNELS = 3
+MODALITY_FIELDS = ("linear_rgb", "gain_map")
 METADATA_FIELDS = (
     "log2_display_width",
     "log2_display_height",
@@ -101,6 +105,108 @@ def primary_image_features(styled: np.ndarray) -> np.ndarray:
         ),
         axis=0,
     ).astype(np.float32)
+
+
+def gain_map_features(gain_map: np.ndarray) -> np.ndarray:
+    """Build bounded features from a decoded linear exposure-gain ratio map.
+
+    The sidecar contract is deliberately semantic rather than container
+    specific: callers decode and orient the gain map, resample it to 256x256,
+    and supply linear gain ratios where 1.0 means no exposure gain.
+    """
+
+    value = np.asarray(gain_map, dtype=np.float32).squeeze()
+    if value.shape != (INPUT_SIZE, INPUT_SIZE):
+        raise ReverseKey1Error(
+            f"gain map must be {INPUT_SIZE}x{INPUT_SIZE} after decoding"
+        )
+    if not np.isfinite(value).all() or np.any(value <= 0):
+        raise ReverseKey1Error("gain map must contain finite positive gain ratios")
+    log_gain = np.clip(np.log2(value), -4.0, 4.0) / 4.0
+    gradient_x = np.zeros_like(log_gain)
+    gradient_y = np.zeros_like(log_gain)
+    gradient_x[:, 1:] = log_gain[:, 1:] - log_gain[:, :-1]
+    gradient_y[1:, :] = log_gain[1:, :] - log_gain[:-1, :]
+    return np.stack((log_gain, gradient_x, gradient_y), axis=0).astype(np.float32)
+
+
+def _sidecar_array(path: Path, preferred_key: str) -> np.ndarray:
+    if path.suffix.lower() == ".npy":
+        return np.asarray(np.load(path, allow_pickle=False))
+    if path.suffix.lower() == ".npz":
+        with np.load(path, allow_pickle=False) as archive:
+            if preferred_key not in archive:
+                raise ReverseKey1Error(
+                    f"optional modality archive {path} is missing {preferred_key!r}"
+                )
+            return np.asarray(archive[preferred_key])
+    raise ReverseKey1Error(
+        f"optional modality sidecar must be .npy or .npz: {path}"
+    )
+
+
+def linear_sidecar_features(path: Path) -> np.ndarray:
+    value = np.asarray(_sidecar_array(path, "linear_rgb"), dtype=np.float32)
+    if value.shape == (INPUT_SIZE, INPUT_SIZE, 3):
+        value = value.transpose(2, 0, 1)
+    if not np.isfinite(value).all() or np.any(value < 0) or np.any(value > 1):
+        raise ReverseKey1Error(
+            "linear RGB sidecar must contain finite scene-linear values in [0, 1]"
+        )
+    return primary_image_features(value)
+
+
+def gain_map_sidecar_features(path: Path) -> np.ndarray:
+    return gain_map_features(_sidecar_array(path, "gain_map"))
+
+
+def _load_optional_modalities_manifest(
+    path: Path | None,
+) -> dict[str, dict[str, Any]]:
+    if path is None:
+        return {}
+    manifest = path.resolve()
+    value = json.loads(manifest.read_text(encoding="utf-8"))
+    if value.get("schema") != OPTIONAL_MODALITIES_SCHEMA:
+        raise ReverseKey1Error("invalid optional modalities manifest")
+    samples = value.get("samples")
+    if not isinstance(samples, list):
+        raise ReverseKey1Error("optional modalities samples are not an array")
+    by_sha: dict[str, dict[str, Any]] = {}
+    for item in samples:
+        if not isinstance(item, dict):
+            raise ReverseKey1Error("optional modality record is not an object")
+        source_sha = str(item.get("sourceSHA256") or "")
+        try:
+            int(source_sha, 16)
+        except ValueError:
+            source_sha = ""
+        if len(source_sha) != 64 or source_sha in by_sha:
+            raise ReverseKey1Error(
+                "optional modality sourceSHA256 must be unique 64-character values"
+            )
+        prepared: dict[str, Any] = {"sourceSHA256": source_sha}
+        for field, feature_builder in (
+            ("linearRGBPath", linear_sidecar_features),
+            ("gainMapPath", gain_map_sidecar_features),
+        ):
+            relative = item.get(field)
+            if relative is None:
+                continue
+            sidecar = (manifest.parent / str(relative)).resolve()
+            if not sidecar.is_file():
+                raise ReverseKey1Error(f"optional modality sidecar does not exist: {sidecar}")
+            # Decode once during preparation so a malformed sidecar cannot make
+            # a long training run fail much later.
+            feature_builder(sidecar)
+            prepared[field] = str(sidecar)
+            prepared[field.removesuffix("Path") + "SHA256"] = sha256_file(sidecar)
+        if len(prepared) == 1:
+            raise ReverseKey1Error(
+                f"optional modality record {source_sha} has no sidecar paths"
+            )
+        by_sha[source_sha] = prepared
+    return by_sha
 
 
 def _number(value: Any) -> float | None:
@@ -191,11 +297,22 @@ class UniversalPreparationConfig:
     native_manifest: Path
     output: Path
     exiftool: str = "exiftool"
+    optional_modalities_manifest: Path | None = None
 
 
 def prepare_universal_dataset(config: UniversalPreparationConfig) -> dict[str, Any]:
     source_manifest = config.native_manifest.resolve()
     source_header, records = load_manifest(source_manifest)
+    optional_modalities = _load_optional_modalities_manifest(
+        config.optional_modalities_manifest
+    )
+    native_hashes = {str(record["sourceSHA256"]) for record in records}
+    unknown_hashes = sorted(set(optional_modalities) - native_hashes)
+    if unknown_hashes:
+        raise ReverseKey1Error(
+            "optional modalities contain samples outside the native manifest: "
+            + ", ".join(unknown_hashes[:3])
+        )
     paths = [str(record["sourcePath"]) for record in records]
     command = [
         config.exiftool,
@@ -238,6 +355,7 @@ def prepare_universal_dataset(config: UniversalPreparationConfig) -> dict[str, A
     source_root = source_manifest.parent
     for index, record in enumerate(records):
         tags = by_path[str(record["sourcePath"])]
+        optional = optional_modalities.get(str(record["sourceSHA256"]), {})
         tag3 = decode_style_binary(tags.get("Tag3"), 516, "Tag3")
         tag_c = decode_style_binary(tags.get("TagC"), 2048, "TagC")
         tag_d = decode_style_binary(tags.get("TagD"), 2048, "TagD")
@@ -249,19 +367,26 @@ def prepare_universal_dataset(config: UniversalPreparationConfig) -> dict[str, A
             if value is not None:
                 scalars[index, scalar_index] = value
                 scalar_mask[index, scalar_index] = 1.0
-        metadata[index], metadata_mask[index] = metadata_vector(record, tags)
-        prepared_records.append(
-            {
-                "index": index,
-                "sourceSHA256": record["sourceSHA256"],
-                "sourcePath": record["sourcePath"],
-                "samplePath": str((source_root / str(record["samplePath"])).resolve()),
-                "captureSession": record["captureSession"],
-                "split": record["split"],
-                "Model": record.get("Model"),
-                "Software": record.get("Software"),
-            }
+        metadata[index], metadata_mask[index] = metadata_vector(
+            record,
+            tags,
+            has_gain_map="gainMapPath" in optional,
+            has_raw="linearRGBPath" in optional,
         )
+        prepared_record = {
+            "index": index,
+            "sourceSHA256": record["sourceSHA256"],
+            "sourcePath": record["sourcePath"],
+            "samplePath": str((source_root / str(record["samplePath"])).resolve()),
+            "captureSession": record["captureSession"],
+            "split": record["split"],
+            "Model": record.get("Model"),
+            "Software": record.get("Software"),
+        }
+        prepared_record.update(
+            {name: value for name, value in optional.items() if name != "sourceSHA256"}
+        )
+        prepared_records.append(prepared_record)
     for name, values in (
         ("lightMaps", light_maps),
         ("scalars", scalars),
@@ -303,6 +428,14 @@ def prepare_universal_dataset(config: UniversalPreparationConfig) -> dict[str, A
             "uncertainty": "input-conditioned normalized error prediction",
         },
         "metadataFields": list(METADATA_FIELDS),
+        "optionalModalities": {
+            "fields": list(MODALITY_FIELDS),
+            "linearRGB": "oriented linear RGB, 3x256x256, .npy or NPZ key linear_rgb",
+            "gainMap": (
+                "oriented linear exposure-gain ratios, 256x256, .npy or NPZ key gain_map"
+            ),
+            "sampleCount": len(optional_modalities),
+        },
     }
     header["recordsSHA256"] = __import__("hashlib").sha256(
         canonical_json_bytes(prepared_records)
@@ -406,7 +539,7 @@ def build_universal_model(
     statistics: Mapping[str, np.ndarray], *, architecture: str = "base"
 ) -> Any:
     torch, nn = _require_torch()
-    if architecture not in {"base", "multiscale_large"}:
+    if architecture not in {"base", "multiscale_large", "multimodal_large"}:
         raise ReverseKey1Error(f"unsupported universal architecture: {architecture}")
 
     class ResidualBlock(nn.Module):
@@ -428,7 +561,10 @@ def build_universal_model(
             super().__init__()
             channels = (64, 96, 160, 256)
             stages: list[Any] = []
+            self.supports_optional_modalities = architecture == "multimodal_large"
             incoming = PRIMARY_CHANNELS
+            if self.supports_optional_modalities:
+                incoming += LINEAR_CHANNELS + GAIN_MAP_CHANNELS + len(MODALITY_FIELDS)
             for outgoing in channels:
                 blocks: list[Any] = [
                     nn.Conv2d(incoming, outgoing, 3, stride=2, padding=1, bias=False),
@@ -436,11 +572,11 @@ def build_universal_model(
                     nn.SiLU(),
                     ResidualBlock(outgoing),
                 ]
-                if architecture == "multiscale_large":
+                if architecture in {"multiscale_large", "multimodal_large"}:
                     blocks.append(ResidualBlock(outgoing))
                 stages.append(nn.Sequential(*blocks))
                 incoming = outgoing
-            if architecture == "multiscale_large":
+            if architecture in {"multiscale_large", "multimodal_large"}:
                 self.encoder = None
                 self.encoder_stages = nn.ModuleList(stages)
                 self.scale_projections = nn.ModuleList(
@@ -557,10 +693,60 @@ def build_universal_model(
                 )
 
         def forward(
-            self, primary: Any, metadata: Any, metadata_mask: Any
+            self,
+            primary: Any,
+            metadata: Any,
+            metadata_mask: Any,
+            linear_rgb: Any | None = None,
+            gain_map: Any | None = None,
+            modality_mask: Any | None = None,
         ) -> dict[str, Any]:
+            encoder_input = primary
+            if self.supports_optional_modalities:
+                batch_size = primary.shape[0]
+                if linear_rgb is None:
+                    linear_rgb = primary.new_zeros(
+                        (batch_size, LINEAR_CHANNELS, INPUT_SIZE, INPUT_SIZE)
+                    )
+                if gain_map is None:
+                    gain_map = primary.new_zeros(
+                        (batch_size, GAIN_MAP_CHANNELS, INPUT_SIZE, INPUT_SIZE)
+                    )
+                if modality_mask is None:
+                    modality_mask = primary.new_zeros(
+                        (batch_size, len(MODALITY_FIELDS))
+                    )
+                if tuple(linear_rgb.shape[1:]) != (
+                    LINEAR_CHANNELS,
+                    INPUT_SIZE,
+                    INPUT_SIZE,
+                ):
+                    raise ReverseKey1Error("invalid linear RGB feature tensor shape")
+                if tuple(gain_map.shape[1:]) != (
+                    GAIN_MAP_CHANNELS,
+                    INPUT_SIZE,
+                    INPUT_SIZE,
+                ):
+                    raise ReverseKey1Error("invalid gain-map feature tensor shape")
+                if tuple(modality_mask.shape[1:]) != (len(MODALITY_FIELDS),):
+                    raise ReverseKey1Error("invalid optional modality mask shape")
+                mask = modality_mask.clamp(0.0, 1.0)
+                linear_mask = mask[:, 0, None, None, None]
+                gain_mask = mask[:, 1, None, None, None]
+                mask_planes = mask[:, :, None, None].expand(
+                    -1, -1, INPUT_SIZE, INPUT_SIZE
+                )
+                encoder_input = torch.cat(
+                    (
+                        primary,
+                        linear_rgb * linear_mask,
+                        gain_map * gain_mask,
+                        mask_planes,
+                    ),
+                    dim=1,
+                )
             if self.encoder_stages is not None:
-                value = primary
+                value = encoder_input
                 pyramid = []
                 for stage, projection in zip(
                     self.encoder_stages, self.scale_projections
@@ -576,7 +762,7 @@ def build_universal_model(
                     )
                 spatial = self.spatial_fusion(torch.cat(pyramid, dim=1))
             else:
-                spatial = self.encoder(primary)
+                spatial = self.encoder(encoder_input)
                 # MPS does not implement adaptive pooling when the input size
                 # is not divisible by the output size (16 -> 12 here).
                 spatial = torch.nn.functional.interpolate(
@@ -651,11 +837,25 @@ class _UniversalDataset:
         manifest: Path,
         records: Sequence[Mapping[str, Any]],
         metadata_dropout: float = 0.0,
+        optional_modality_dropout: float = 0.0,
     ) -> None:
         self.manifest = manifest
         self.records = list(records)
         self.labels = np.load(manifest.parent / "labels.npz", allow_pickle=False)
         self.metadata_dropout = metadata_dropout
+        self.optional_modality_dropout = optional_modality_dropout
+        for record in self.records:
+            for path_field in ("linearRGBPath", "gainMapPath"):
+                path_value = record.get(path_field)
+                if path_value is None:
+                    continue
+                path = Path(str(path_value))
+                expected = record.get(path_field.removesuffix("Path") + "SHA256")
+                if not path.is_file() or expected != sha256_file(path):
+                    raise ReverseKey1Error(
+                        f"optional modality identity mismatch: {path_field} for "
+                        f"{record.get('sourceSHA256')}"
+                    )
 
     def __len__(self) -> int:
         return len(self.records)
@@ -675,6 +875,29 @@ class _UniversalDataset:
         if self.metadata_dropout and float(torch.rand(())) < self.metadata_dropout:
             metadata = np.zeros_like(metadata)
             metadata_mask = np.zeros_like(metadata_mask)
+        linear_rgb = np.zeros(
+            (LINEAR_CHANNELS, INPUT_SIZE, INPUT_SIZE), dtype=np.float32
+        )
+        gain_map = np.zeros(
+            (GAIN_MAP_CHANNELS, INPUT_SIZE, INPUT_SIZE), dtype=np.float32
+        )
+        modality_mask = np.zeros(len(MODALITY_FIELDS), dtype=np.float32)
+        if record.get("linearRGBPath"):
+            linear_rgb = linear_sidecar_features(Path(str(record["linearRGBPath"])))
+            modality_mask[0] = 1.0
+        if record.get("gainMapPath"):
+            gain_map = gain_map_sidecar_features(Path(str(record["gainMapPath"])))
+            modality_mask[1] = 1.0
+        if self.optional_modality_dropout:
+            keep = (
+                torch.rand(len(MODALITY_FIELDS))
+                >= self.optional_modality_dropout
+            ).numpy().astype(np.float32)
+            modality_mask *= keep
+            linear_rgb *= modality_mask[0]
+            gain_map *= modality_mask[1]
+            metadata[METADATA_FIELDS.index("has_raw")] = modality_mask[0]
+            metadata[METADATA_FIELDS.index("has_gain_map")] = modality_mask[1]
         return (
             torch.from_numpy(primary),
             torch.from_numpy(metadata),
@@ -688,7 +911,36 @@ class _UniversalDataset:
             torch.from_numpy(unstyled),
             str(record["captureSession"]),
             str(record.get("Model") or "unknown"),
+            torch.from_numpy(linear_rgb),
+            torch.from_numpy(gain_map),
+            torch.from_numpy(modality_mask),
         )
+
+
+def _model_forward(model: Any, batch: Sequence[Any]) -> Mapping[str, Any]:
+    return model(batch[0], batch[1], batch[2], batch[12], batch[13], batch[14])
+
+
+def _apply_modality_policy(batch: Sequence[Any], policy: str) -> tuple[Any, ...]:
+    if policy == "available":
+        return tuple(batch)
+    if policy not in {"primary_only", "linear_only", "gain_only"}:
+        raise ReverseKey1Error(f"unsupported modality evaluation policy: {policy}")
+    values = list(batch)
+    mask = values[14].clone()
+    if policy == "primary_only":
+        mask.zero_()
+    elif policy == "linear_only":
+        mask[:, 1] = 0
+    else:
+        mask[:, 0] = 0
+    values[12] = values[12] * mask[:, 0, None, None, None]
+    values[13] = values[13] * mask[:, 1, None, None, None]
+    values[14] = mask
+    values[1] = values[1].clone()
+    values[1][:, METADATA_FIELDS.index("has_raw")] = mask[:, 0]
+    values[1][:, METADATA_FIELDS.index("has_gain_map")] = mask[:, 1]
+    return tuple(values)
 
 
 def _consumer_quadratic_proxy(torch: Any, key1: Any, primary: Any) -> Any:
@@ -728,6 +980,9 @@ def _losses(
         unstyled,
         _sessions,
         _models,
+        _linear_rgb,
+        _gain_map,
+        _modality_mask,
     ) = batch
     expanded = key_mask[:, :, :, None, None, None].expand_as(key1)
     normalized_key = (output["key1"] - key1) / model.key1_scale
@@ -774,7 +1029,14 @@ def _move_batch(batch: Sequence[Any], device: str) -> tuple[Any, ...]:
     return tuple(value.to(device) if hasattr(value, "to") else value for value in batch)
 
 
-def _evaluate(torch: Any, model: Any, loader: Any, device: str) -> dict[str, Any]:
+def _evaluate(
+    torch: Any,
+    model: Any,
+    loader: Any,
+    device: str,
+    *,
+    modality_policy: str = "available",
+) -> dict[str, Any]:
     model.eval()
     key_errors: list[float] = []
     predicted_uncertainty: list[float] = []
@@ -786,8 +1048,10 @@ def _evaluate(torch: Any, model: Any, loader: Any, device: str) -> dict[str, Any
     consumer_proxy_errors: list[float] = []
     with torch.no_grad():
         for original in loader:
-            batch = _move_batch(original, device)
-            output = model(batch[0], batch[1], batch[2])
+            batch = _apply_modality_policy(
+                _move_batch(original, device), modality_policy
+            )
+            output = _model_forward(model, batch)
             consumer_proxy = _consumer_quadratic_proxy(torch, output["key1"], batch[0])
             consumer_delta = consumer_proxy - batch[9]
             consumer_proxy_errors.extend(
@@ -795,7 +1059,7 @@ def _evaluate(torch: Any, model: Any, loader: Any, device: str) -> dict[str, Any
             )
             key1, key_mask = batch[3], batch[4]
             normalized = ((output["key1"] - key1) / model.key1_scale).abs()
-            for index, model_name in enumerate(original[-1]):
+            for index, model_name in enumerate(original[11]):
                 selected = key_mask[index, :, :, None, None, None].expand_as(normalized[index])
                 error = float(normalized[index][selected].mean().cpu())
                 key_errors.append(error)
@@ -849,9 +1113,11 @@ class UniversalTrainingConfig:
     device: str = "auto"
     seed: int = 260820
     metadata_dropout: float = 0.25
+    optional_modality_dropout: float = 0.35
     architecture: str = "base"
     consumer_weight: float = 0.0
     resume: Path | None = None
+    warm_start: Path | None = None
 
 
 def train_universal_model(config: UniversalTrainingConfig) -> dict[str, Any]:
@@ -864,9 +1130,13 @@ def train_universal_model(config: UniversalTrainingConfig) -> dict[str, Any]:
         raise ReverseKey1Error("MPS was requested but is unavailable")
     if not 0 <= config.metadata_dropout <= 1:
         raise ReverseKey1Error("metadata dropout must be in [0, 1]")
+    if not 0 <= config.optional_modality_dropout <= 1:
+        raise ReverseKey1Error("optional modality dropout must be in [0, 1]")
     if config.consumer_weight < 0:
         raise ReverseKey1Error("consumer weight must be non-negative")
-    if config.architecture not in {"base", "multiscale_large"}:
+    if config.resume is not None and config.warm_start is not None:
+        raise ReverseKey1Error("resume and warm start are mutually exclusive")
+    if config.architecture not in {"base", "multiscale_large", "multimodal_large"}:
         raise ReverseKey1Error(
             f"unsupported universal architecture: {config.architecture}"
         )
@@ -884,17 +1154,51 @@ def train_universal_model(config: UniversalTrainingConfig) -> dict[str, Any]:
     model = build_universal_model(
         statistics, architecture=config.architecture
     ).to(device)
-    if config.resume is not None:
-        checkpoint = torch.load(config.resume.resolve(), map_location=device, weights_only=False)
-        if checkpoint.get("manifestSHA256") != sha256_file(manifest):
+    checkpoint_path = config.resume or config.warm_start
+    if checkpoint_path is not None:
+        checkpoint = torch.load(
+            checkpoint_path.resolve(), map_location=device, weights_only=False
+        )
+        if (
+            config.resume is not None
+            and checkpoint.get("manifestSHA256") != sha256_file(manifest)
+        ):
             raise ReverseKey1Error("resume checkpoint manifest hash does not match dataset")
-        model.load_state_dict(checkpoint["model"])
+        checkpoint_architecture = checkpoint.get("architectureConfig", "base")
+        if checkpoint_architecture == config.architecture:
+            model.load_state_dict(checkpoint["model"])
+        elif (
+            config.architecture == "multimodal_large"
+            and checkpoint_architecture == "multiscale_large"
+        ):
+            # Warm-start the required-image path exactly. Optional channels are
+            # initialized to zero so an all-missing v3 model starts from the
+            # same function as the v2 checkpoint.
+            migrated = model.state_dict()
+            for name, value in checkpoint["model"].items():
+                if name == "encoder_stages.0.0.weight":
+                    migrated[name].zero_()
+                    migrated[name][:, :PRIMARY_CHANNELS].copy_(value)
+                elif name in migrated and migrated[name].shape == value.shape:
+                    migrated[name].copy_(value)
+                else:
+                    raise ReverseKey1Error(
+                        f"cannot migrate multiscale checkpoint parameter: {name}"
+                    )
+            model.load_state_dict(migrated)
+        else:
+            raise ReverseKey1Error(
+                f"cannot resume {config.architecture} from {checkpoint_architecture}"
+            )
     loaders = {
         split: torch.utils.data.DataLoader(
             _UniversalDataset(
                 manifest,
                 values,
                 metadata_dropout=config.metadata_dropout if split == "train" else 0.0,
+                optional_modality_dropout=(
+                    config.optional_modality_dropout if split == "train" else 0.0
+                ),
             ),
             batch_size=config.batch_size,
             shuffle=split == "train",
@@ -916,7 +1220,7 @@ def train_universal_model(config: UniversalTrainingConfig) -> dict[str, Any]:
         for original in loaders["train"]:
             batch = _move_batch(original, device)
             optimizer.zero_grad(set_to_none=True)
-            prediction = model(batch[0], batch[1], batch[2])
+            prediction = _model_forward(model, batch)
             total, details = _losses(
                 torch, model, prediction, batch, consumer_weight=config.consumer_weight
             )
@@ -926,7 +1230,13 @@ def train_universal_model(config: UniversalTrainingConfig) -> dict[str, Any]:
             totals.append(float(total.detach().cpu()))
             for name, value in details.items():
                 components[name].append(value)
-        calibration = _evaluate(torch, model, loaders["calibration"], device)
+        calibration = _evaluate(
+            torch,
+            model,
+            loaders["calibration"],
+            device,
+            modality_policy="primary_only",
+        )
         score = calibration["key1NormalizedMAE"] + 0.15 * (
             calibration["gtcNormalizedMAE"] + calibration["lightMapsNormalizedMAE"]
         )
@@ -942,11 +1252,11 @@ def train_universal_model(config: UniversalTrainingConfig) -> dict[str, Any]:
         history.append(row)
         checkpoint = {
             "schema": REPORT_SCHEMA,
-            "architecture": (
-                "UniversalPhotographicStyleStateNet-v2-multiscale-large"
-                if config.architecture == "multiscale_large"
-                else "UniversalPhotographicStyleStateNet-v1"
-            ),
+            "architecture": {
+                "base": "UniversalPhotographicStyleStateNet-v1",
+                "multiscale_large": "UniversalPhotographicStyleStateNet-v2-multiscale-large",
+                "multimodal_large": "UniversalPhotographicStyleStateNet-v3-optional-modalities",
+            }[config.architecture],
             "architectureConfig": config.architecture,
             "epoch": epoch,
             "manifestSHA256": manifest_hash,
@@ -964,8 +1274,29 @@ def train_universal_model(config: UniversalTrainingConfig) -> dict[str, Any]:
         print(json.dumps(row, sort_keys=True), flush=True)
     best = torch.load(output / "best.pt", map_location=device, weights_only=False)
     model.load_state_dict(best["model"])
-    heldout = _evaluate(torch, model, loaders["heldout"], device)
-    calibration = _evaluate(torch, model, loaders["calibration"], device)
+    heldout = _evaluate(
+        torch, model, loaders["heldout"], device, modality_policy="primary_only"
+    )
+    calibration = _evaluate(
+        torch,
+        model,
+        loaders["calibration"],
+        device,
+        modality_policy="primary_only",
+    )
+    modality_ablations = {
+        split: {
+            policy: _evaluate(
+                torch,
+                model,
+                loaders[split],
+                device,
+                modality_policy=policy,
+            )
+            for policy in ("available", "linear_only", "gain_only")
+        }
+        for split in ("calibration", "heldout")
+    }
     report = {
         "schema": REPORT_SCHEMA,
         "architecture": best["architecture"],
@@ -978,6 +1309,8 @@ def train_universal_model(config: UniversalTrainingConfig) -> dict[str, Any]:
         "bestSelectionScore": best_score,
         "calibration": calibration,
         "heldout": heldout,
+        "primaryOnly": {"calibration": calibration, "heldout": heldout},
+        "modalityAblations": modality_ablations,
         "parameterCount": sum(parameter.numel() for parameter in model.parameters()),
         "inputContract": header["inputContract"],
         "outputContract": header["outputContract"],
@@ -986,7 +1319,10 @@ def train_universal_model(config: UniversalTrainingConfig) -> dict[str, Any]:
             "require separate acceptance."
         ),
         "consumerWeight": config.consumer_weight,
+        "optionalModalityDropout": config.optional_modality_dropout,
+        "optionalModalities": header.get("optionalModalities", {}),
         "resume": str(config.resume.resolve()) if config.resume else None,
+        "warmStart": str(config.warm_start.resolve()) if config.warm_start else None,
     }
     _atomic_json(output / "report.json", report)
     return report


### PR DESCRIPTION
## Summary

- keeps the primary image as the only required model input
- adds real RAW-derived linear RGB and gain-map feature tensors with an explicit modality mask
- adds independent optional-modality dropout, strict primary-only model selection, and calibration/heldout modality ablations
- supports warm-starting the multimodal stem from the current multiscale checkpoint without requiring the same dataset manifest
- adds Python inference/Core ML export contracts and a GitHub Actions PyTorch regression job
- adds an opt-in self-hosted Apple Silicon training job; private samples and checkpoints remain outside Git

## Accuracy boundary

This PR does not claim an accuracy gain yet. The repository does not contain the private 603-sample cache or PyTorch checkpoint, and GitHub-hosted macOS cannot provide the complete Neutrino solver teacher. A labelled manifest plus checkpoint (or a configured `xdremux-style-training` self-hosted runner) is required before training and heldout comparison against the current primary-only 0.82233 normalized key1 MAE.

## Local checks

- `python3 -m compileall -q xdremux_py scripts Tests`
- `python3 -m unittest Tests.test_apple_reverse_key1_training Tests.test_universal_photographic_style_training` (22 tests, 7 PyTorch-dependent skips in this Linux environment)
- workflow YAML parse and `git diff --check`

GitHub Actions is expected to run the same regressions with the `training` extra so the skipped PyTorch forward/mask tests execute.