### PR TITLE
experiment: Palette HEIC carrier probe (device verdict pending)

### DIFF
--- a/.github/workflows/palette-heic-probe.yml
+++ b/.github/workflows/palette-heic-probe.yml
@@ -1,0 +1,72 @@
+name: Palette HEIC Compatibility Probe
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "scripts/build_palette_heic_probe.py"
+      - "Tests/test_palette_heic_probe.py"
+      - ".github/workflows/palette-heic-probe.yml"
+      - "fixtures/IMG20260710191114_ColorOS_16.jpg"
+
+permissions:
+  contents: read
+
+jobs:
+  build-probe:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run focused probe tests
+        shell: bash
+        run: |
+          python3 Tests/test_palette_heic_probe.py
+
+      - name: Build HEIC base from ColorOS 16 fixture
+        shell: bash
+        run: |
+          mkdir -p artifacts/palette-heic-probe
+          SOURCE="fixtures/IMG20260710191114_ColorOS_16.jpg"
+          BASE="artifacts/palette-heic-probe/base.heic"
+          sips -s format heic "$SOURCE" --out "$BASE"
+          test -s "$BASE"
+          file "$BASE" | tee artifacts/palette-heic-probe/base-file.txt
+          sips -g pixelWidth -g pixelHeight "$BASE" | tee artifacts/palette-heic-probe/base-image.txt
+
+      - name: Carry Palette and BasicTone context
+        shell: bash
+        run: |
+          python3 scripts/build_palette_heic_probe.py \
+            --source fixtures/IMG20260710191114_ColorOS_16.jpg \
+            --base-heic artifacts/palette-heic-probe/base.heic \
+            --output artifacts/palette-heic-probe/palette-context-probe.heic \
+            --report artifacts/palette-heic-probe/palette-context-report.json
+
+      - name: Validate generated candidate structure
+        shell: bash
+        run: |
+          CANDIDATE="artifacts/palette-heic-probe/palette-context-probe.heic"
+          test -s "$CANDIDATE"
+          file "$CANDIDATE" | tee artifacts/palette-heic-probe/candidate-file.txt
+          sips -g pixelWidth -g pixelHeight "$CANDIDATE" | tee artifacts/palette-heic-probe/candidate-image.txt
+          python3 scripts/inspect_oppo_heif.py "$CANDIDATE" \
+            > artifacts/palette-heic-probe/candidate-inspection.json
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          report = json.loads(Path("artifacts/palette-heic-probe/palette-context-report.json").read_text())
+          print("selected:", ", ".join(report["candidate_contains"]))
+          print("basic tone present:", ", ".join(report["basic_tone_entries_present"]) or "none")
+          print("basic tone missing:", ", ".join(report["basic_tone_entries_missing"]) or "none")
+          print("device acceptance:", report["device_acceptance"])
+          PY
+
+      - name: Upload probe artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: palette-heic-compatibility-probe
+          if-no-files-found: error
+          path: artifacts/palette-heic-probe/

--- a/.github/workflows/palette-heic-probe.yml
+++ b/.github/workflows/palette-heic-probe.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run focused probe tests
         shell: bash
         run: |
-          python3 Tests/test_palette_heic_probe.py
+          PYTHONPATH="$PWD" python3 Tests/test_palette_heic_probe.py
 
       - name: Build HEIC base from ColorOS 16 fixture
         shell: bash
@@ -38,7 +38,7 @@ jobs:
       - name: Carry Palette and BasicTone context
         shell: bash
         run: |
-          python3 scripts/build_palette_heic_probe.py \
+          PYTHONPATH="$PWD" python3 scripts/build_palette_heic_probe.py \
             --source fixtures/IMG20260710191114_ColorOS_16.jpg \
             --base-heic artifacts/palette-heic-probe/base.heic \
             --output artifacts/palette-heic-probe/palette-context-probe.heic \
@@ -51,7 +51,7 @@ jobs:
           test -s "$CANDIDATE"
           file "$CANDIDATE" | tee artifacts/palette-heic-probe/candidate-file.txt
           sips -g pixelWidth -g pixelHeight "$CANDIDATE" | tee artifacts/palette-heic-probe/candidate-image.txt
-          python3 scripts/inspect_oppo_heif.py "$CANDIDATE" \
+          PYTHONPATH="$PWD" python3 scripts/inspect_oppo_heif.py "$CANDIDATE" \
             > artifacts/palette-heic-probe/candidate-inspection.json
           python3 - <<'PY'
           import json

--- a/Tests/test_palette_heic_probe.py
+++ b/Tests/test_palette_heic_probe.py
@@ -1,0 +1,83 @@
+import importlib.util
+import json
+import struct
+import unittest
+from pathlib import Path
+
+from xdremux_py import container
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "build_palette_heic_probe.py"
+SPEC = importlib.util.spec_from_file_location("build_palette_heic_probe", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+probe = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(probe)
+
+
+def build_tail(entries: list[tuple[str, bytes]], tag: bytes = b"jxrs") -> bytes:
+    payload = bytearray()
+    starts = []
+    for name, block in entries:
+        starts.append((name, len(payload), len(block)))
+        payload.extend(block)
+    records = [
+        {
+            "length": length,
+            "name": name,
+            "offset": len(payload) - start,
+            "version": 1,
+        }
+        for name, start, length in starts
+    ]
+    manifest = json.dumps(records, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return bytes(payload) + manifest + b"\x00" + tag + struct.pack("<I", len(manifest) + 9)
+
+
+def payload_for(tail: bytes, name: str) -> bytes:
+    entries, json_start, _ = container.parse_manifest(tail)
+    entry = next(item for item in entries if item["name"] == name)
+    start = json_start - entry["offset"]
+    return tail[start:start + entry["length"]]
+
+
+class PaletteHEICProbeTests(unittest.TestCase):
+    def test_selects_only_palette_context_entries(self) -> None:
+        source = build_tail(
+            [
+                ("watermark.logo", b"watermark"),
+                ("master.mode.preset.info", b"unrelated-preset"),
+                ("basictone.info", b"basic-info"),
+                ("basictone.lmtlut.table", b"lut"),
+                ("basictone.vig.table", b"vig"),
+                ("hdr.transform.data", b"hdr"),
+                ("filter.info", b"filter"),
+            ],
+            tag=b"wtmk",
+        )
+        entries, tag = probe.extract_manifested_payloads(source)
+        selected = probe.select_palette_entries(entries)
+        rebuilt = probe.build_tail(selected, tag)
+        names = [entry["name"] for entry, _ in selected]
+
+        self.assertEqual(
+            names,
+            [
+                "basictone.info",
+                "basictone.lmtlut.table",
+                "basictone.vig.table",
+                "hdr.transform.data",
+            ],
+        )
+        self.assertEqual(payload_for(rebuilt, "basictone.info"), b"basic-info")
+        self.assertEqual(payload_for(rebuilt, "basictone.lmtlut.table"), b"lut")
+        self.assertEqual(payload_for(rebuilt, "basictone.vig.table"), b"vig")
+        self.assertEqual(payload_for(rebuilt, "hdr.transform.data"), b"hdr")
+        self.assertEqual(rebuilt[-8:-4], b"wtmk")
+
+    def test_rejects_unparseable_source(self) -> None:
+        with self.assertRaisesRegex(ValueError, "parseable OPPO extension manifest"):
+            probe.extract_manifested_payloads(b"not-a-container-tail")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/build_palette_heic_probe.py
+++ b/scripts/build_palette_heic_probe.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Build a HEIC compatibility probe from an existing OPPO/OnePlus image.
+
+The probe is deliberately narrow: it carries only metadata families that are
+needed by the Palette/BasicTone render path under test. It does not mutate the
+source fixture and it does not claim device-side acceptance; that remains a
+manual validation step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import struct
+from pathlib import Path
+from typing import Any
+
+from xdremux_py import container
+
+
+BASIC_TONE_ENTRY_NAMES = {
+    "basictone.info",
+    "basictone.lmtlut.table",
+    "basictone.vig.table",
+}
+
+# Palette processing is HDR-aware. Keep the existing per-image HDR transform
+# alongside BasicTone payloads when the source fixture has it, but do not copy
+# unrelated preset, watermark, portrait, or filter metadata into this probe.
+PALETTE_CONTEXT_ENTRY_NAMES = BASIC_TONE_ENTRY_NAMES | {
+    "hdr.transform.data",
+}
+
+
+def _footer_tag(data: bytes) -> bytes:
+    if len(data) >= 9 and data[-9] == 0:
+        tag = data[-8:-4]
+        if len(tag) == 4 and all(32 <= byte <= 126 for byte in tag):
+            return tag
+    return b"jxrs"
+
+
+def extract_manifested_payloads(data: bytes) -> tuple[list[tuple[dict[str, Any], bytes]], bytes]:
+    parsed = container.parse_manifest(data)
+    if parsed is None:
+        raise ValueError("source does not contain a parseable OPPO extension manifest")
+
+    entries, json_start, _ = parsed
+    result: list[tuple[dict[str, Any], bytes]] = []
+    for entry in entries:
+        name = str(entry.get("name", ""))
+        try:
+            length = int(entry["length"])
+            start = json_start - int(entry["offset"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(f"invalid manifest entry: {name or '<unnamed>'}") from exc
+        end = start + length
+        if length < 0 or start < 0 or end > json_start:
+            raise ValueError(f"manifest entry is out of bounds: {name or '<unnamed>'}")
+        result.append((dict(entry), data[start:end]))
+    return result, _footer_tag(data)
+
+
+def build_tail(entries: list[tuple[dict[str, Any], bytes]], tag: bytes) -> bytes:
+    payload = bytearray()
+    starts: list[tuple[dict[str, Any], int, int]] = []
+    for entry, block in entries:
+        starts.append((entry, len(payload), len(block)))
+        payload.extend(block)
+
+    payload_length = len(payload)
+    records: list[dict[str, Any]] = []
+    for entry, start, length in starts:
+        record = dict(entry)
+        record["length"] = length
+        record["offset"] = payload_length - start
+        records.append(record)
+
+    manifest = json.dumps(records, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return bytes(payload) + manifest + b"\x00" + tag + struct.pack("<I", len(manifest) + 9)
+
+
+def select_palette_entries(
+    entries: list[tuple[dict[str, Any], bytes]],
+) -> list[tuple[dict[str, Any], bytes]]:
+    return [
+        (entry, payload)
+        for entry, payload in entries
+        if str(entry.get("name", "")) in PALETTE_CONTEXT_ENTRY_NAMES
+    ]
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def make_report(
+    source: Path,
+    entries: list[tuple[dict[str, Any], bytes]],
+    selected: list[tuple[dict[str, Any], bytes]],
+) -> dict[str, Any]:
+    names = [str(entry.get("name", "")) for entry, _ in entries]
+    selected_names = [str(entry.get("name", "")) for entry, _ in selected]
+    return {
+        "source": source.as_posix(),
+        "source_entries": [
+            {
+                "name": str(entry.get("name", "")),
+                "length": len(payload),
+                "sha256": sha256(payload),
+            }
+            for entry, payload in entries
+        ],
+        "selected_entries": [
+            {
+                "name": str(entry.get("name", "")),
+                "length": len(payload),
+                "sha256": sha256(payload),
+            }
+            for entry, payload in selected
+        ],
+        "basic_tone_entries_present": sorted(BASIC_TONE_ENTRY_NAMES.intersection(names)),
+        "basic_tone_entries_missing": sorted(BASIC_TONE_ENTRY_NAMES.difference(names)),
+        "has_hdr_transform": "hdr.transform.data" in names,
+        "candidate_contains": selected_names,
+        "device_acceptance": "unverified",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--base-heic", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--report", type=Path, required=True)
+    args = parser.parse_args()
+
+    source_data = args.source.read_bytes()
+    entries, tag = extract_manifested_payloads(source_data)
+    selected = select_palette_entries(entries)
+    if not selected:
+        raise SystemExit("source fixture has no Palette/BasicTone context entries to carry")
+
+    tail = build_tail(selected, tag)
+    base_data = args.base_heic.read_bytes()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_bytes(base_data + tail)
+
+    report = make_report(args.source, entries, selected)
+    report.update(
+        {
+            "footer_tag": tag.decode("ascii", errors="replace"),
+            "base_heic_sha256": sha256(base_data),
+            "tail_sha256": sha256(tail),
+            "output_sha256": sha256(base_data + tail),
+            "output_size": len(base_data) + len(tail),
+        }
+    )
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## State

**Isolated experiment — device verdict pending.**

This branch builds a HEIC artifact from the existing ColorOS 16 fixture and carries only Palette/BasicTone render-context entries already present in the source.

## Evidence

The workflow proves that the probe can construct an artifact and produce its structural report. It does not change the canonical Rust conversion path.

This evidence does **not** prove that ColorOS Gallery recognizes Palette editing, exposes an editing control, preserves reversibility, or survives an edit/save/reopen round trip.

## Promotion gate

Record the result from the intended real ColorOS consumer:

1. import the generated artifact;
2. check whether the Palette control appears;
3. edit and save;
4. reopen and verify that the edit remains reversible.

A positive result can promote the smallest verified contract and regression. A negative result should archive only the tested hypothesis, artifact identity, device/software version, and result. The temporary workflow and builder should then be removed unless they remain useful as a reproducible diagnostic tool.

No private fixture or device-only sample is added to Git or a public artifact.