### PR TITLE
release: publish XDRemux v1.4

### DIFF
--- a/.github/releases/v1.4.json
+++ b/.github/releases/v1.4.json
@@ -1,0 +1,6 @@
+{
+  "version": "v1.4",
+  "title": "XDRemux v1.4",
+  "notes": "docs/releases/v1.4.md",
+  "replace_tag_if": "6d99b568f9eefc95d307d52542d20754e8412a9e"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: xdremux-release-${{ github.ref }}
@@ -155,7 +155,12 @@ jobs:
           python -m pip install --upgrade pip build
           python -m build
 
-          expected="${VERSION#v}.0"
+          release_version="${VERSION#v}"
+          if [[ "$release_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            expected="$release_version.0"
+          else
+            expected="$release_version"
+          fi
           actual="$(python -c 'import xdremux_py; print(xdremux_py.__version__)')"
           if [[ "$actual" != "$expected" ]]; then
             echo "::error::Python package version $actual does not match release $VERSION (expected $expected)."
@@ -184,6 +189,8 @@ jobs:
     needs: [metadata, swift-package, python-package]
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
     env:
       GH_TOKEN: ${{ github.token }}
       VERSION: ${{ needs.metadata.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,249 @@
+name: XDRemux Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/releases/*.json"
+  workflow_dispatch:
+    inputs:
+      manifest:
+        description: "Release manifest path"
+        required: true
+        default: ".github/releases/v1.4.json"
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: xdremux-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      title: ${{ steps.release.outputs.title }}
+      notes: ${{ steps.release.outputs.notes }}
+      replace_tag_if: ${{ steps.release.outputs.replace_tag_if }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release manifest
+        id: release
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_MANIFEST: ${{ inputs.manifest }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            manifest="$DISPATCH_MANIFEST"
+          else
+            mapfile -t manifests < <(
+              git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA" -- '.github/releases/*.json'
+            )
+            if [[ ${#manifests[@]} -ne 1 ]]; then
+              echo "::error::Expected exactly one changed release manifest, found ${#manifests[@]}."
+              exit 1
+            fi
+            manifest="${manifests[0]}"
+          fi
+
+          if [[ "$manifest" != .github/releases/*.json || ! -f "$manifest" ]]; then
+            echo "::error::Invalid release manifest: $manifest"
+            exit 1
+          fi
+
+          version="$(jq -r '.version // empty' "$manifest")"
+          title="$(jq -r '.title // empty' "$manifest")"
+          notes="$(jq -r '.notes // empty' "$manifest")"
+          replace_tag_if="$(jq -r '.replace_tag_if // empty' "$manifest")"
+
+          if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+            echo "::error::Invalid release version: $version"
+            exit 1
+          fi
+          if [[ -z "$title" ]]; then
+            echo "::error::Release title is required."
+            exit 1
+          fi
+          if [[ "$notes" != docs/releases/*.md || ! -f "$notes" ]]; then
+            echo "::error::Invalid release notes path: $notes"
+            exit 1
+          fi
+          if [[ -n "$replace_tag_if" && ! "$replace_tag_if" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::replace_tag_if must be a full commit SHA."
+            exit 1
+          fi
+
+          {
+            echo "version=$version"
+            echo "title=$title"
+            echo "notes=$notes"
+            echo "replace_tag_if=$replace_tag_if"
+          } >> "$GITHUB_OUTPUT"
+
+  swift-package:
+    needs: metadata
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build and test Swift release
+        shell: bash
+        run: |
+          set -euo pipefail
+          swift build -c release --product xdremux
+          swift test -c release
+
+      - name: Package Swift CLI
+        shell: bash
+        env:
+          VERSION: ${{ needs.metadata.outputs.version }}
+        run: |
+          set -euo pipefail
+          bin_dir="$(swift build -c release --show-bin-path)"
+          arch="$(uname -m)"
+          stage="$RUNNER_TEMP/XDRemux-${VERSION}-macOS-${arch}"
+          archive="$RUNNER_TEMP/XDRemux-${VERSION}-macOS-${arch}.tar.gz"
+
+          mkdir -p "$stage"
+          cp "$bin_dir/xdremux" "$stage/"
+          find "$bin_dir" -maxdepth 1 -type d -name '*.bundle' -exec cp -R {} "$stage/" \;
+          cp README.md README.en.md "$stage/"
+          printf '%s\n' "$GITHUB_SHA" > "$stage/COMMIT"
+
+          "$stage/xdremux" --help >/dev/null
+          tar -C "$RUNNER_TEMP" -czf "$archive" "$(basename "$stage")"
+          printf '%s  %s\n' "$(shasum -a 256 "$archive" | awk '{print $1}')" "$(basename "$archive")" > "$archive.sha256"
+
+          mkdir -p release-assets
+          cp "$archive" "$archive.sha256" release-assets/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: swift-release-assets
+          path: release-assets/
+          if-no-files-found: error
+          retention-days: 14
+
+  python-package:
+    needs: metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Build and test Python distributions
+        shell: bash
+        env:
+          VERSION: ${{ needs.metadata.outputs.version }}
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip build
+          python -m build
+
+          expected="${VERSION#v}.0"
+          actual="$(python -c 'import xdremux_py; print(xdremux_py.__version__)')"
+          if [[ "$actual" != "$expected" ]]; then
+            echo "::error::Python package version $actual does not match release $VERSION (expected $expected)."
+            exit 1
+          fi
+
+          python -m venv "$RUNNER_TEMP/release-smoke"
+          "$RUNNER_TEMP/release-smoke/bin/python" -m pip install dist/*.whl
+          "$RUNNER_TEMP/release-smoke/bin/xdremux-py" --help >/dev/null
+
+          mkdir -p release-assets
+          cp dist/* release-assets/
+          (
+            cd release-assets
+            sha256sum * > SHA256SUMS-python.txt
+          )
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: python-release-assets
+          path: release-assets/
+          if-no-files-found: error
+          retention-days: 14
+
+  publish:
+    needs: [metadata, swift-package, python-package]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ github.token }}
+      VERSION: ${{ needs.metadata.outputs.version }}
+      TITLE: ${{ needs.metadata.outputs.title }}
+      NOTES: ${{ needs.metadata.outputs.notes }}
+      REPLACE_TAG_IF: ${{ needs.metadata.outputs.replace_tag_if }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v8
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Verify tag state
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "::error::Release $VERSION already exists."
+            exit 1
+          fi
+
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            old="$(git rev-parse "$VERSION^{commit}")"
+            if [[ "$old" != "$GITHUB_SHA" ]]; then
+              if [[ -z "$REPLACE_TAG_IF" || "$old" != "$REPLACE_TAG_IF" ]]; then
+                echo "::error::Tag $VERSION points to unexpected commit $old."
+                exit 1
+              fi
+            fi
+          fi
+
+      - name: Publish tag and GitHub Release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -f "$VERSION" "$GITHUB_SHA"
+          git push origin "refs/tags/$VERSION" --force
+
+          gh release create "$VERSION" \
+            release-assets/* \
+            --verify-tag \
+            --title "$TITLE" \
+            --notes-file "$NOTES"
+
+      - name: Verify published release
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_target="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${VERSION}" --jq '.object.sha')"
+          if [[ "$release_target" != "$GITHUB_SHA" ]]; then
+            echo "::error::Published tag points to $release_target instead of $GITHUB_SHA."
+            exit 1
+          fi
+          gh release view "$VERSION" --json tagName,name,isDraft,isPrerelease,url

--- a/docs/releases/v1.4.md
+++ b/docs/releases/v1.4.md
@@ -1,0 +1,189 @@
+# XDRemux v1.4
+
+## English
+
+XDRemux v1.4 is the final release that ships both the Swift and Python implementations.
+
+This release adds Android Motion Photo → Apple Live Photo conversion, improves Photographic Styles, adds asset-aware photo classification, and hardens the conversion pipeline.
+
+Development after v1.4 will move to the Rust rewrite.
+
+### Motion Photo → Live Photo
+
+XDRemux can now convert supported Android Motion Photos to Apple Live Photo.
+
+The output is an HEIC + MOV pair. The conversion preserves the source Motion Photo.
+
+For supported inputs, XDRemux preserves:
+
+- the HDR still image and Gain Map;
+- the source cover-frame PTS;
+- Apple `still-image-time`;
+- compressed video samples;
+- compressed audio samples when present.
+
+Motion Photo detection is automatic for supported JPEG and HEIC/HEIF files.
+
+Batch conversion also supports Motion Photos.
+
+The Swift CLI can also combine Motion Photo conversion with Photographic Styles.
+
+### Python implementation
+
+`xdremux-py` is now an installable Python package.
+
+It supports standard HDR conversion, photo classification, and Motion Photo → Live Photo conversion.
+
+The Live Photo implementation does not require Apple frameworks at runtime. It can run on non-macOS systems.
+
+The repository tests the Python-generated Live Photos with PhotoKit on macOS.
+
+Photographic Styles and Apple Portrait remain Swift/macOS features in v1.4.
+
+### Photo classification
+
+Photo classification now works with complete photo assets.
+
+A Live Photo HEIC + MOV pair stays together as one asset.
+
+The default directory layout separates static photos and Live Photos:
+
+```text
+Static Photos/<capture mode>/
+Live Photos/<capture mode>/
+```
+
+HDR, Gain Map, portrait data, and other properties remain tags instead of additional directory levels.
+
+### Photographic Styles
+
+The Photographic Styles solver now uses less temporary memory and runs faster in the repository solver benchmark.
+
+The conversion pipeline also supports the private Photographic Styles API changes in macOS 27.
+
+The default style-data producer remains `constrained-solver`.
+
+### Safety and reliability
+
+This release includes a broad conversion-safety update.
+
+XDRemux now:
+
+- preserves Motion Photo source files;
+- does not silently overwrite existing Live Photo resources;
+- validates source provenance before batch resume reuses an existing pair;
+- publishes replacement files through safer temporary-file paths;
+- performs stricter HEIF and ISO-BMFF bounds checks;
+- handles malformed and truncated containers more safely;
+- reports unsupported and already-converted files more clearly.
+
+The Swift CLI now uses `swift-argument-parser`.
+
+The repository also includes 14 versioned Motion Photo fixtures for Swift and Python regression testing.
+
+### Project maintenance
+
+The technical documentation has been updated to match the current code and tests.
+
+The repository now also uses CodeQL, secret scanning, Dependabot, protected `main` rules, and required exact-HEAD validation.
+
+### What comes next
+
+v1.4 closes the current Swift + Python implementation line.
+
+The next XDRemux release line will use the Rust rewrite.
+
+---
+
+## 中文
+
+XDRemux v1.4 是最后一个同时提供 Swift 和 Python 实现的版本。
+
+本版本新增 Android Motion Photo → Apple Live Photo 转换，并改进摄影风格、照片分类和转换安全性。
+
+v1.4 之后，XDRemux 将转向 Rust 重写版本。
+
+### Motion Photo → Live Photo
+
+XDRemux 现在可以将支持的 Android Motion Photo 转换为 Apple Live Photo。
+
+输出为 HEIC + MOV 资源对。转换过程不会修改源 Motion Photo。
+
+对于支持的输入，XDRemux 会保留：
+
+- HDR 静态照片和 Gain Map；
+- 源文件的封面帧 PTS；
+- Apple `still-image-time`；
+- 压缩视频样本；
+- 存在时的压缩音频样本。
+
+对于支持的 JPEG 和 HEIC/HEIF 文件，Motion Photo 会被自动识别。
+
+批量转换同样支持 Motion Photo。
+
+Swift CLI 还可以在 Motion Photo 转换过程中同时生成摄影风格。
+
+### Python 实现
+
+`xdremux-py` 现在是可安装的 Python package。
+
+它支持标准 HDR 转换、照片分类和 Motion Photo → Live Photo 转换。
+
+Live Photo 转换在运行时不依赖 Apple framework，因此可以运行在非 macOS 系统上。
+
+仓库会在 macOS 上使用 PhotoKit 验证 Python 生成的 Live Photo。
+
+在 v1.4 中，摄影风格和 Apple 人像仍然属于 Swift/macOS 功能。
+
+### 照片分类
+
+照片分类现在以完整照片资产为单位。
+
+一个 Live Photo 的 HEIC + MOV 会始终作为同一个资产处理。
+
+默认目录结构会区分静态照片和 Live Photo：
+
+```text
+静态照片/<拍摄模式>/
+实况照片/<拍摄模式>/
+```
+
+HDR、Gain Map、人像数据和其他属性继续作为 tag 保存，不会增加额外目录层级。
+
+### 摄影风格
+
+摄影风格 solver 现在需要更少的临时内存，并且在仓库的 solver benchmark 中运行更快。
+
+转换链路也已经适配 macOS 27 中发生变化的私有摄影风格接口。
+
+默认 style-data producer 仍然是 `constrained-solver`。
+
+### 安全性和可靠性
+
+本版本对转换安全性进行了较大范围的改进。
+
+XDRemux 现在会：
+
+- 保留 Motion Photo 源文件；
+- 避免静默覆盖已有的 Live Photo 资源；
+- 在 batch resume 复用已有资源对前验证源文件 provenance；
+- 通过更安全的临时文件流程发布替换文件；
+- 对 HEIF 和 ISO-BMFF 增加更严格的边界检查；
+- 更安全地处理损坏或截断的容器；
+- 更清楚地区分不支持的文件和已经转换的文件。
+
+Swift CLI 现在使用 `swift-argument-parser`。
+
+仓库还包含 14 个版本化 Motion Photo fixture，用于 Swift 和 Python 的回归测试。
+
+### 项目维护
+
+技术文档已经根据当前代码和测试重新整理。
+
+仓库现在还启用了 CodeQL、secret scanning、Dependabot、`main` 分支保护和 exact-HEAD 必需验证。
+
+### 下一步
+
+v1.4 是当前 Swift + Python 实现线的最后一个版本。
+
+XDRemux 的下一条版本线将使用 Rust 重写实现。


### PR DESCRIPTION
## Summary

Prepare the XDRemux v1.4 release from the current protected `main` line.

- add the reviewed bilingual v1.4 release notes;
- add a release manifest for `v1.4`;
- add a release workflow that builds and tests the Swift release product on macOS;
- package the Swift CLI together with its SwiftPM resource bundles and SHA-256;
- build the Python wheel and sdist, install the wheel in a clean venv, and generate SHA-256 values;
- publish the GitHub Release only after both package jobs pass;
- move the pre-existing stale `v1.4` tag only if it still points to the known old commit `6d99b568f9eefc95d307d52542d20754e8412a9e`;
- bind the final tag and release to the exact merge commit that contains this release manifest and notes.

## Release position

v1.4 is the final release that ships both the Swift and Python implementations. The next XDRemux release line will use the Rust rewrite.

## Safety

The workflow fails closed if a v1.4 GitHub Release already exists or if the existing v1.4 tag has moved to an unexpected commit. Release publication uses a job-scoped `contents: write` token; ordinary repository workflows remain read-only by default.